### PR TITLE
Adapt taxon search to reset a study's focal clade.

### DIFF
--- a/curator/controllers/study.py
+++ b/curator/controllers/study.py
@@ -37,7 +37,7 @@ def view():
     """
     response.view = 'study/edit.html'
     view_dict = get_opentree_services_method_urls(request)
-    view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names()
+    #view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names()
     view_dict['studyID'] = request.args[0]
     view_dict['viewOrEdit'] = 'VIEW'
     view_dict['userCanEdit'] = auth.is_logged_in() and True or False;
@@ -55,6 +55,7 @@ def edit():
     # TODO: fetch a fresh list of search contexts for TNRS? see working example in
     # the header search of the main opentree webapp
     view_dict = get_opentree_services_method_urls(request)
+    view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names()
     view_dict['studyID'] = request.args[0]
     view_dict['viewOrEdit'] = 'EDIT'
     return view_dict

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -244,9 +244,48 @@ body {
                 <label class="control-label" for="ot_focalClade">Focal clade</label>
                 <div class="controls">
                 {{ if viewOrEdit == 'EDIT': }}
+                  <div class="static-form-value" 
+                       data-bind="text: nexml['^ot:focalCladeOTTTaxonName'] || 'None', attr:{'title': ('ottid:'+ nexml['^ot:focalClade'])}, css: viewModel.ticklers.GENERAL_METADATA">
+                    &nbsp;
+                  </div>
+            <!-- reuse some (not all) style and behavior for taxon search in synth-tree viewer -->
+            <div id="taxon-search-form" class="Xnavbar-search Xpull-right" autocomplete="off" style="Xdisplay: inline-block; position: relative;">
+                <input type="text" name="taxon-search" class="Xsearch-query input-large" 
+                    placeholder="Choose another taxon..." autocomplete="off">
+                <!-- <input type="submit" style="" name="taxon-search-go" value="Go" onclick="return false;"/> -->
+                <!-- then show dropdown when results are ready... -->
+                <span style="color: #999; padding: 0 2px; font-size: 14px;">in</span>
+                <select style="margin-bottom: 0; width: auto;" name="taxon-search-context">
+                    {{ # generate our contextNames list based on newly fetched names
+                      try:
+                       for context_name in taxonSearchContextNames:
+                          if context_name == 'All life': }}
+                           <option selected="selected">{{= context_name }}</option>
+                       {{ else: }}
+                            <option>{{= context_name }}</option>
+                       {{ pass }}
+                    {{ pass }}
+                    {{ except:
+                        pass}}
+                <!-- 
+                NOTE that the displayed OPTION values (confirmed as current via AJAX) are accepted 
+                by the server, ie, there's no distinction between visible and occult values.
+                -->
+                </select>
+                <div class="">
+                    <ul id="search-results" class="dropdown-menu">
+                        ...
+                    </ul>
+                </div>
+            </div>
+                  <input data-bind="value: nexml['^ot:focalClade'], valueUpdate: 'afterkeydown', event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }, css: viewModel.ticklers.GENERAL_METADATA" type="hidden" id="ot_focalClade" placeholder="">
+                  <!--
                   <input data-bind="value: nexml['^ot:focalClade'], valueUpdate: 'afterkeydown', event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }" type="text" id="ot_focalClade" class="input-small" placeholder="">
+                    -->
                 {{ else: }}
-                  <p class="static-form-value" data-bind="text: nexml['^ot:focalClade']"></p>
+                  <p class="static-form-value">
+                    <span data-bind="text: nexml['^ot:focalCladeOTTTaxonName'], attr:{'title': ('ottid:'+ nexml['^ot:focalClade'])}, css: viewModel.ticklers.GENERAL_METADATA">&nbsp;</span>
+                  </p>
                 {{ pass }}
                 </div>
               </div>


### PR DESCRIPTION
This gives us a proper UI for setting the focal clade by name, rather than a cryptic OTT id.
