### PR TITLE
Clarify web2py patches

### DIFF
--- a/oauth20_account.py
+++ b/oauth20_account.py
@@ -12,6 +12,8 @@ OAuth 2.0 spec: http://tools.ietf.org/html/rfc6749
 *****************************
 NOTE that this is a modified version from web2py 2.8.2. For full details on what has changed, see
 https://github.com/OpenTreeOfLife/opentree/commits/master/oauth20_account.py
+
+This file was patched (by jimallman, on 3/25/2014) to support redirection on proxied web2py servers.
 *****************************
 """
 

--- a/rewrite.py
+++ b/rewrite.py
@@ -16,7 +16,10 @@ Refer to router.example.py and routes.example.py for additional documentation.
 
 *****************************
 NOTE that this is a modified version from web2py 2.8.2. For full details on what has changed, see
-https://github.com/OpenTreeOfLife/opentree/commits/master/rewrite.py
+ https://github.com/OpenTreeOfLife/opentree/commits/master/rewrite.py
+
+This file was patched (by jimallman, on 3/25/2014) to restore liberal CORS
+headers when returning exceptions from a cross-domain request.
 *****************************
 """
 


### PR DESCRIPTION
These commits clarify the exact changes made to web2py 2.8.2 and its `gluon/rewrite.py` file. That file ends up exactly the same as it was before, but storing these commits in the graph **should** record our web2py patch and how to carry it forward into newer versions of web2py.

See related discussion in https://github.com/OpenTreeOfLife/phylesystem-api/issues/121
