### PR TITLE
Enable default JSON response at API root.

### DIFF
--- a/deploy/setup/apache-config-shared
+++ b/deploy/setup/apache-config-shared
@@ -125,3 +125,9 @@
       Allow from all
       ProxyPass  http://localhost:7478/db/data/ext
     </Location>
+
+    # ------------------------------------------------------------
+    # default home page (JSON with links to API docs) via web2py
+
+    RewriteEngine on
+    RewriteRule ^/$ /phylesystem/default/index.html [PT]


### PR DESCRIPTION
This replaces the current "invalid request" message at the root of the API site (e.g., http://devapi.opentreeoflife.org or http://api.opentreeoflife.org/) with the intended response, a tiny JSON document that points to API docs and source code.

This is available for review on **devapi**. I've tested with a few method URLs from v1 and v2 APIs, and it seems to leave all other URLs unaffected.
