### PR TITLE
Improve compound node labels in tree viewer.

### DIFF
--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1063,7 +1063,22 @@ function createArgus(spec) {
             });
         } else {
             // create the new label
-            label = paper.text(labelX, labelY, node.name).attr({
+            var displayLabel;
+            if (node.isLocalLeafNode()) {
+                // always show labels for leaf nodes (in this view)
+                displayLabel = node.name;
+            } else {
+                // hide synthetic/compound node labels for internal (in this view) nodes
+                var compoundNodeNameDelimiter = ' + ';
+                var compoundNodeNamePrefix = '[';
+                var compoundNodeNameSuffix = ']';
+                // N.B. this is determined using vars above, COPIED from treeview.js!
+                var isCompoundNodeName = ((node.name.indexOf(compoundNodeNameDelimiter) !== -1) &&
+                                          (node.name.indexOf(compoundNodeNamePrefix) === 0) && 
+                                          (node.name.indexOf(compoundNodeNameSuffix) === (node.name.length -1)));
+                displayLabel = (isCompoundNodeName ? '' : node.name);
+            }
+            label = paper.text(labelX, labelY, displayLabel).attr({
                 'text-anchor': labelAnchor,
                 "fill": this.labelColor,
                 "font-size": fontSize
@@ -1220,7 +1235,7 @@ function createArgus(spec) {
                             }).insertBefore(dividerBeforeAnchoredUI);
                             circle.id = (nodeCircleElementID);
 
-                            label = paper.text(labelX, labelY, ancestorNode.name || "unnamed").attr({
+                            label = paper.text(labelX, labelY, ancestorNode.name || "").attr({
                                 'text-anchor': 'end',
                                 "fill": this.labelColor,
                                 "font-size": fontSize


### PR DESCRIPTION
Show the proposed **[Taxon A + Taxon B]** format for (display) leaf nodes,
page titles, and in the property inspector. URLs will use slightly
modified version with web2py-safe characters. To avoid clutter and
confusion, do **not** show these labels for (display) internal nodes in the
tree view.

**N.B.** This does not include proper leaf counts, since we need more data
from treemachine. Likewise, for "upward" nodes from the target, we don't
yet have data in the view to create these labels. Once we have a proper leaf 
count for every node, consider changing the label format to 
**[Taxon A + Taxon B; n tips]**, for example: **[Forstera + Stylidium; 11 tips]**
