### PR TITLE
Improve mapping information for synonyms, etc.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4458,15 +4458,20 @@ function proposedMapping( otu ) {
     var acc = proposedOTUMappings()[ OTUid ];
     return acc ? acc() : null;
 }
-function approveProposedOTULabel(otu, selectedIndex) {
+function approveProposedOTULabel(otu) {
     // undoes 'editOTULabel', releasing a label to use shared hints
     var OTUid = otu['@id'];
-    var approvedMapping = proposedOTUMappings()[ OTUid ];
+    var itsMappingInfo = proposedOTUMappings()[ OTUid ];
+    var approvedMapping = $.isFunction(itsMappingInfo) ?
+        itsMappingInfo() :
+        itsMappingInfo;
     if ($.isArray(approvedMapping)) {
-        // there are multiple candidates; match the selected index
-        approvedMapping = approvedMapping[ selectedIndex ];
+        // apply the first (only) value
+        mapOTUToTaxon( OTUid, approvedMapping[0] );
+    } else {
+        // apply the inner value of an observable (accessor) function
+        mapOTUToTaxon( OTUid, ko.unwrap(approvedMapping) );
     }
-    mapOTUToTaxon( OTUid, approvedMapping() );
     delete proposedOTUMappings()[ OTUid ];
     proposedOTUMappings.valueHasMutated();
     nudgeTickler('OTU_MAPPING_HINTS');
@@ -4746,6 +4751,7 @@ function requestTaxonMapping( otuToMap ) {
                     failedMappingOTUs.push( otuID );
                     break;
 
+                /* SKIPPING THIS to provide uniform treatment of all matches
                 case 1:
                     // choose the first+only match automatically!
                     var resultToMap = candidateMatches[0];
@@ -4761,6 +4767,7 @@ function requestTaxonMapping( otuToMap ) {
                     proposeOTULabel(otuID, otuMapping);
                     // postpone actual mapping until user approves
                     break;
+                 */
 
                 default: 
                     // multiple matches found, offer a choice

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1074,7 +1074,7 @@ body {
                                 >Select</span><input type="checkbox" onclick="toggleAllMappingCheckboxes(this); return true;" /></th>
                         <th width="" colspan="2">Original name</th>
                         <th width="30%" {{ if viewOrEdit == 'EDIT': }}colspan="2"{{pass}}>Modified for mapping</th>
-                        <th width="30%">Mapped to taxon</th>
+                        <th width="30%">Mapped to taxon <a href="#" onclick="showPossibleMappingsKey(); return false;">(key)</a></th>
                       {{ else: }}
                         <th width="" colspan="2">Original name</th>
                         <th width="30%" colspan="2">Mapped to taxon</th>
@@ -1151,7 +1151,7 @@ body {
                                     data-bind="visible: !autoMappingInProgress(),
                                                click: requestTaxonMapping">Fuzzy matches</button>
                           <!-- /ko -->
-                          <!-- ko if: proposedMapping(otu) && !($.isArray(proposedMapping(otu))) -->
+                          <!-- ko if: proposedMapping(otu) && (proposedMapping(otu).length === 1) -->
                            {{ # show mapped label }}
                             <div class="btn-group pull-right">
                                 <button class="btn btn-mini" data-bind="click: approveProposedOTULabel, css: viewModel.ticklers.OTU_MAPPING_HINTS">
@@ -1161,21 +1161,22 @@ body {
                                     <i class="icon-remove"></i>
                                 </button>
                             </div>
-                            <strong data-bind="text: proposedMapping(otu).name,
-                                               css: viewModel.ticklers.OTU_MAPPING_HINTS"
+                            <strong data-bind="text: proposedMapping(otu)[0].name,
+                                               css: viewModel.ticklers.OTU_MAPPING_HINTS,
+                                               attr: getAttrsForMappingOption(proposedMapping(otu)[0])"
                                     style="color: red"
                                 >PROPOSED LABEL</strong>
                           <!-- /ko -->
-                          <!-- ko if: proposedMapping(otu) && $.isArray(proposedMapping(otu)) -->
+                          <!-- ko if: proposedMapping(otu) && (proposedMapping(otu).length > 1) -->
                            {{ # show available choices for mapping this OTU }}
                             <div class="btn-group pull-right">
                                 <button class="btn btn-mini" data-bind="click: rejectProposedOTULabel, css: viewModel.ticklers.OTU_MAPPING_HINTS">
                                     <i class="icon-remove"></i>
                                 </button>
                             </div>
-                            <strong style="color: #999;"><em>Possible mappings <a href="#" onclick="showPossibleMappingsKey(); return false;">(key)</a></em></strong>
+                            <strong style="font-size: 85%; color: #999;"><em>Possible mappings <a href="#" onclick="showPossibleMappingsKey(); return false;">(key)</a></em></strong>
                             <ul class="mapping-options"
-                                data-bind="foreach: proposedMapping(otu), 
+                                data-bind="foreach: makeArray(proposedMapping(otu)), 
                                            css: viewModel.ticklers.OTU_MAPPING_HINTS">
                                 <li><a data-bind="text: $data.originalMatch.unique_name,
                                                   click: approveProposedOTUMappingOption,


### PR DESCRIPTION
This treats single mapping matches (including synonyms) like the multiple list items in "fuzzy matching" cases. Same appearance and colors, same explanations on rollover. Addresses (fixes?) #499.