### PR TITLE
Kill getConflictTaxJsonAltRel, getJSONFromNode_url

### DIFF
--- a/curator/private/config.example
+++ b/curator/private/config.example
@@ -43,7 +43,6 @@ opentree_api = http://dev.opentreeoflife.org/phylesystem/v1
 getDraftTreeID_url = {treemachine_domain}/getDraftTreeID
 getSyntheticTree_url = {treemachine_domain}/getSyntheticTree  
 getSourceTree_url = {treemachine_domain}/getSourceTree  
-getConflictTaxJsonAltRel_url = {taxomachine_domain}/../ext/GetJsons/node/{nodeID}/getConflictTaxJsonAltRel
 getDraftTreeForOttolID_url = {treemachine_domain}/getDraftTreeForottId
 # N.B. getDraftTreeForottId doesn't match the capitalization conventions used elsewhere.
 getDraftTreeForNodeID_url = {treemachine_domain}/getDraftTreeForNodeID
@@ -51,7 +50,6 @@ doTNRSForAutocomplete_url = {taxomachine_domain}/autocompleteQuery
 doTNRSForMappingOTUs_url = {taxomachine_domain}/contextQuery
 getContextsJSON_url = {taxomachine_domain}/getContextsJSON
 getNodeIDForOttolID_url = {treemachine_domain}/getNodeIDForottId
-getJSONFromNode_url = {treemachine_domain}/ext/GetJsons/node
 phylesystem_config_url = {opentree_api_domain}/phylesystem_config
 render_markdown_url = {opentree_api_domain}/render_markdown
 getSynthesisSourceList_url = {treemachine_domain}/getSynthesisSourceList

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1706,13 +1706,11 @@ body {
     var getDraftTreeID_url = "{{=getDraftTreeID_url}}";
     var getSyntheticTree_url = "{{=getSyntheticTree_url}}";
     var getSourceTree_url = "{{=getSourceTree_url}}";
-    var getConflictTaxJsonAltRel_url = "{{=getConflictTaxJsonAltRel_url}}";
     var getDraftTreeForOttolID_url = "{{=getDraftTreeForOttolID_url}}";
     var getDraftTreeForNodeID_url = "{{=getDraftTreeForNodeID_url}}";
     var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
     var doTNRSForMappingOTUs_url = "{{=doTNRSForMappingOTUs_url}}";
     var getNodeIDForOttolID_url = "{{=getNodeIDForOttolID_url}}";
-    var getJSONFromNode_url = "{{=getJSONFromNode_url}}";
     var phylesystem_config_url = "{{=phylesystem_config_url}}";
     var render_markdown_url = "{{=render_markdown_url}}";
     var getMRCAForNodes_url = "{{=getMRCAForNodes_url}}";

--- a/webapp/private/config.example
+++ b/webapp/private/config.example
@@ -37,14 +37,12 @@ opentree_api = http://opentree.myserver.org/phylesystem/v1
 getDraftTreeID_url = {treemachine_domain}/getDraftTreeID
 getSyntheticTree_url = {treemachine_domain}/getSyntheticTree  
 getSourceTree_url = {treemachine_domain}/getSourceTree  
-getConflictTaxJsonAltRel_url = {taxomachine_domain}/../ext/GetJsons/node/{nodeID}/getConflictTaxJsonAltRel
 getDraftTreeForOttolID_url = {treemachine_domain}/getDraftTreeForottId
 # N.B. getDraftTreeForottId doesn't match the capitalization conventions used elsewhere.
 getDraftTreeForNodeID_url = {treemachine_domain}/getDraftTreeForNodeID
 doTNRSForAutocomplete_url = {taxomachine_domain}/autocompleteQuery
 getContextsJSON_url = {taxomachine_domain}/getContextsJSON
 getNodeIDForOttolID_url = {treemachine_domain}/getNodeIDForottId
-getJSONFromNode_url = {treemachine_domain}/ext/GetJsons/node
 getSynthesisSourceList_url = {treemachine_domain}/getSynthesisSourceList
 findAllStudies_url = {oti_domain}/findAllStudies
 # Include one phylesystem-api method to download NexSON from Bibliographic References page

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -258,10 +258,14 @@ function createArgus(spec) {
                 ajaxData.subtreeNodeID = String(o.nodeID);
             }
         } else {
+            /* TODO: Restore the ability to fetch conflict information from taxomachine?
             url = getConflictTaxJsonAltRel_url.replace('{nodeID}', o.nodeID);
             // @TEMP assuming ottol
             ds = o.domSource === undefined ? "ottol" : o.domSource;
             ajaxData = {"domsource": ds}; // phylotastic TNRS API wants domsource, MTH believes.
+            */
+            alert("AJAX calls via taxomachine are no longer supported.");
+            return;
         }
         return {
             "url": url,

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -74,12 +74,10 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         var getDraftTreeID_url = "{{=getDraftTreeID_url}}";
         var getSyntheticTree_url = "{{=getSyntheticTree_url}}";
         var getSourceTree_url = "{{=getSourceTree_url}}";
-        var getConflictTaxJsonAltRel_url = "{{=getConflictTaxJsonAltRel_url}}";
         var getDraftTreeForOttolID_url = "{{=getDraftTreeForOttolID_url}}";
         var getDraftTreeForNodeID_url = "{{=getDraftTreeForNodeID_url}}";
         var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
         var getNodeIDForOttolID_url = "{{=getNodeIDForOttolID_url}}";
-        var getJSONFromNode_url = "{{=getJSONFromNode_url}}";
     </script>
     {{pass}}
     <script type="text/javascript">


### PR DESCRIPTION
These are no longer used, but had references in configuration and code
that might lead to confusion. Related to
https://github.com/OpenTreeOfLife/taxomachine/commit/1c5e1fa216a87302959efecc9b8b7f8fc4acc33b
