### PR TITLE
Revised study list. Shared curation-helpers.js

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -338,6 +338,14 @@ a.full-ref-toggle {
     color: #999 !important;
     text-decoration: none;
 }
+a.full-ref-toggle:hover {
+    color: #333 !important;
+    text-decoration: underline;
+}
+.full-study-ref, 
+.compact-study-ref {
+    /* font-weight: bold; */
+}
 .full-ref {
     background-color: #fff;
     border: 1px solid #eee;

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1,0 +1,15 @@
+/*
+ * Utilities common to multiple pages in the OpenTree study-curation tool.
+ */
+
+function fullToCompactReference( fullReference ) {
+    var compactReference = "(Untitled)";
+    if ($.trim(fullReference) !== "") {
+        // capture the first valid year in the reference
+        var compactYear = fullReference.match(/(\d{4})/)[0];  
+        // split on the year to get authors (before), and capture the first surname
+        var compactPrimaryAuthor = fullReference.split(compactYear)[0].split(',')[0];
+        var compactReference = compactPrimaryAuthor +", "+ compactYear;    // eg, "Smith, 1999";
+    }
+    return compactReference;
+}

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -564,14 +564,7 @@ function loadSelectedStudy(id) {
             ko.applyBindings(viewModel, mainPageArea);
 
             var studyFullReference = getMetaTagAccessorByAtProperty(viewModel.nexml.meta, 'ot:studyPublicationReference')();
-            var studyCompactReference = "(Untitled)";
-            if ($.trim(studyFullReference) !== "") {
-                // capture the first valid year in the reference
-                var compactYear = studyFullReference.match(/(\d{4})/)[0];  
-                // split on the year to get authors (before), and capture the first surname
-                var compactPrimaryAuthor = studyFullReference.split(compactYear)[0].split(',')[0];
-                var studyCompactReference = compactPrimaryAuthor +", "+ compactYear;    // eg, "Smith, 1999";
-            }
+            var studyCompactReference = fullToCompactReference(studyFullReference);
             $('#main-title').html('<span style="color: #ccc;">Editing study</span> '+ studyCompactReference);
 
             var studyDOI = getMetaTagAccessorByAtProperty(viewModel.nexml.meta, 'ot:studyPublication')();

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -35,6 +35,7 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
     var API_load_study_list_GET_url = '{{= conf.get("apis", "API_load_study_GET_url") }}';
 </script>
 
+<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script src="{{=URL('static','js/curation-dashboard.js')}}"></script>
 
 <div class="row">
@@ -57,7 +58,8 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
       <div class="navbar">
        <div class="navbar-inner">
         <form class="navbar-search pull-left">
-            <input type="text" class="search-query" placeholder="Filter by author, title, journal"
+            <input type="text" class="search-query" style="widtH: 320px;"
+                   placeholder="Filter by author, title, journal, year, DOI, tag, curator&hellip;"
                    data-bind="value: viewModel.listFilters.STUDIES.match, valueUpdate: 'afterkeydown'">
         </form>
         <ul class="nav" style="padding-left: 1em;">
@@ -91,26 +93,52 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
         <table class="table table-condensed">
           <thead>
             <tr>
-                <th>First Author</th>
               {{ if viewOrEdit == 'EDIT': }}
-                <th>Study Title (click to edit study)</th>
+                <th>Reference (click to edit study)</th>
               {{ else: }}
-                <th>Study Title (click to view study)</th>
+                <th>Reference (click to view study)</th>
               {{ pass }}
+                <th>Focal clade</th>
+                <th>Curator</th>
+                <th>Completeness</th>
+                <!--
                 <th>Year</th>
                 <th>Journal</th>
-                <th>Completeness</th>
                 <th>Actions</th>
+                -->
             </tr>
           </thead>
           <tbody data-bind="foreach: { data: viewModel.filteredStudies().pagedItems(), as: 'study' }">
             <tr>
-                <td data-bind="html: getFirstAuthorLink(study)">?</td>
-                <td data-bind="html: getViewOrEditLink(study)">?</td>
+                <td data-bind="html: getViewOrEditLinks(study)">?</td>
+                <td data-bind="html: getFocalCladeLink(study)">?</td>
+                <td data-bind="html: getCuratorLink(study)">?</td>
+                <td data-bind="text: study.completeness">?</td>
+                <!--
                 <td data-bind="text: study.pubYear">?</td>
                 <td data-bind="html: getJournalLink(study)">?</td>
-                <td data-bind="text: study.completeness">?</td>
                 <td data-bind="html: getSuggestedActions(study)">?</td>
+                -->
+            </tr>
+            <tr>
+                <td colspan="4" style="border-top: none;">
+                    <!--<label class="pull-left">Tags:&nbsp;</label>-->
+                    <!-- TODO: make all tags clickable (search in new window?) -->
+                    <div class="bootstrap-tagsinput" 
+                         style="display: inline-block; border: none; margin-bottom: 0; padding: 0 0 4px 0;"
+                         data-bind="visible: study.tags().length > 0">
+                    <!-- ko foreach: study.tags() -->
+                        <a class="tag label label-info" href="#" data-bind="text: $data"
+                           onclick="filterByTag($(this).text()); return false;">TAG</a>
+                    <!-- /ko -->
+                    </div>
+                    <strong data-bind="visible: study.tags().length === 0">
+                       <em>No tags</em>
+                    </strong>
+
+                    <div class="pull-right" style="font-size: 85%" data-bind="html: getPubLink(study)">&nbsp;</div>
+                    <!--<label class="pull-right">Publication:&nbsp;</label>-->
+                </td>
             </tr>
           </tbody>
         </table>

--- a/curator/views/study/create.html
+++ b/curator/views/study/create.html
@@ -92,4 +92,5 @@ body {
     var API_create_study_POST_url = '{{= conf.get("apis", "API_create_study_POST_url") }}';
         // this can take a few possible POSTed arguments (DOI, or initial input)
 </script>
+<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script src="{{=URL('static','js/study-creation.js')}}"></script>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1211,6 +1211,7 @@ Please review and re-submit.</pre>
     var getNodeIDForOttolID_url = "{{=getNodeIDForOttolID_url}}";
     var getJSONFromNode_url = "{{=getJSONFromNode_url}}";
 </script>
+<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script src="{{=URL('static','js/study-editor.js')}}"></script>
 
 <!-- hidden template for the tree-viewer (editor) -->


### PR DESCRIPTION
Study list markup (and filter logic) adapted to the data we actually collect during curation. 

TODO: Add workflow state display, define how to reckon completeness data and focal clade name.
