### PR TITLE
New definition of public domain (for Janrain, etc)

### DIFF
--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -35,6 +35,8 @@ while [ $# -gt 0 ]; do
 	break
     elif [ "x$1" = "x-h" ]; then
 	OPENTREE_HOST="$2"
+    elif [ "x$1" = "x-p" ]; then
+	OPENTREE_PUBLIC_DOMAIN="$2"
     elif [ "x$1" = "x-u" ]; then
 	OPENTREE_ADMIN="$2"
     elif [ "x$1" = "x-i" ]; then
@@ -62,6 +64,7 @@ fi
 [ "x$OPENTREE_HOST" != x ] || (echo "OPENTREE_HOST not specified"; exit 1)
 [ -r $OPENTREE_IDENTITY ] || (echo "$OPENTREE_IDENTITY not found"; exit 1)
 [ "x$OPENTREE_NEO4J_HOST" != x ] || OPENTREE_NEO4J=$OPENTREE_HOST
+[ "x$OPENTREE_PUBLIC_DOMAIN" != x ] || OPENTREE_PUBLIC_DOMAIN=$OPENTREE_HOST
 
 # abbreviations... no good reason for these, they just make the commands shorter
 ADMIN=$OPENTREE_ADMIN
@@ -132,7 +135,7 @@ function restart_apache {
 }
 
 function pushweb2py {
-    ${SSH} "$OT_USER@$OPENTREE_HOST" ./setup/install-web2py-apps.sh "$OPENTREE_HOST" "${NEO4JHOST}" $CONTROLLER
+    ${SSH} "$OT_USER@$OPENTREE_HOST" ./setup/install-web2py-apps.sh "$OPENTREE_HOST" "${OPENTREE_PUBLIC_DOMAIN}" "${NEO4JHOST}" $CONTROLLER
 }
 
 function pushapi {

--- a/deploy/sample.config
+++ b/deploy/sample.config
@@ -8,12 +8,17 @@
 
 # -----
 # OPENTREE_HOST is the host that you're going to initialize or update.
-# This is used as a target for ssh, and the name also ends up getting
-# stored in the web2py configuration
-# applications/opentree/private/config for use in server
-# authentication.
+# This is used as a target for ssh during deployment.
 
 OPENTREE_HOST=ec2-12-345-678-901.us-west-2.compute.amazonaws.com
+
+#-----
+# OPENTREE_PUBLIC_DOMAIN is the domain name used by site visitors and
+# third-party authentication via Janrain, OAuth, etc. This is stored in the
+# web2py configuration file (applications/opentree/private/config).
+# If not specified, this will be defined as $OPENTREE_HOST.
+
+OPENTREE_PUBLIC_DOMAIN=dev.opentreeoflife.org
 
 # -----
 # OPENTREE_IDENTITY is the name of the file containing the ssh private

--- a/deploy/setup/install-web2py-apps.sh
+++ b/deploy/setup/install-web2py-apps.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 OPENTREE_HOST=$1
-NEO4JHOST=$2
-CONTROLLER=$3
+OPENTREE_PUBLIC_DOMAIN=$2
+NEO4JHOST=$3
+CONTROLLER=$4
 BRANCH=master
 
 . setup/functions.sh
 
-echo "Installing web2py applications.  Hostname = $OPENTREE_HOST"
+echo "Installing web2py applications.  Hostname = $OPENTREE_HOST. Public-facing domain = $OPENTREE_PUBLIC_DOMAIN"
 
 # **** Begin setup that is common to opentree/curator and api
 
@@ -56,7 +57,7 @@ cp -p setup/webapp-config $configfile
 # authentication purposes.  'hostname' doesn't work on EC2 instances,
 # so it has to be passed in as a parameter.
 
-sed "s+hostdomain = .*+hostdomain = $OPENTREE_HOST+" < $configfile > tmp.tmp
+sed "s+hostdomain = .*+hostdomain = $OPENTREE_PUBLIC_DOMAIN+" < $configfile > tmp.tmp
 if ! cmp -s tmp.tmp $configfile; then
     mv tmp.tmp $configfile
     echo "Apache / web2py restart required (host name)"


### PR DESCRIPTION
New config (or command-line) option for push.sh deployment script. This specifies the public-facing domain that's registered for login via Janrain, OAuth, etc. as opposed to the more ephemeral hostname of a deployment target machine.
