### PR TITLE
Support for choosing a starting node in argus view

### DIFF
--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -121,8 +121,8 @@
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/apple-touch-icon-114-precomposed.png">
       <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/apple-touch-icon-72-precomposed.png">
                     <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-57-precomposed.png">
-                                   <link rel="shortcut icon" href="/favicon.png">
     -->
+                                   <link rel="shortcut icon" href="/favicon.ico">
   </head>
   
   <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->	
@@ -198,7 +198,7 @@
     </div>
 --><!-- topbar -->
 
-    <div class="flash alert">
+    <div class="flash alert container">
         <!--<button type="button" class="close" data-dismiss="alert">&times;</button>-->
         <span class="message">{{=response.flash or ''}}</span>
     </div> <!-- notification div (adapted for Bootstrap) -->

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -40,6 +40,7 @@ def index():
 
     if len(request.args) > 1:
         if not treeview_dict['nodeID']:
+        #if (not treeview_dict['nodeID']) and '@' in request.args[1]:
             treeview_dict['domSource'], treeview_dict['nodeID'] = request.args[1].split('@')
         else:
             treeview_dict['nodeName'] = request.args[1]
@@ -54,7 +55,7 @@ def index():
 
     # retrieve latest synthetic-tree ID (and its 'life' node ID)
     # TODO: Only refresh this periodically? Or only when needed for initial destination?
-    treeview_dict['draftTreeName'], treeview_dict['lifeNodeID'] = fetch_current_synthetic_tree_ids()
+    treeview_dict['draftTreeName'], treeview_dict['lifeNodeID'], treeview_dict['startingNodeID'] = fetch_current_synthetic_tree_ids()
     treeview_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names()
 
     return treeview_dict
@@ -115,17 +116,22 @@ def fetch_current_synthetic_tree_ids():
 
         method_dict = get_opentree_services_method_urls(request)
         fetch_url = method_dict['getDraftTreeID_url']
-        # this needs to be a POST (pass empty fetch_args); if GET, it just describes the API
-        ids_response = fetch(fetch_url, data='')
+
+        fetch_args = {'startingTaxonName': "cellular organisms"}
+
+        # this needs to be a POST (pass fetch_args or ''); if GET, it just describes the API
+        ids_response = fetch(fetch_url, data=fetch_args)
 
         ids_json = simplejson.loads( ids_response )
         draftTreeName = ids_json['draftTreeName'].encode('utf-8')
         lifeNodeID = ids_json['lifeNodeID'].encode('utf-8')
-        return (draftTreeName, lifeNodeID)
+        # IF we get a separate starting node ID, use it; else we'll start at 'life'
+        startingNodeID = ids_json.get('startingNodeID', lifeNodeID).encode('utf-8')
+        return (draftTreeName, lifeNodeID, startingNodeID)
 
     except Exception, e:
         # throw 403 or 500 or just leave it
-        return ('ERROR', e.message)
+        return ('ERROR', e.message, 'NO_STARTING_NODE_ID')
 
 def fetch_current_TNRS_context_names():
     try:

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -174,7 +174,7 @@
 
   <script type="text/javascript">
     var syntheticTreeID = '{{=draftTreeName}}';
-    var syntheticTreeDefaultStartingNodeID = '{{=lifeNodeID}}';
+    var syntheticTreeDefaultStartingNodeID = '{{=startingNodeID}}';
         // TODO: Allow other choices via URL?
 
     // if inbound URL points to a particular location+view, record it here


### PR DESCRIPTION
This is client-side support. Once the server (treemachine) sends startingNodeID, it will work as intended. Meanwhile argus will default to showing 'life' node as before.
