### PR TITLE
py_package_setup_install function. peyotl in api

### DIFF
--- a/deploy/sample.config
+++ b/deploy/sample.config
@@ -110,3 +110,4 @@ GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
 # opentree_branch oti master
 # opentree_branch taxomachine master
 # opentree_branch treemachine master
+# opentree_branch peyotl master

--- a/deploy/setup/functions.sh
+++ b/deploy/setup/functions.sh
@@ -124,3 +124,26 @@ function git_refresh() {
 }
 
 # See http://stackoverflow.com/questions/1741143/git-pull-origin-mybranch-leaves-local-mybranch-n-commits-ahead-of-origin-why
+
+# Runs "python setup.py develop" from a git repo version of a 
+#   python package. Also runs pip install -r requirements.txt
+#   if there is a "requirements.txt" file at the top level of
+#   the repo. Used to install the peyotl dependency of the
+#   most recent branches of the api repo.
+function py_package_setup_install() {
+    reponame=$1
+    # Directory in which all local checkouts of git repos reside
+    repo_dir=$REPOS_DIR/$reponame
+    # returns true (0) if the installation was performed
+    installed=0
+    if [ ! -d $repo_dir ] ; then
+        log Install: $reponame "failed no parent"
+        installed=1
+    else
+        (cd $repo_dir; \
+         if test -f requirements.txt ; then pip install -r requirements.txt ; fi ; \
+         python setup.py develop)
+        log Install: $reponame "setup.py develop run"
+    fi
+    return $installed
+}

--- a/deploy/setup/install-api.sh
+++ b/deploy/setup/install-api.sh
@@ -37,6 +37,9 @@ if grep --invert-match "distribute" \
     mv requirements.txt.new $APPROOT/requirements.txt
 fi
 
+git_refresh OpenTreeOfLife peyotl || true
+py_package_setup_install peyotl || true
+
 (cd $APPROOT; pip install -r requirements.txt)
 
 (cd web2py/applications; \


### PR DESCRIPTION
The translatingnexson branch of api.opentreeoflife.org
requires peyotl which can be installed by running
git clone (or pull) and then the python setup.py based
installation.
Adding of this step to an earlier branch of
the api repo should not hurt anything.
