### PR TITLE
Updated curation UI with standard tabs

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -440,6 +440,7 @@ div.flash #closeflash{color:inherit; float:right; margin-left:15px; cursor:point
 .criterion-details {
     padding-top: 0px;
     padding-bottom: 5px;
+    cursor: pointer;
 }
 .criterion-details ul {
     list-style-type: disc;
@@ -448,4 +449,15 @@ div.flash #closeflash{color:inherit; float:right; margin-left:15px; cursor:point
 .criterion-details ul li {
     line-height: 1em;
     padding: 0.25em 0;
+}
+
+.suggestion-list {
+    /* list-style-type: none; */
+}
+.suggestion-list li {
+    padding-bottom: 0.2em;
+    color: #b94a48;
+}
+.suggestion-list span.label {
+    padding: 0.3em 0.7em 0.4em;
 }

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -28,12 +28,13 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
     <!-- Appears only during creation..? then replaced by status
       <li><a href="#">Import</a></li>
     -->
-      <li><a href="#Status" data-toggle="tab">Status</a></li>
-      <li><a href="#Metadata" data-toggle="tab">Metadata</a></li>
-      <li><a href="#Trees" data-toggle="tab">Trees</a></li>
-      <li><a href="#Files" data-toggle="tab">Files</a></li>
-      <li><a href="#OTU-Mapping" data-toggle="tab">OTU Mapping</a></li>
-      <li><a href="#Annotations" data-toggle="tab">Annotations</a></li>
+      <li><a href="#Status" data-toggle="tab">Status <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Metadata" data-toggle="tab">Metadata <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Trees" data-toggle="tab">Trees <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Files" data-toggle="tab">Files <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#OTU-Mapping" data-toggle="tab">OTU Mapping <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Annotations" data-toggle="tab">Annotations <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Tools" data-toggle="tab">Tools <span class="badge badge-important" style="display: none;">?</span></a></li>
     </ul>
 
     <div class="span4 Xbtn-group" style="float: right; margin-top: -56px;">
@@ -58,9 +59,10 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             </div>
 
           <div class="tab-pane" id="Status">
+            <ul class="suggestion-list"></ul>
             <div style="margin-bottom: 100px;">
 
-            <img src="{{=URL('static','images/study-status-under-revision.png')}}" alt="Under Revision" />
+                <img src="{{=URL('static','images/study-status-under-revision.png')}}" alt="Under Revision" />
 
                   <p>
                     <strong style="color: #c33;">There is an active hold on this study (details below).</strong>
@@ -83,6 +85,7 @@ Please review and re-submit.</pre>
           </div>
 
           <div class="tab-pane" id="Metadata">
+            <ul class="suggestion-list"></ul>
             <form class="form-horizontal wider-fields">
               <div class="control-group">
                 <label class="control-label" for="ot_studyPublicationReference">Publication reference</label>
@@ -140,6 +143,7 @@ Please review and re-submit.</pre>
           </div>
 
           <div class="tab-pane" id="Trees">
+            <ul class="suggestion-list"></ul>
             <div style="margin-bottom: 100px;">
                 <p><em>{A paginated list of trees in this study. Also possibly a single-tree import tool? Probably a modal tree view/editor (D3?).}</em></p>
 
@@ -183,6 +187,7 @@ Please review and re-submit.</pre>
           </div>
 
           <div class="tab-pane" id="Files">
+            <ul class="suggestion-list"></ul>
             <div style="margin-bottom: 100px;">
                 <p><em>{A paginated(?) list of files in this study. Also possibly an import tool? Bulk imports?}</em></p>
 
@@ -211,6 +216,7 @@ Please review and re-submit.</pre>
           </div>
 
           <div class="tab-pane" id="OTU-Mapping">
+            <ul class="suggestion-list"></ul>
             <div style="margin-bottom: 100px;">
                 <p><em>{A paginated(?) grid of OTUs (in preferred trees only?), their original names, and any mapping in effect. Also possibly some regex-helpers?}</em></p>
 
@@ -264,6 +270,7 @@ Please review and re-submit.</pre>
           </div>
 
           <div class="tab-pane" id="Annotations">
+            <ul class="suggestion-list"></ul>
             <div style="margin-bottom: 100px;">
                 <p><em>{A paginated list of notes in this study, most recent first. Add filters? Location links jump to each annotation in situ.}</em></p>
 
@@ -334,6 +341,12 @@ Please review and re-submit.</pre>
             </div>
           </div>
 
+          <div class="tab-pane" id="Tools">
+            <ul class="suggestion-list"></ul>
+            <div style="margin-bottom: 100px;">
+                <p><em>{A collection of available tools for this study, and other (ghosted) tools that could become available. Space carrots!}</em></p>
+            </div>
+          </div>
 
             <i><a href="#" onclick="if ($('#formatted-nexson').is(':visible')) { $('#formatted-nexson').hide() } else { $('#formatted-nexson').show() }; return false;">current nexml</a> (remapped for return to server)</i>
             <pre id="formatted-nexson" data-bind="text: ko.mapping.toJSON(nexml.meta)" style="color: #933; font-size: small; width: 90%; height: 500px; overflow: auto; display: none;">
@@ -346,7 +359,7 @@ Please review and re-submit.</pre>
 
     <div class="span4">
       <div class="span4">
-        <strong>Study quality</strong> <a id="quality-details-toggle" onclick="toggleQualityDetails(); return false;" href="#">(hide details)</a>
+        <strong>Study quality</strong> <a id="quality-details-toggle" onclick="toggleQualityDetails(); return false;" href="#">(show details)</a>
         
         <div data-bind="css: studyQualityBarClass">
           <div class="bar" data-bind="style: { width: studyQualityPercentStyle }">
@@ -354,7 +367,7 @@ Please review and re-submit.</pre>
           </div>
         </div>
 
-        <div id="study-quality-details" class="well" style="margin-top: -6px; padding: 11px 15px 0px;">
+        <div id="study-quality-details" class="well" style="display: none; margin-top: -6px; padding: 11px 15px 0px;">
             <!-- details for score criteria will appear here -->
         </div>
       </div>


### PR DESCRIPTION
I also simplified and re-organized the quality assessment tool, with rules organized by tab vs. abstract criteria. Suggestions appear within each tab's panel, and "to-do" tallies appear on the tabs themselves. This should guide the curator more easily to needed tasks.
