### PR TITLE
Fix bogus matching on curator-as-focal-clade

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -150,8 +150,8 @@ function loadStudyList() {
                         var curator = study['ot:curatorName'];
                         var clade = ('ot:focalCladeOTTTaxonName' in study && 
                                      ($.trim(study['ot:focalCladeOTTTaxonName']) !== "")) ?
-                                        study['ot:curatorName'] :
-                                        study['ot:focalClade'];
+                                        study['ot:focalCladeOTTTaxonName'] :  // use mapped name if found
+                                        study['ot:focalClade']; // fall back to numeric ID (should be very rare)
                         if (!matchPattern.test(pubReference) && !matchPattern.test(pubURL) && !matchPattern.test(pubYear) && !matchPattern.test(curator) && !matchPattern.test(tags) && !matchPattern.test(clade)) {
                             return false;
                         }


### PR DESCRIPTION
This is in the JS-powered filtered study list of the curation app. For an example, filter on "Basidiomycota". Before the fix, this finds studies that use this taxon name in the title, but there are others that will appear if we search directly on the `ot:focalCladeOTTTaxonName` property as originally intended.
