### PR TITLE
Allow errors from the API to be returned

### DIFF
--- a/SITE.routes.py
+++ b/SITE.routes.py
@@ -35,7 +35,8 @@ routes_onerror=[
   # this catch-all captures errors in 'curator', so we need to spell out all apps below :-/
   # ('*/*', '/opentree/default/error'),
   ('opentree/*', '/opentree/default/error'),
-  ('api/*', '/opentree/default/error'),
+  # this obfuscates error messages from the API
+  # ('api/*', '/opentree/default/error'),
   ('admin/*', '/opentree/default/error'),
 ]
 


### PR DESCRIPTION
I think we want errors from the API to be returned regardless of deploying to dev or production. Without this, figuring out what went wrong is quite a hassle and requires a lot of manual intervention.
