### PR TITLE
Fixes for re-rooting bug in curation app.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -5038,7 +5038,7 @@ function showNodeOptionsMenu( tree, node, nodePageOffset, importantNodeIDs ) {
     if (nodeID == importantNodeIDs.treeRoot) {
         nodeInfoBox.append('<span class="node-type specifiedRoot">tree root</span>');
     } else {
-        if (viewOrEdit === 'EDIT') {
+        if ((viewOrEdit === 'EDIT') && !(node['^ot:isLeaf'])) {
             nodeMenu.append('<li><a href="#" onclick="hideNodeOptionsMenu(); setTreeRoot( \''+ tree['@id'] +'\', \''+ nodeID +'\' ); return false;">Mark as root of this tree</a></li>');
         }
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -3491,6 +3491,8 @@ function updateEdgesInTree( tree ) {
     sweepEdgePolarity( tree, rootNodeID, null, inGroupClade );
     clearFastLookup('EDGES_BY_SOURCE_ID');
     clearFastLookup('EDGES_BY_TARGET_ID');
+    // set (or remove) ot:isLeaf flags on all nodes
+    updateLeafNodeFlags(tree);
 }
 
 function sweepEdgePolarity( tree, startNodeID, upstreamNeighborID, inGroupClade, insideInGroupClade ) {
@@ -3593,6 +3595,37 @@ function reverseEdgeDirection( edge ) {
     var oldSource = edge['@source'];
     edge['@source'] = edge['@target'];
     edge['@target'] = oldSource;
+}
+function updateLeafNodeFlags(tree) {
+    // ASSUMES that this parent-node lookup is up to date
+    var sourceLookup = getFastLookup('EDGES_BY_SOURCE_ID');
+    $.each( tree.node, function( i, node ) {
+        var nodeID = node['@id'];
+        parentEdges = sourceLookup[ nodeID ];
+        if (parentEdges) {
+            // it's a parent, so not a leaf
+            if ('^ot:isLeaf' in node) {
+                delete node['^ot:isLeaf'];
+                //console.log(">> REMOVING isLeaf from node "+ nodeID);
+            }
+        } else {
+            // a leaf node is nobody's parent, (re)set its flag
+            if (!('^ot:isLeaf' in node) || node['^ot:isLeaf'] !== true) {
+                node['^ot:isLeaf'] = true;
+                //console.log(">> SETTING isLeaf for node "+ nodeID);
+            }
+        }
+    });
+    /* NOTE: Other related properties are for d3 (display) only, so no action
+     * required; see clearD3PropertiesFromTree()
+     *  .parent
+     *  .children
+     *  .rootDistsance
+     *  .ingroup
+     *  .depth
+     *  .length
+     *  .rootDist
+     */
 }
 function getTreeNodeLabel(tree, node, importantNodeIDs) {
     // Return the best available label for this node, and its type:


### PR DESCRIPTION
Discussed in issue #531. Two improvements in this area.

* Update `ot:isLeaf` properties of all nodes whenever we re-root a tree (important for validation)

* Block re-rooting directly on tips; curators should instead use the adjacent edge