### PR TITLE
Removing unused shutils; general cleanup.

### DIFF
--- a/curator/controllers/supporting_files.py
+++ b/curator/controllers/supporting_files.py
@@ -8,6 +8,8 @@ def upload_file():
     File upload handler for the AJAX form of the plugin jquery-file-upload
     Return the response in JSON required by the plugin
     """
+    import os
+    import gluon
     response.view = 'generic.json'
     try:
         # Get the file from the form
@@ -17,14 +19,13 @@ def upload_file():
         id = db.supporting_files.insert(doc = db.supporting_files.doc.store(f.file, f.filename))
          
         # Compute size of the file and update the record
-        import shutil
         record = db.supporting_files[id]
          
         path_list = []
         path_list.append(request.folder)
         path_list.append('uploads')
         path_list.append(record['doc'])
-        size = shutil.os.path.getsize(shutil.os.path.join(*path_list))
+        size = os.path.getsize(os.path.join(*path_list))
          
         File = db(db.supporting_files.id==id).select()[0]
         db.supporting_files[id] = dict(file_size=size)
@@ -32,10 +33,6 @@ def upload_file():
          
         res = dict(files=[{"name": str(f.filename), "size": size, "url": URL(f='download', args=[File['doc']]), "delete_url": URL(f='delete_file', args=[File['doc']])}])
          
-        import gluon
-        ## print(">>>>>>>")
-        ## print(gluon.contrib.simplejson.dumps(res, separators=(',',':')))
-        ## print("<<<<<<<")
         return gluon.contrib.simplejson.dumps(res, separators=(',',':'))
 
     except:


### PR DESCRIPTION
This matches similar changes made in #476. Seems wise, since `os` support in `shutils` is not guaranteed.
