### PR TITLE
Cleanup and preparation for focal-clade names

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -144,7 +144,10 @@ function loadStudyList() {
                         var pubYear = study['ot:studyYear'];
                         var tags = $.isArray(study['ot:tag']) ? study['ot:tag'].join('|') : study['ot:tag'];
                         var curator = study['ot:curatorName'];
-                        var clade = study.cladeName;
+                        var clade = ('ot:focalCladeOTTTaxonName' in study && 
+                                     ($.trim(study['ot:focalCladeOTTTaxonName']) !== "")) ?
+                                        study['ot:curatorName'] :
+                                        study['ot:focalClade'];
                         if (!matchPattern.test(pubReference) && !matchPattern.test(pubURL) && !matchPattern.test(pubYear) && !matchPattern.test(curator) && !matchPattern.test(tags) && !matchPattern.test(clade)) {
                             return false;
                         }
@@ -257,21 +260,41 @@ function getCuratorLink(study) {
     return '<a href="#" onclick="filterByCurator(\''+ study['ot:curatorName'] +'\'); return false;"'+'>'+ study['ot:curatorName'] +'</a'+'>';
 }
 function getFocalCladeLink(study) {
-    var cladeNotFound = false;
-    var cladeID;
+    var ottIdNotFound = false;
+    var ottID;
     if ('ot:focalClade' in study) {
-        cladeID = study['ot:focalClade'];
-        if ($.trim(cladeID) === "") {
-            cladeNotFound = true;
+        ottID = study['ot:focalClade'];
+        if ($.trim(ottID) === "") {
+            ottIdNotFound = true;
         }
     } else {
-        cladeNotFound = true;
+        ottIdNotFound = true;
     }
-    if (cladeNotFound) {
-        return '<span style="color: #ccc;">&mdash;</span>';
-        //return '<span style="color: #ccc;">[clade not found]</span>';
+
+    var cladeNameNotFound = false;
+    var cladeName;
+    if ('ot:focalCladeOTTTaxonName' in study) {
+        cladeName = study['ot:focalCladeOTTTaxonName'];
+        if ($.trim(cladeName) === "") {
+            cladeNameNotFound = true;
+        }
+    } else {
+        cladeNameNotFound = true;
     }
-    return '<a href="#" onclick="filterByClade(\''+ cladeID +'\'); return false;"'+'>'+ cladeID +'</a'+'>';
+    if (cladeNameNotFound) {
+        // use the best available placeholder
+        if (ottIdNotFound) {
+            cladeName = '&mdash;';
+        } else {
+            cladeName = ottID;
+        }
+    }
+
+    if (ottIdNotFound) {
+        return '<span style="color: #ccc;">'+ cladeName +'</span>';
+    }
+
+    return '<a href="#" onclick="filterByClade(\''+ ottID +'\'); return false;"'+'>'+ cladeName +'</a'+'>';
 }
 function getPubLink(study) {
     var urlNotFound = false;

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -108,10 +108,10 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
           </thead>
           <tbody data-bind="foreach: { data: viewModel.filteredStudies().pagedItems(), as: 'study' }">
             <tr>
-                <td data-bind="html: getViewOrEditLinks(study)">?</td>
-                <td data-bind="html: getFocalCladeLink(study)">?</td>
-                <td data-bind="html: getCuratorLink(study)">?</td>
-                <td data-bind="text: study.completeness">?</td>
+                <td data-bind="html: getViewOrEditLinks(study)">&nbsp;</td>
+                <td data-bind="html: getFocalCladeLink(study)">&nbsp;</td>
+                <td data-bind="html: getCuratorLink(study)">&nbsp;</td>
+                <td data-bind="text: study.completeness">&nbsp;</td>
                 <!--
                 <td data-bind="text: study.is_deprecated">?</td>
                 <td data-bind="text: study.pubYear">?</td>
@@ -129,11 +129,12 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                          style="display: inline-block; border: none; margin-bottom: 0; padding: 0 0 4px 0;"
                          data-bind="visible: study['ot:tag'] !== ''">
                     <!-- ko foreach: makeArray(study['ot:tag']) -->
-                        <a class="tag label label-info" href="#" data-bind="text: $data"
-                           onclick="filterByTag($(this).text()); return false;">TAG</a>
+                        <a class="tag label label-info" style="display: none;" 
+                           href="#" data-bind="text: $data, visible: true"
+                           onclick="filterByTag($(this).text()); return false;">&nbsp;</a>
                     <!-- /ko -->
                     </div>
-                    <strong data-bind="visible: study['ot:tag'] === ''">
+                    <strong style="display: none;" data-bind="visible: study['ot:tag'] === ''">
                        <em>No tags</em>
                     </strong>
 


### PR DESCRIPTION
These should soon appear as meta elements with @property='ot:focalCladeOTTTaxonName'.
