### PR TITLE
Disable Save Study button if no unsaved changes.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -244,6 +244,7 @@ $(document).ready(function() {
     }
     // N.B. We'll check this again once we've loaded the selected study, then clear it
 
+    disableSaveButton();
     loadSelectedStudy();
     
     // Initialize the jQuery File Upload widgets
@@ -1164,6 +1165,7 @@ function loadSelectedStudy() {
 
             // Any further changes (*after* tree normalization) should prompt for a save before leaving
             viewModel.ticklers.STUDY_HAS_CHANGED.subscribe( function() {
+                enableSaveButton();
                 addPageExitWarning( "WARNING: This study has unsaved changes! To preserve your work, you should save this study before leaving or reloading the page." );
                 updateQualityDisplay();
             });
@@ -1648,8 +1650,28 @@ function saveFormDataToStudyJSON() {
             showSuccessMessage('Study saved to remote storage.');
 
             removePageExitWarning();
+            disableSaveButton();
             // TODO: should we expect fresh JSON to refresh the form?
         }
+    });
+}
+
+function disableSaveButton() {
+    var $btn = $('#save-study-button');
+    $btn.addClass('disabled');
+    $btn.unbind('click').click(function(evt) {
+        showErrorMessage('There are no unsaved changes.');
+        return false;
+    });
+}
+function enableSaveButton() {
+    var $btn = $('#save-study-button');
+    $btn.removeClass('disabled');
+    $btn.unbind('click').click(function(evt) {
+        if (validateFormData()) {
+            promptForSaveComments(); 
+        }
+        return false;
     });
 }
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -203,8 +203,7 @@ body {
 
     <div class="span4 Xbtn-group" style="float: right; margin-top: -56px;">
         {{ if viewOrEdit == 'EDIT': }}
-          <button class="btn btn"
-            onclick="if (validateFormData()) promptForSaveComments(); return false;">Save Study</button>
+          <button id="save-study-button" class="btn">Save Study</button>
           <a id="return-to-study-list" class="btn btn-link" href="{{= URL(a='curator', c='default', f='index')}}">Cancel</a>
           <button class="btn btn-danger pull-right"
             onclick="removeStudy(); return false;">Delete Study</button>


### PR DESCRIPTION
This is triggered by the same logic that adds or removes the "safety
net" when trying to close or reload the curation app.

Fixes #377.