### PR TITLE
Phylesystem without redirects

### DIFF
--- a/deploy/setup/apache-config
+++ b/deploy/setup/apache-config
@@ -51,11 +51,6 @@
 
     # OPENTREE STUFF INSERTED HERE
 
-    <Location /phylesystem>
-      RedirectMatch temp /phylesystem/v1/study/(.*) /api/v1/study/$1
-      Redirect temp /phylesystem/v1/study_list /api/study_list
-    </Location>
-
     # See http://stackoverflow.com/questions/13216837/install-web2py-in-virtual-hosting
     # Had: user=opentree group=opentree
     WSGIDaemonProcess web2py user=opentree group=opentree display-name=%{GROUP}

--- a/deploy/setup/install-api.sh
+++ b/deploy/setup/install-api.sh
@@ -74,7 +74,8 @@ py_package_setup_install peyotl || true
 (cd $APPROOT/ot-celery; pip install -r requirements.txt ; python setup.py develop)
 
 (cd web2py/applications; \
-    ln -sf ../../repo/$WEBAPP ./api)
+    rm -f ./phylesystem
+    ln -sf ../../repo/$WEBAPP ./phylesystem)
 
 # ---------- DOC STORE ----------
 


### PR DESCRIPTION
uses phylesystem as the phylesystem-api app name in web2py applications and removes the redirects that add v1 because they are not necessary in the production system.
this is what I just used to push to ot12
