### PR TITLE
Fix missing search-context list on Contact page.

### DIFF
--- a/webapp/controllers/contact.py
+++ b/webapp/controllers/contact.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from opentreewebapputil import (get_opentree_services_method_urls, 
+                                fetch_current_TNRS_context_names)
 
 ### required - do no delete
 def user(): return dict(form=auth())
@@ -6,6 +8,9 @@ def download(): return response.download(request,db)
 def call(): return service()
 ### end requires
 
+default_view_dict = get_opentree_services_method_urls(request)
+default_view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
+
 def index():
-    return dict()
+    return default_view_dict
 


### PR DESCRIPTION
@kcranston, @jar398 : An isolated fix for the Contact page of the synth-tree viewer.
