### PR TITLE
Hiding stale "mapped labels" for legacy Nexson

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -432,14 +432,15 @@ body {
                         <td data-bind="text: getMetaTagAccessorByAtProperty(otu.meta(), 'ot:originalLabel')">ORIGINAL?</td>
                         <td><em data-bind="text: adjustedLabel(getMetaTagAccessorByAtProperty(otu.meta(), 'ot:originalLabel'))">WORKING?</em></td>
                         <td>
-                         <!-- ko if: currentlyMappingOTUs.indexOf(otu['@id']()) === -1 -->
-                            <strong data-bind="text: otu['@label']">MAPPED LABEL</strong>
-                         <!-- /ko -->
                          <!-- ko if: currentlyMappingOTUs.indexOf(otu['@id']()) !== -1 -->
                             <strong style="color: red;"><em>...mapping now...</em></strong>
                          <!-- /ko -->
                          <!-- ko if: failedMappingOTUs.indexOf(otu['@id']()) !== -1 -->
                             <strong style="color: #999;"><em>Failed mapping (try adding hints)</em></strong>
+                         <!-- /ko -->
+                         <!-- ko if: (currentlyMappingOTUs.indexOf(otu['@id']()) === -1) && 
+                                     (failedMappingOTUs.indexOf(otu['@id']()) === -1) -->
+                            <strong data-bind="text: otu['@label']">MAPPED LABEL</strong>
                          <!-- /ko -->
                         </td>
                     </tr>


### PR DESCRIPTION
This is due to older Nexson records that still have 'ot:ottolid' properties in their metadata, versus the expected 'ot:ottId'. This will go away soon, but note that it will give rise to other weird behavior (due to "unmapped" OTUs that have their 'label' property set).
