### PR TITLE
Show updated version history after saving a study.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1609,6 +1609,10 @@ function saveFormDataToStudyJSON() {
             }
             var putResponse = $.parseJSON(jqXHR.responseText);
             viewModel.startingCommitSHA = putResponse['sha'] || viewModel.startingCommitSHA;
+            // update the History tab to show the latest commit
+            if ('versionHistory' in putResponse) {
+                viewModel.versions(putResponse['versionHistory'] || [ ]);
+            }
             if (putResponse['merge_needed']) {
                 var errMsg = 'Your changes were saved, but an edit by another user prevented your edit from merging to the publicly visible location. In the near future, we hope to take care of this automatically. In the meantime, please <a href="mailto:info@opentreeoflife.org?subject=Merge%20needed%20-%20'+ viewModel.startingCommitSHA +'">report this error</a> to the Open Tree of Life software team';
                 hideModalScreen();


### PR DESCRIPTION
Fixes #391. NOTE: This requires merging the matching branch in **phylesystem-api** to fully work (else it will do nothing).
