### PR TITLE
Add link to OT blog from main webapp (tree viewer)

### DIFF
--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -187,6 +187,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                   </ul>
               </li>
               <li><a href="{{= URL('contact','index') }}">Contact</a></li>
+              <li><a href="http://blog.opentreeoflife.org/" target="_blank">Blog</a></li>
             </ul>
             <form id="taxon-search-form" class="navbar-search pull-right" autocomplete="off">
                 <input type="text" name="taxon-search" class="search-query" placeholder="Search for taxon" autocomplete="off"


### PR DESCRIPTION
Fixes #451. Blog will open in a new tab or window, as we've done for other "offsite" links.
