### PR TITLE
Working integration of GitHub OAuth2 for login

### DIFF
--- a/curator/languages/plural-en.py
+++ b/curator/languages/plural-en.py
@@ -8,6 +8,7 @@
 'miss': ['misses'],
 'person': ['people'],
 'quark': ['quarks'],
+'row': ['rows'],
 'shop': ['shops'],
 'this': ['these'],
 'was': ['were'],


### PR DESCRIPTION
This uses the GitHub user API to fetch and 'shadow' core GitHub user properties in web2py's auth_user table. This stores a working GitHub auth token for API operations, for proper attribution. Adding user entries in auth_user allows us to use web2py's normal mechanisms for setting groups, roles, and permissions.
