### PR TITLE
Modify deployment tools to handle two GitHub apps.

### DIFF
--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -82,14 +82,19 @@ if [ "x$OPENTREE_IDENTITY" = x ]; then echo "OPENTREE_IDENTITY not specified"; e
 if [ ! -r $OPENTREE_IDENTITY ]; then echo "$OPENTREE_IDENTITY not found"; exit 1; fi
 [ "x$OPENTREE_NEO4J_HOST" != x ] || OPENTREE_NEO4J_HOST=$OPENTREE_HOST
 [ "x$OPENTREE_PUBLIC_DOMAIN" != x ] || OPENTREE_PUBLIC_DOMAIN=$OPENTREE_HOST
-[ "x$GITHUB_CLIENT_ID" != x ] || GITHUB_CLIENT_ID=ID_NOT_PROVIDED
-[ "x$GITHUB_REDIRECT_URI" != x ] || GITHUB_REDIRECT_URI=$OPENTREE_PUBLIC_DOMAIN/curator/user/login
+
+[ "x$CURATION_GITHUB_CLIENT_ID" != x ] || CURATION_GITHUB_CLIENT_ID=ID_NOT_PROVIDED
+[ "x$CURATION_GITHUB_REDIRECT_URI" != x ] || CURATION_GITHUB_REDIRECT_URI=$OPENTREE_PUBLIC_DOMAIN/webapp/user/login
+[ "x$TREEVIEW_GITHUB_CLIENT_ID" != x ] || TREEVIEW_GITHUB_CLIENT_ID=ID_NOT_PROVIDED
+[ "x$TREEVIEW_GITHUB_REDIRECT_URI" != x ] || TREEVIEW_GITHUB_REDIRECT_URI=$OPENTREE_PUBLIC_DOMAIN/curator/user/login
+
 [ "x$TREEMACHINE_BASE_URL" != x ] || TREEMACHINE_BASE_URL=$OPENTREE_NEO4J_HOST/treemachine
 [ "x$TAXOMACHINE_BASE_URL" != x ] || TAXOMACHINE_BASE_URL=$OPENTREE_NEO4J_HOST/taxomachine
 [ "x$OTI_BASE_URL" != x ] || OTI_BASE_URL=http://$OPENTREE_NEO4J_HOST/oti
 [ "x$OPENTREE_API_BASE_URL" != x ] || OPENTREE_API_BASE_URL=$OPENTREE_PUBLIC_DOMAIN/api/v1
 
-if [ $GITHUB_CLIENT_ID = ID_NOT_PROVIDED ]; then echo "WARNING: Missing GitHub client ID! Curation UI will be disabled."; fi
+if [ $CURATION_GITHUB_CLIENT_ID = ID_NOT_PROVIDED ]; then echo "WARNING: Missing GitHub client ID! Curation UI will be disabled."; fi
+if [ $TREEVIEW_GITHUB_CLIENT_ID = ID_NOT_PROVIDED ]; then echo "WARNING: Missing GitHub client ID! Tree-view feedback will be disabled."; fi
 
 # abbreviations... no good reason for these, they just make the commands shorter
 
@@ -197,7 +202,7 @@ function restart_apache {
 
 function push_opentree {
     if [ $DRYRUN = "yes" ]; then echo "[opentree]"; return; fi
-    ${SSH} "$OT_USER@$OPENTREE_HOST" ./setup/install-web2py-apps.sh "$OPENTREE_HOST" "${OPENTREE_PUBLIC_DOMAIN}" "${NEO4JHOST}" $CONTROLLER "${GITHUB_CLIENT_ID}" "${GITHUB_REDIRECT_URI}" "${TREEMACHINE_BASE_URL}" "${TAXOMACHINE_BASE_URL}" "${OTI_BASE_URL}" "${OPENTREE_API_BASE_URL}"
+    ${SSH} "$OT_USER@$OPENTREE_HOST" ./setup/install-web2py-apps.sh "$OPENTREE_HOST" "${OPENTREE_PUBLIC_DOMAIN}" "${NEO4JHOST}" "$CONTROLLER" "${CURATION_GITHUB_CLIENT_ID}" "${CURATION_GITHUB_REDIRECT_URI}" "${TREEVIEW_GITHUB_CLIENT_ID}" "${TREEVIEW_GITHUB_REDIRECT_URI}" "${TREEMACHINE_BASE_URL}" "${TAXOMACHINE_BASE_URL}" "${OTI_BASE_URL}" "${OPENTREE_API_BASE_URL}"
     # place the files with secret GitHub API keys for curator and webapp (tree browser feedback) apps
     # N.B. This includes the final domain name, since we'll need different keys for dev.opentreeoflife.org, www.opentreeoflife.org, etc.
     keyfile=~/.ssh/opentree/curator-GITHUB_CLIENT_SECRET-$OPENTREE_PUBLIC_DOMAIN

--- a/deploy/sample.config
+++ b/deploy/sample.config
@@ -82,9 +82,16 @@ OPENTREE_API_BASE_URL=http://${OPENTREE_PUBLIC_DOMAIN}/api/v1
 # -----
 # Some variables are used to authenticate the registered curation app on GitHub
 
-GITHUB_CLIENT_ID=YOUR_GITHUB_CLIENT_ID_HERE
-GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
-# N.B. The GITHUB_CLIENT_SECRET is stored separately, in a file with that name.
+CURATION_GITHUB_CLIENT_ID=YOUR_GITHUB_CLIENT_ID_HERE
+CURATION_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/curator/user/login
+# N.B. The GITHUB_CLIENT_SECRET is stored separately, in a file like 'curation-GITHUB_CLIENT_SECRET-dev.opentreeoflife.org'
+
+# -----
+# Similar variables are used to authenticate the registered tree-viewer app on GitHub
+
+TREEVIEW_GITHUB_CLIENT_ID=YOUR_GITHUB_CLIENT_ID_HERE
+TREEVIEW_GITHUB_REDIRECT_URI=http://${OPENTREE_PUBLIC_DOMAIN}/opentree/user/login
+# N.B. The GITHUB_CLIENT_SECRET is stored separately, in a file like 'treeview-GITHUB_CLIENT_SECRET-dev.opentreeoflife.org'
 
 # -----
 # OPENTREE_DOCSTORE is the name of the OpenTreeOfLife git repository

--- a/deploy/setup/install-web2py-apps.sh
+++ b/deploy/setup/install-web2py-apps.sh
@@ -3,8 +3,8 @@
 # Some of this repeats what's found in install-api.sh.  Keep in sync.
 
 # Lots of arguments to make this work.. check to see if we have them all.
-if [ "$#" -ne 10 ]; then
-    echo "install-web2py-apps.sh missing required parameters (expecting 10)"
+if [ "$#" -ne 12 ]; then
+    echo "install-web2py-apps.sh missing required parameters (expecting 12)"
     exit 1
 fi
 
@@ -12,13 +12,15 @@ OPENTREE_HOST=$1
 OPENTREE_PUBLIC_DOMAIN=$2
 NEO4JHOST=$3
 CONTROLLER=$4
-GITHUB_CLIENT_ID=$5
-GITHUB_REDIRECT_URI=$6
-TREEMACHINE_BASE_URL=$7
-TAXOMACHINE_BASE_URL=$8
-OTI_BASE_URL=$9
+CURATION_GITHUB_CLIENT_ID=$5
+CURATION_GITHUB_REDIRECT_URI=$6
+TREEVIEW_GITHUB_CLIENT_ID=$7
+TREEVIEW_GITHUB_REDIRECT_URI=$8
+TREEMACHINE_BASE_URL=$9
 # NOTE that args beyond nine must be referenced in curly braces
-OPENTREE_API_BASE_URL=${10}
+TAXOMACHINE_BASE_URL=${10}
+OTI_BASE_URL=${11}
+OPENTREE_API_BASE_URL=${12}
 
 . setup/functions.sh
 
@@ -122,7 +124,9 @@ configfile=$configdir/config
 
 # Replace tokens in example config file to make the active config (assume this always changes)
 cp -p $configtemplate $configfile
-sed "s+hostdomain = .*+hostdomain = $OPENTREE_PUBLIC_DOMAIN+;
+sed "s+github_client_id = .*+github_client_id = $TREEVIEW_GITHUB_CLIENT_ID+;
+     s+github_redirect_uri = .*+github_redirect_uri = $TREEVIEW_GITHUB_REDIRECT_URI+
+     s+hostdomain = .*+hostdomain = $OPENTREE_PUBLIC_DOMAIN+;
      s+treemachine = .*+treemachine = $TREEMACHINE_BASE_URL+
      s+taxomachine = .*+taxomachine = $TAXOMACHINE_BASE_URL+
      s+oti = .*+oti = $OTI_BASE_URL+
@@ -136,8 +140,8 @@ configfile=$configdir/config
 
 # Replace tokens in example config file to make the active config (assume this always changes)
 cp -p $configtemplate $configfile
-sed "s+github_client_id = .*+github_client_id = $GITHUB_CLIENT_ID+;
-     s+github_redirect_uri = .*+github_redirect_uri = $GITHUB_REDIRECT_URI+
+sed "s+github_client_id = .*+github_client_id = $CURATION_GITHUB_CLIENT_ID+;
+     s+github_redirect_uri = .*+github_redirect_uri = $CURATION_GITHUB_REDIRECT_URI+
      s+treemachine = .*+treemachine = $TREEMACHINE_BASE_URL+
      s+taxomachine = .*+taxomachine = $TAXOMACHINE_BASE_URL+
      s+oti = .*+oti = $OTI_BASE_URL+


### PR DESCRIPTION
We've not registered two apps with GitHub, one for curation and another for the tree-viewer's feedback tool. While a user is likely using the same credentials in both cases, we need to distinguish between these in order to return to the correct app after login.
