### PR TITLE
More efficient OTU mapping UI

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -780,3 +780,12 @@ ul.mapping-options li a:hover {
     -moz-box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.5);
     box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.5);
 }
+
+tr.table-shims td {
+    height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+tr.after-shims th {
+    border-top: 0;
+}

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4417,8 +4417,12 @@ function editOTULabel(otu, evt) {
     var originalLabel = otu['^ot:originalLabel'];
     otu['^ot:altLabel'] = adjustedLabel(originalLabel);
     
+    // Mark this OTU as selected for mapping.
+    otu['selectedForAction'] = true;
+
     // If we have a proper mouse event, try to move input focus to this field
     // and pre-select its full text.
+    //
     // N.B. There's a 'hasFocus' binding with similar behavior, but it's tricky
     // to mark the new field vs. existing ones:
     //   http://knockoutjs.com/documentation/hasfocus-binding.html 
@@ -4433,6 +4437,7 @@ function editOTULabel(otu, evt) {
 
     // this should make the editor appear (altering the DOM)
     bogusEditedLabelCounter( bogusEditedLabelCounter() + 1);
+    nudgeTickler( 'OTU_MAPPING_HINTS'); // to refresh 'selected' checkbox
 }
 function modifyEditedLabel(otu) {
     // remove its otu-id from failed-OTU list when user makes changes

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4412,11 +4412,26 @@ function toggleAllMappingCheckboxes(cb) {
     return true;
 }
 
-function editOTULabel(otu) {
+function editOTULabel(otu, evt) {
     var OTUid = otu['@id'];
     var originalLabel = otu['^ot:originalLabel'];
     otu['^ot:altLabel'] = adjustedLabel(originalLabel);
-    // this should make the editor appear
+    
+    // If we have a proper mouse event, try to move input focus to this field
+    // and pre-select its full text.
+    // N.B. There's a 'hasFocus' binding with similar behavior, but it's tricky
+    // to mark the new field vs. existing ones:
+    //   http://knockoutjs.com/documentation/hasfocus-binding.html 
+    if ('currentTarget' in evt) {
+        // capture the current table row before DOM updates
+        var $currentRow = $(evt.currentTarget).closest('tr');
+        setTimeout(function() {
+            var $editField = $currentRow.find('input:text');
+            $editField.focus().select();
+        }, 50);
+    }
+
+    // this should make the editor appear (altering the DOM)
     bogusEditedLabelCounter( bogusEditedLabelCounter() + 1);
 }
 function modifyEditedLabel(otu) {

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1065,19 +1065,32 @@ body {
                     OTUs in this study.
                 </div>
 
-                <table class="table table-condensed table-hover"
+                <table class="table table-condensed table-hover" style="table-layout: fixed;"
                        data-bind="visible: viewModel.filteredOTUs().pagedItems().length !== 0">
                   <thead>
-                    <tr>
+                    <tr class="table-shims">
                       {{ if viewOrEdit == 'EDIT': }}
-                        <th width="5%" style="position: relative;"><span style="position: absolute; top: -0.75em; left: -0.5em; z-index: -1; font-size: 0.85em;"
-                                >Select</span><input type="checkbox" onclick="toggleAllMappingCheckboxes(this); return true;" /></th>
-                        <th width="" colspan="2">Original name</th>
-                        <th width="30%" {{ if viewOrEdit == 'EDIT': }}colspan="2"{{pass}}>Modified for mapping</th>
-                        <th width="30%">Mapped to taxon</th>
+                        <td width="5%"></td>
+                        <td width="25%"></td>
+                        <td width="28"></td><!-- width in px, based on button width -->
+                        <td width="25%"></td>
+                        <td width="28"></td><!-- width in px, based on button width -->
+                        <td width="30%"></td>
                       {{ else: }}
-                        <th width="" colspan="2">Original name</th>
-                        <th width="30%" colspan="2">Mapped to taxon</th>
+                        <td width="70%" colspan="2"></td>
+                        <td width="30%" colspan="2"></td>
+                      {{ pass }}
+                    </tr>
+                    <tr class="after-shims">
+                      {{ if viewOrEdit == 'EDIT': }}
+                        <th style="position: relative;"><span style="position: absolute; top: -0.75em; left: -0.5em; z-index: -1; font-size: 0.85em;"
+                                >Select</span><input type="checkbox" onclick="toggleAllMappingCheckboxes(this); return true;" /></th>
+                        <th colspan="2">Original name</th>
+                        <th colspan="2">Modified for mapping</th>
+                        <th >Mapped to taxon</th>
+                      {{ else: }}
+                        <th colspan="2">Original name</th>
+                        <th colspan="2">Mapped to taxon</th>
                       {{ pass }}
                     </tr>
                   </thead>
@@ -1120,8 +1133,8 @@ body {
                          <!-- ko if: viewModel.ticklers.OTU_MAPPING_HINTS() && (bogusEditedLabelCounter() > 0)  && ('^ot:altLabel' in otu) --> 
                           {{ # show editable label field and its remove widget }}
                         <td>
-                            <input type="text" style="height: 14px; margin:
-                            0; width: 97%;" data-bind="value: otu['^ot:altLabel'], valueUpdate: ['afterkeydown', 'input'], event: { keyup: modifyEditedLabel, change: modifyEditedLabel }, css: viewModel.ticklers.OTU_MAPPING_HINTS">
+                            <input type="text" class="input-block-level" style="min-height: inherit; height: 1.6em; margin-bottom: 0" 
+                                   data-bind="value: otu['^ot:altLabel'], valueUpdate: ['afterkeydown', 'input'], event: { keyup: modifyEditedLabel, change: modifyEditedLabel }, css: viewModel.ticklers.OTU_MAPPING_HINTS">
                         </td>
                         <td>
                             <button class="btn btn-mini row-controls-ghosted pull-right" type="button" style="margin-top: 1px;" data-bind="click: revertOTULabel, css: viewModel.ticklers.OTU_MAPPING_HINTS">


### PR DESCRIPTION
* Auto-select the OTU label editor when it's enabled (select all text)
* Auto-select manually edited OTU label for mapping (check its box)
* Improve display of these labels in a narrow window