### PR TITLE
Simple fix for exact matches in taxon search

### DIFF
--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -389,7 +389,7 @@ function searchForMatchingTaxa() {
         type: 'POST',
         dataType: 'json',
         data: JSON.stringify({ 
-            "queryString": (searchText+"*"),
+            "queryString": (searchText+","+searchText+"*"),
             "contextName": ''
         }),  // data (asterisk required for completion suggestions)
         crossDomain: true,


### PR DESCRIPTION
We now search for both the exact string AND a wildcard with *. Lucene will now return an exact match (if found) as the first search result, followed by the first several "starts-with" matches found.
