### PR TITLE
Offer circular layout for curation tree viewer.

### DIFF
--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -460,7 +460,7 @@ if (!d3) { throw "d3 wasn't included!"};
       .append("svg:g")
         .attr("transform", "translate(" + r + "," + r + ")");
         
-    var tree = d3.layout.tree()
+    var tree = d3.layout.cluster()
       .size([360, r - labelWidth])
       .sort(function(node) { return node.children ? node.children.length : -1; })
       .children(options.children || function(node) {

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2171,6 +2171,12 @@ body {
                      onclick="toggleBranchLengthsInViewer(this); return true;" />
               Cladogram (hide branch lengths)
           </label>
+
+          <label class="checkbox" style="margin-left: 25px;" for="radial-layout-toggle"> 
+              <input type="checkbox" id="radial-layout-toggle"
+                     onclick="toggleRadialTreeLayoutInViewer(this); return true;" />
+              Radial tree layout
+          </label>
       </div>
       <a class="btn" onclick="$('#tree-viewer').modal('hide'); false;">Close</a>
       <!-- <a class="btn btn-primary" id="btnSaveChanges">Save changes</a> -->


### PR DESCRIPTION
(The only feedback I've received on this branch was from @chinchliff, and it was positive.) This layout ignores edge lengths. Its height and width will adapt based on the total number of nodes, so big trees will require scrolling within the tree viewer. 

This is once again deployed to **devtree**. Here are some examples (choose "Radial tree layout"):
- [A small tree](http://devtree.opentreeoflife.org/curator/study/view/pg_10/?tab=tree&tree=tree3)
- [A really big tree](http://devtree.opentreeoflife.org/curator/study/view/pg_2584/?tab=trees&tree=tree5990)
