### PR TITLE
Support for a 4th arg to git_refresh for dir

### DIFF
--- a/deploy/setup/functions.sh
+++ b/deploy/setup/functions.sh
@@ -89,6 +89,7 @@ function git_refresh() {
     guser=$1    # OpenTreeOfLife
     reponame=$2
     branch=$3
+    repos_par_arg=$4
 
     if [ x$branch = x ]; then
 	branch=${OPENTREE_BRANCHES[$reponame]}
@@ -99,11 +100,16 @@ function git_refresh() {
     echo "Using branch $branch of repo $reponame"
 
     # Directory in which all local checkouts of git repos reside
-    repo_dir=$REPOS_DIR/$reponame
+    if [ x${repos_par_arg} = x ]; then
+        repo_par=${REPOS_DIR}
+    else
+        repo_par=${repos_par_arg}
+    fi
+    repo_dir=$repo_par/$reponame
     # Exit 0 (true) means has changed
     changed=0
     if [ ! -d $repo_dir ] ; then
-        (cd $REPOS_DIR; \
+        (cd $repo_par; \
          git clone --branch $branch https://github.com/$guser/$reponame.git)
 	log Clone: $reponame `cd $repo_dir; git log | head -1`
     else

--- a/deploy/setup/install-api.sh
+++ b/deploy/setup/install-api.sh
@@ -50,8 +50,9 @@ py_package_setup_install peyotl || true
 
 echo "...fetching $OPENTREE_DOCSTORE repo..."
 
-phylesystem=repo/$OPENTREE_DOCSTORE
-git_refresh OpenTreeOfLife $OPENTREE_DOCSTORE $BRANCH || true
+phylesystem=repo/${OPENTREE_DOCSTORE}_par/$OPENTREE_DOCSTORE
+mkdir -p repo/${OPENTREE_DOCSTORE}_par
+git_refresh OpenTreeOfLife $OPENTREE_DOCSTORE "$BRANCH" repo/${OPENTREE_DOCSTORE}_par || true
 
 pushd .
     cd $phylesystem
@@ -67,7 +68,8 @@ pushd .
 
     cd $APPROOT/private
     cp config.example config
-    sed -i -e "s+REPO_PATH+$OTHOME/repo/$OPENTREE_DOCSTORE+" config
+    sed -i -e "s+REPO_PATH+$OTHOME/repo/${OPENTREE_DOCSTORE}_par/$OPENTREE_DOCSTORE+" config
+    sed -i -e "s+REPO_PAR+$OTHOME/repo/${OPENTREE_DOCSTORE}_par+" config
 
     # Specify our remote to push to, which is added to local repo above
     sed -i -e "s+REPO_REMOTE+originssh+" config


### PR DESCRIPTION
The multi-repo version of api needs a
parent directory that will be the parent
of each "shard" of the phylesystem. So
I added an optional 4th arg to git_refresh so
that the api could checkout the phylesystem
repos to repo/phylesystem_par/phyelsystem
rather than repo/phylesystem
The install-api.sh depends on the local-dep
branch of api. So it should not be merged to
master until that merge happens.
