### PR TITLE
Bouncing to 404 page on a bad tree-browse request

### DIFF
--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -37,6 +37,9 @@ def index():
             treeview_dict['viewer'] = request.args[0]
         elif '@' in request.args[0]:
             treeview_dict['domSource'], treeview_dict['nodeID'] = request.args[0].split('@')
+        else:
+            # first arg is neither a viewer nor a proper node, which is a Bad Thing
+            raise HTTP(404)
 
     if len(request.args) > 1:
         if not treeview_dict['nodeID']:


### PR DESCRIPTION
This is a URL whose first argument (beyond the optional app-name 'opentree') is invalid. That is, it's neither a viewer name (eg, 'argus') nor a proper destination (eg, 'otol.draft.22@123')
