### PR TITLE
Improved provenance display, conflating node+edge

### DIFF
--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1800,7 +1800,7 @@ ArgusCluster.prototype.updateDisplayBounds = function() {
     // update my layout properties and store results (for faster access)
     this.displayBounds = {
         topY: this.y - (argus.nodeHeight * 0.7),
-        bottomY: this.y + (argus.nodeHeight * 0.7)
+        bottomY: this.y + (argus.nodeHeight * 1.0)
     };
     return this.displayBounds;
 };

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -289,15 +289,42 @@ div.viewer-frame {
 }
 #provenance-panel .taxon-image {
     float: right;
-    margin-top: -40px;
-    margin-right: 26px;
+    position: relative;
+    margin-top: -23px;
+    margin-right: 15px;
     width: 32px;
     height: 32px;
     background: url(/opentree/static/images/phylopic-vignette.png) center center no-repeat;
     padding: 2px;
 }
+#provenance-panel .ordered-sections {
+    margin-top: 0.5em;
+}
+#provenance-panel .properties-section {
+    border: 2px solid #bbb;
+    border-radius: 5px;
+    padding: 8px 6px 2px;
+    margin: 1.3em 0;
+    position: relative;
+}
+#provenance-panel .properties-section .section-title {
+    font-size: 110%;
+    font-weight: bold;
+    color: #999;
+    position: absolute;
+    top: -0.8em;
+    background-color: #eee;
+    padding: 0 0.25em;
+}
+#provenance-panel .properties-section.selected {
+    border: 2px solid #d33;
+}
+#provenance-panel .properties-section.selected .section-title {
+    color: #d33;
+}
+
 .panel-content dl {
-    margin: 6px 0 12px;
+    margin: 6px 0 12px 8px;
 }
 .panel-content dl dt {
     color: #777;

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -162,31 +162,8 @@
              <div class="panel-controls">
                  <a id="provenance-hide" href="#" title="Hide properties">&times;</a>
              </div>
-             <div class="provenance-intro">Loading&hellip;</div>
              <div class="provenance-title">&nbsp;</div>
-             <dl>
-             <!-- TODO: add these?
-                 OTT id: 
-                 Neo4J node ID:
-                 Tree ID:
-                 Source Tree:
-                IF TAXON,
-                 Jump to NCBI
-                 Jump to GBIF
- 
-             -->
-             <!-- add found properties here
-                 <dt>Original publication</dt>
-                 <dd><a href="#">Cruikshank, 1992</a></dd>
-                 <dd><a href="#">doi:10.1016/r.cruikshank.1992.03.013</a></dd>
-                 <dt>Related publicatons</dt>
-                 <dd><a href="#">Morrison, 2004</a></dd>
-                 <dd><a href="#">doi:10.1016/l.morrison.2004.03.013</a></dd>
-                 <dt style="margin-top: 1em;"><a id="extract-subtree" href="#">Extract subtree</a></dt>
-                 <dd id="extract-subtree-caveats">...</dd>
-             -->
-             </dl>
-             <div></div>
+             <div class="ordered-sections">&nbsp;</div>
             </div>
            </div>
           </div>


### PR DESCRIPTION
New provenance (properties) view that lists all properties for a node and its adjacent edge(s) to parent node(s). NOTE that this will probably need more work to show alternate edges in conflict areas. Properties are organized into named sections, eg, "Node Properties", and the relevant section (based on the selected element in argus) will be highlighted.
