### PR TITLE
Return supporting file

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -205,7 +205,7 @@ def to_nexson():
     ##pdb.set_trace()
     orig_args = {}
     is_upload = False
-    # several of our NexSON use "uploadid" instead of "uploadId"
+    # several of our NexSON use "uploadid" instead of "uploadId" so we should accept either
     if ('uploadId' in request.vars) or ('uploadid' in request.vars):
         try:
             if ('uploadId' in request.vars):


### PR DESCRIPTION
The "@url" fields for several (perhaps all) or our SUPPORTING_FILES use "uploadid" rather than "uploadId" 
This commit will allow either case convention.
I've tested this locally, but it will be hard to test on devapi because that instance of the curator has not been doing the importing of supporting files. So it can't return any supporting files.

Issue https://github.com/OpenTreeOfLife/opentree/issues/280 seems pretty important to address.
