### PR TITLE
Clean up unused ad-hoc elements before saving

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1007,6 +1007,7 @@ function saveFormDataToStudyJSON() {
         });
     });
     $.each( allTrees, function(i, tree) {
+        cleanupAdHocRoot(tree);
         clearD3PropertiesFromTree(tree);
     });
     


### PR DESCRIPTION
This refers to a node and edge created when re-rooting a Nexson tree on
an edge. If these are added, then we re-root to an existing node, we can
remove the ad-hoc elements to avoid clutter.
