### PR TITLE
Simpler page title and DOI, more cleanup.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -91,8 +91,24 @@ function loadSelectedStudy(id) {
 
             ko.applyBindings(viewModel);
 
-            var studyShortDescription = getMetaTagAccessorByAtProperty(viewModel.nexml.meta(), 'ot:studyPublicationReference')();
-            $('#main-title').html('<span style="color: #ccc;">Editing study</span> '+ studyShortDescription);
+            var studyFullReference = getMetaTagAccessorByAtProperty(viewModel.nexml.meta(), 'ot:studyPublicationReference')();
+            var studyCompactReference = "(Untitled)";
+            if ($.trim(studyFullReference) !== "") {
+                // capture the first valid year in the reference
+                var compactYear = studyFullReference.match(/(\d{4})/)[0];  
+                // split on the year to get authors (before), and capture the first surname
+                var compactPrimaryAuthor = studyFullReference.split(compactYear)[0].split(',')[0];
+                var studyCompactReference = compactPrimaryAuthor +", "+ compactYear;    // eg, "Smith, 1999";
+            }
+            $('#main-title').html('<span style="color: #ccc;">Editing study</span> '+ studyCompactReference);
+
+            var studyDOI = getMetaTagAccessorByAtProperty(viewModel.nexml.meta(), 'ot:studyPublication')();
+            studyDOI = $.trim(studyDOI);
+            if (studyDOI === "") {
+                $('a.main-title-DOI').hide();
+            } else {
+                $('a.main-title-DOI').text(studyDOI).attr('href', studyDOI).show();
+            }
 
             updateQualityDisplay();
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -19,10 +19,13 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
 
 {{extend 'layout.html'}}
 
+<a class="main-title-DOI" style="display: none; position: relative; top: -24px;" href="#" target="_blank">{DOI}</a>
+
 <style type="text/css">
 </style>
 
 <div class="row">
+ <div class="span12">
   <div class="tabbable tabs">
     <ul class="nav nav-tabs">
     <!-- Appears only during creation..? then replaced by status
@@ -45,6 +48,7 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             onclick="confirm('Are you sure you want to delete this study?'); return false;">Delete Study</button>
     </div>
   </div>
+ </div>
 </div>
 <div class="row">
     <div class="span8"><!-- not too wide... -->
@@ -358,7 +362,6 @@ Please review and re-submit.</pre>
     </div><!-- end of main col -->
 
     <div class="span4">
-      <div class="span4">
         <strong>Study quality</strong> <a id="quality-details-toggle" onclick="toggleQualityDetails(); return false;" href="#">(show details)</a>
         
         <div data-bind="css: studyQualityBarClass">
@@ -370,7 +373,6 @@ Please review and re-submit.</pre>
         <div id="study-quality-details" class="well" style="display: none; margin-top: -6px; padding: 11px 15px 0px;">
             <!-- details for score criteria will appear here -->
         </div>
-      </div>
     </div><!-- end of right col -->
 
 </div><!-- /.row -->


### PR DESCRIPTION
NOTE that this uses the same JS for generating compact references from the old 'opentree' webapp. This is not as reliable as a properly curated compact reference, but at least it doesn't wrap for 4 or 5 lines.
