### PR TITLE
Attempting study creation via OTOL API

### DIFF
--- a/curator/static/js/study-creation.js
+++ b/curator/static/js/study-creation.js
@@ -117,7 +117,6 @@ function createStudyFromForm( clicked ) {
             'cc0_agreement': $('#cc0-agreement').is(':checked'),
             'import_option': $('[name=import-option]:checked').val() || '',
             'treebase_id': $('[name=treebase-id]').val() || '',
-            'dryad_DOI': $('[name=dryad-DOI]').val() || '',
             'publication_DOI': $('[name=publication-DOI]').val() || '',
             // misc identifying information
             'author_name': authorName,

--- a/curator/views/study/create.html
+++ b/curator/views/study/create.html
@@ -49,25 +49,12 @@ body {
     </div>
 
 
-    <label for="import-option-DRYAD" class="featured-label">
-        <input type="radio" id="import-option-DRYAD" name="import-option" value="IMPORT_FROM_DRYAD" />
-        Import the study from Dryad
-    </label>
-    <p class="featured-label-description">
-        This option is also preferred, since it may automate the import of tree data.
-    </p>
-    <div id="import-details-DRYAD" class="featured-label-child">
-        <input class="span4" type="text" name="dryad-DOI" placeholder="Enter the Dryad deposition DOI"></input>
-        <button class="btn btn-info">Import using Dryad deposition DOI</button>
-    </div>
-
-
     <label for="import-option-PUBLICATION_DOI" class="featured-label">
         <input type="radio" id="import-option-PUBLICATION_DOI" name="import-option" value="IMPORT_FROM_PUBLICATION_DOI" />
         Import the study's metadata using its publication DOI
     </label>
     <p class="featured-label-description">
-        This option saves a little time, but you'll need to upload and map the study's tree data.
+        This option saves time, especially if this study's data is in Dryad.
     </p>
     <div id="import-details-PUBLICATION_DOI" class="featured-label-child">
         <input class="span4" type="text" name="publication-DOI" placeholder="Enter the publication DOI"></input>


### PR DESCRIPTION
@leto, @mtholder: NOTE that the required "upstream" functionality is not yet provided in the OTOL API or in treemachine, but this should be enough information to jump-start implementation there. We should talk more about details of implementation, but here's roughly what I have in mind.

I'm following the RESTful API convention of using POST to create a new resource, like so:
http://dev.opentreeoflife.org/api/api/study

This passes the creation form data. I'm hoping that the OTOL API can provide study creation by passing this along to treemachine, which populates a new study based on the import choices (if any) made here. The "manual" option would simply create a study using the "empty" Nexson template.

If creation/import is successful, this response will redirect the curation tool to the edit page for this new study. If the import fails for some reason, OTOL API could still create the study as an a "empty" Nexson template with explanatory annotations (returning its URL and status 201). 

Or it could return an error message (status 500) that we can show on the creation page, if it's something the user can fix, or something so serious that a resource couldn't be created. 
