### PR TITLE
Smarter list filters

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -131,7 +131,7 @@ function loadStudyList() {
             viewModel.filteredStudies = ko.computed(function() {
                 // filter raw tree list, returning a
                 // new paged observableArray
-                updateClearSearchWidget( '#study-list-filter' );
+                updateClearSearchWidget( '#study-list-filter', viewModel.listFilters.STUDIES.match );
 
                 var match = viewModel.listFilters.STUDIES.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );
@@ -334,7 +334,7 @@ function getFocalCladeLink(study) {
         return '<span style="color: #ccc;">'+ cladeName +'</span>';
     }
 
-    return '<a href="#" onclick="filterByClade(\''+ ottID +'\'); return false;"'+'>'+ cladeName +'</a'+'>';
+    return '<a href="#" onclick="filterByClade(\''+ cladeName +'\'); return false;"'+'>'+ cladeName +'</a'+'>';
 }
 function getPubLink(study) {
     var urlNotFound = false;

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -1,3 +1,34 @@
+/*    
+@licstart  The following is the entire license notice for the JavaScript code in this page. 
+
+    Copyright (c) 2013, Jim Allman
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+@licend  The above is the entire license notice for the JavaScript code in this page.
+*/
+
 /*
  * Client-side behavior for the Open Tree curation home page and personalized dashboard
  *
@@ -6,6 +37,14 @@
  * then use client-side code to filter and sort them.
  */
 
+/*
+ * Subscribe to history changes (adapted from History.js boilerplate) 
+ */
+
+var History = window.History; // Note: capital H refers to History.js!
+// History.js can be disabled for HTML4 browsers, but this should not be the case for opentree!
+
+
 // these variables should already be defined in the main HTML page
 var findAllStudies_url;
 var viewOrEdit;
@@ -13,9 +52,84 @@ var viewOrEdit;
 // working space for parsed JSON objects (incl. sub-objects)
 var viewModel;
 
+/* Use history plugin to track moves from tab to tab, single-tree popup, others? */
+
+var listFilterDefaults; // defined in main page, for a clean initial state
+
+if ( History && History.enabled ) {
+    
+    var handleChangingState = function() {
+        if (!viewModel) {
+            // try again soon (waiting for the study list to load)
+            setTimeout( handleChangingState, 50 );
+            return;
+        }
+        var State = History.getState(); // Note: We are using History.getState() instead of event.state
+        ///History.log(State.data, State.title, State.url);
+
+        // Extract our state vars from State.url (not from State.data) for equal
+        // treatment of initial URLs.
+        var activeFilter = viewModel.listFilters.STUDIES;
+        var filterDefaults = listFilterDefaults.STUDIES;
+        // assert any saved filter values
+        for (var prop in activeFilter) {
+            if (prop in State.data) {
+                activeFilter[prop]( State.data[prop] );
+            } else {
+                // (re)set to its default value
+                activeFilter[prop]( filterDefaults[prop] );
+            }
+        }
+
+        initialState = null;  // clear this to unlock history for other changes
+    };
+
+    // bind to statechange event
+    History.Adapter.bind(window, 'statechange', handleChangingState);
+}
+
+function updateListFiltersWithHistory() {
+    // capture changing list filters in browser history
+    // N.B. This is triggered when filter is updated programmatically
+    // TODO: Try not to capture all keystrokes, or trivial changes?
+    if (History && History.enabled) {
+        if (initialState) {
+            // wait until initial state has been applied!
+            return;
+        }
+        var oldState = History.getState().data;
+
+        // Determine which list filter is active (currently based on tab)
+        // N.B. There's currently just one filter per tab (Trees, Files, OTU Mapping).
+        var activeFilter = viewModel.listFilters.STUDIES;
+        var filterDefaults = listFilterDefaults.STUDIES;
+        var newState = { };
+        var newQSValues = { };
+        for (prop in activeFilter) {
+            newState[prop] = ko.unwrap(activeFilter[prop]);
+            // Hide default filter settings, for simpler URLs
+            if (newState[prop] !== filterDefaults[prop]) {
+                newQSValues[prop] = ko.unwrap(activeFilter[prop]);
+            }
+        }
+        //var newQueryString = '?'+ encodeURIComponent($.param(newQSValues));
+        var newQueryString = '?'+ $.param(newQSValues);
+        History.pushState( newState, (window.document.title), newQueryString );
+    }
+}
+
 $(document).ready(function() {
     bindHelpPanels();
     loadStudyList();
+    
+    // NOTE that our initial state is set in the main page template, so we 
+    // can build it from incoming URL in web2py. Try to recapture this state,
+    // ideally through manipulating history.
+    if (History && History.enabled) {
+        // "formalize" the current state with an object
+        initialState.nudge = new Date().getTime();
+        History.replaceState(initialState, window.document.title, window.location.href);
+    }
 });
 
 function loadStudyList() {
@@ -132,6 +246,7 @@ function loadStudyList() {
                 // filter raw tree list, returning a
                 // new paged observableArray
                 updateClearSearchWidget( '#study-list-filter', viewModel.listFilters.STUDIES.match );
+                updateListFiltersWithHistory();
 
                 var match = viewModel.listFilters.STUDIES.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -127,14 +127,23 @@ function makeArray( val ) {
     return arr;
 }
 
-function updateClearSearchWidget( searchFieldSelector ) {
-    // add/remove clear widget based on field's contents
+function updateClearSearchWidget( searchFieldSelector, observable ) {
+    // Add/remove clear widget based on field's contents (or its 
+    // underlying observable, if provided).
     var $search = $(searchFieldSelector);
     if ($search.length === 0) {
         console.warn("updateClearSearchWidget: field '"+ searchFieldSelector +"' not found!");
         return;
     }
-    if ($.trim($search.val()) === '') {
+    var testText;
+    if ($.isFunction(observable)) {
+        // this is more accurate when the filter value is set programmatically
+        testText = observable();
+    } else {
+        // this is good enough if value is always typed directly into the field
+        testText = $search.val();
+    }
+    if ($.trim(testText) === '') {
         // remove clear widget, if any
         $search.next('.clear-search').remove();
     } else {
@@ -149,7 +158,6 @@ function updateClearSearchWidget( searchFieldSelector ) {
             });
         }
     }
-
 }
 
 function getPageNumbers( pagedArray ) {

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -387,3 +387,12 @@ function getViewURLFromStudyID( studyID ) {
         .replace('{HOST}', window.location.host)
         .replace('{STUDY_ID}', studyID);
 }
+
+function slugify(str) {
+    // Convert any string into a simplified "slug" suitable for use in URL or query-string
+    return str.toLowerCase()
+              .replace(/[^a-z0-9 -]/g, '')  // remove invalid chars
+              .replace(/\s+/g, '-')         // collapse whitespace and replace by -
+              .replace(/-+/g, '-');         // collapse dashes
+}
+

--- a/curator/static/js/study-creation.js
+++ b/curator/static/js/study-creation.js
@@ -1,7 +1,38 @@
 /*
+@licstart  The following is the entire license notice for the JavaScript code in this page.
+
+    Copyright (c) 2013, Jim Allman
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+@licend  The above is the entire license notice for the JavaScript code in this page.
+*/
+
+/*
  * Client-side behavior for the Open Tree curation UI
  *
- * This uses the Open Tree API to fetch and store studies and trees remotely.
+ * This uses the Open Tree API to trigger the creation of a new study.
  */
 
 // these variables should already be defined in the main HTML page

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -806,7 +806,7 @@ function loadSelectedStudy() {
                 // new paged observableArray
                 var ticklers = [ viewModel.ticklers.TREES() ];
 
-                updateClearSearchWidget( '#tree-list-filter' );
+                updateClearSearchWidget( '#tree-list-filter', viewModel.listFilters.TREES.match );
 
                 var match = viewModel.listFilters.TREES.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -90,9 +90,16 @@ function captureTagTextOnBlur( $tagsSelect ) {
 
 /* Use history plugin to track moves from tab to tab, single-tree popup, others? */
 
+var listFilterDefaults; // defined in main page, for a clean initial state
+
 if ( History && History.enabled ) {
-    // bind to statechange event
-    History.Adapter.bind(window,'statechange',function(){ // Note: We are using statechange instead of popstate
+    
+    var handleChangingState = function() {
+        if (!viewModel) {
+            // try again soon (waiting for a study to load)
+            setTimeout( handleChangingState, 50 );
+            return;
+        }
         var State = History.getState(); // Note: We are using History.getState() instead of event.state
         ///History.log(State.data, State.title, State.url);
 
@@ -101,9 +108,38 @@ if ( History && History.enabled ) {
         // treatment of initial URLs.
         var currentTab = State.data.tab;
         var currentTree = State.data.tree;
+        var activeFilter = null;
+        var filterDefaults = null;
         
         if (currentTab) {
             goToTab( currentTab );
+            switch(slugify(currentTab)) {
+                case 'trees':
+                    activeFilter = viewModel.listFilters.TREES;
+                    filterDefaults = listFilterDefaults.TREES;
+                    break;
+
+                case 'files':
+                    activeFilter = viewModel.listFilters.FILES;
+                    filterDefaults = listFilterDefaults.FILES;
+                    break;
+
+                case 'otu-mapping':
+                    activeFilter = viewModel.listFilters.OTUS;
+                    filterDefaults = listFilterDefaults.OTUS;
+                    break;
+            }
+            if (activeFilter) {
+                // assert any saved filter values
+                for (var prop in activeFilter) {
+                    if (prop in State.data) {
+                        activeFilter[prop]( State.data[prop] );
+                    } else {
+                        // (re)set to its default value
+                        activeFilter[prop]( filterDefaults[prop] );
+                    }
+                }
+            }
         }
         if (currentTree) {
             var tree = getTreeByID(currentTree);
@@ -114,7 +150,6 @@ if ( History && History.enabled ) {
                 hideModalScreen();
                 showInfoMessage(errMsg);
             }
-            delete initialState;  // clear this to avoid repeat viewing
         } else {
             // hide any active tree viewer
             if (treeViewerIsInUse) {
@@ -124,7 +159,12 @@ if ( History && History.enabled ) {
 
         // TODO: update all login links to use the new URL?
         fixLoginLinks();
-    });
+        
+        initialState = null;  // clear this to unlock history for other changes
+    };
+
+    // bind to statechange event
+    History.Adapter.bind(window, 'statechange', handleChangingState);
 }
 
 function deparam( querystring ) {
@@ -142,7 +182,6 @@ function bindHistoryAwareWidgets() {
     // TODO: set first event handlers on tabs, tree popups, etc.
     var $tabBar = $('ul.nav-tabs:eq(0)');
     $tabBar.find('li > a').click(function() {
-        console.log('INITIAL CLICK on tab');
         var $tab = $(this);
         var tabName = $.trim( $tab.html().split('<')[0] );
         changeTab( {'tab': tabName } );
@@ -207,6 +246,58 @@ function hideTreeWithHistory() {
     }
 }
 
+function updateListFiltersWithHistory() {
+    // capture changing list filters in browser history
+    // N.B. This is triggered when filter is updated programmatically
+    // TODO: Try not to capture all keystrokes, or trivial changes?
+    if (History && History.enabled) {
+        if (initialState) {
+            // wait until initial state has been applied!
+            return;
+        }
+        var oldState = History.getState().data;
+
+        // Determine which list filter is active (currently based on tab)
+        // N.B. There's currently just one filter per tab (Trees, Files, OTU Mapping).
+        var activeFilter;
+        var filterDefaults;
+        switch(slugify(oldState.tab)) {
+            case 'trees':
+                activeFilter = viewModel.listFilters.TREES;
+                filterDefaults = listFilterDefaults.TREES;
+                break;
+            case 'files':
+                activeFilter = viewModel.listFilters.FILES;
+                filterDefaults = listFilterDefaults.FILES;
+                break;
+            case 'otu-mapping':
+                activeFilter = viewModel.listFilters.OTUS;
+                filterDefaults = listFilterDefaults.OTUS;
+                break;
+            default:
+                console.warn('updateListFiltersWithHistory(): No filters in this tab: '+ oldState.tab);
+                return;
+        }
+        var newState = {
+            tab: oldState.tab
+        };
+        // use slugified tab name for the query-string (filter values are preserved)
+        var newQSValues = {
+            tab: slugify(oldState.tab)
+        };
+        for (prop in activeFilter) {
+            newState[prop] = ko.unwrap(activeFilter[prop]);
+            // Hide default filter settings, for simpler URLs
+            if (newState[prop] !== filterDefaults[prop]) {
+                newQSValues[prop] = ko.unwrap(activeFilter[prop]);
+            }
+        }
+        //var newQueryString = '?'+ encodeURIComponent($.param(newQSValues));
+        var newQueryString = '?'+ $.param(newQSValues);
+        History.pushState( newState, (window.document.title), newQueryString );
+    }
+}
+
 function fixLoginLinks() {
     // Update all login links to return directly to the current URL (NOTE that this 
     // doesn't seem to work for Logout)
@@ -242,7 +333,7 @@ $(document).ready(function() {
     } else {
         goToTab( initialState.tab );
     }
-    // N.B. We'll check this again once we've loaded the selected study, then clear it
+    // N.B. We'll apply this once we've loaded the selected study, then clear it
 
     loadSelectedStudy();
     
@@ -781,21 +872,21 @@ function loadSelectedStudy() {
                 // UI widgets bound to these variables will trigger the
                 // computed display lists below..
                 'TREES': {
-                    'match': ko.observable("")
+                    'match': ko.observable( listFilterDefaults.TREES.match )
                 },
                 'FILES': {
-                    'match': ko.observable("")
+                    'match': ko.observable( listFilterDefaults.FILES.match )
                 },
                 'OTUS': {
                     // TODO: add 'pagesize'?
-                    'match': ko.observable(""),
-                    'scope': ko.observable("In all trees"),
-                    'order': ko.observable("Unmapped OTUs first")
+                    'match': ko.observable( listFilterDefaults.OTUS.match ),
+                    'scope': ko.observable( listFilterDefaults.OTUS.scope ),
+                    'order': ko.observable( listFilterDefaults.OTUS.order )
                 },
                 'ANNOTATIONS': {
-                    'match': ko.observable(""),
-                    'scope': ko.observable("Anywhere in the study"),
-                    'submitter': ko.observable("Submitted by all")
+                    'match': ko.observable( listFilterDefaults.ANNOTATIONS.match ),
+                    'scope': ko.observable( listFilterDefaults.ANNOTATIONS.scope ),
+                    'submitter': ko.observable( listFilterDefaults.ANNOTATIONS.submitter )
                 }
             };
 
@@ -807,6 +898,7 @@ function loadSelectedStudy() {
                 var ticklers = [ viewModel.ticklers.TREES() ];
 
                 updateClearSearchWidget( '#tree-list-filter', viewModel.listFilters.TREES.match );
+                updateListFiltersWithHistory();
 
                 var match = viewModel.listFilters.TREES.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );
@@ -849,6 +941,7 @@ function loadSelectedStudy() {
                 var ticklers = [ viewModel.ticklers.SUPPORTING_FILES() ];
 
                 updateClearSearchWidget( '#file-list-filter' );
+                updateListFiltersWithHistory();
 
                 var match = viewModel.listFilters.FILES.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );
@@ -886,7 +979,9 @@ function loadSelectedStudy() {
                 // filter raw OTU list, then sort, returning a
                 // new (OR MODIFIED??) paged observableArray
                 var ticklers = [ viewModel.ticklers.OTU_MAPPING_HINTS() ];
+
                 updateClearSearchWidget( '#otu-list-filter' );
+                updateListFiltersWithHistory();
 
                 var match = viewModel.listFilters.OTUS.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );
@@ -1049,6 +1144,7 @@ function loadSelectedStudy() {
                 // filter raw OTU list, then sort, returning a
                 // new (OR MODIFIED??) paged observableArray
                 updateClearSearchWidget( '#annotation-list-filter' );
+                updateListFiltersWithHistory();
 
                 var match = viewModel.listFilters.ANNOTATIONS.match(),
                     matchPattern = new RegExp( $.trim(match), 'i' );
@@ -1184,19 +1280,6 @@ function loadSelectedStudy() {
 
             hideModalScreen();
             showInfoMessage('Study data loaded.');
-
-            if (initialState.tree) {
-                var tree = getTreeByID(initialState.tree);
-                if (tree) {
-                    showTreeViewer(tree);
-                } else {
-                    var errMsg = 'The requested tree (\''+ initialState.tree +'\') was not found. It has probably been deleted from this study.';
-                    hideModalScreen();
-                    showInfoMessage(errMsg);
-                }
-                delete initialState;  // clear this to avoid repeat viewing
-            }
-
         }
     });
 }
@@ -6694,14 +6777,6 @@ function getDataDepositMessage() {
     
     // default message simply repeats the dataDeposit URL
     return 'Data for this study is permanently archived here:<br/><a href="'+ url +'" target="_blank">'+ url +'</a>';
-}
-
-function slugify(str) {
-    // Convert any string into a simplified "slug" suitable for use in URL or query-string
-    return str.toLowerCase()
-              .replace(/[^a-z0-9 -]/g, '')  // remove invalid chars
-              .replace(/\s+/g, '-')         // collapse whitespace and replace by -
-              .replace(/-+/g, '-');         // collapse dashes
 }
 
 function showDownloadFormatDetails() {

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -27,14 +27,32 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
 
 {{extend 'layout.html'}}
 
+<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script type='text/javascript'>
     var viewOrEdit = '{{= viewOrEdit }}';
     var findAllStudies_url = "{{=findAllStudies_url}}";
-
     var phylesystem_config_url = '{{=phylesystem_config_url}}';
-</script>
 
-<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
+    // If inbound URL specifies tab, tree, or filter settings, record them here
+    var initialState = {{= XML( dict(request.vars) ) }};
+    // set any required defaults (for clean/simple history behavior)
+    var listFilterDefaults = {
+        // track these defaults so we can reset them in history
+        'STUDIES': {
+            // TODO: add 'pagesize'?
+            'match': "",
+            'workflow': "Any workflow state",
+            'order': "Newest publication first"
+        }
+    };
+    var filterDefaults = listFilterDefaults.STUDIES;
+    // apply any missing filter defaults
+    for (var prop in filterDefaults) {
+        if (!(prop in initialState)) {
+            initialState[prop] = filterDefaults[prop];
+        }
+    }
+</script>
 <script src="{{=URL('static','js/curation-dashboard.js')}}"></script>
 
 <div class="row">

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -104,6 +104,7 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                    data-bind="value: viewModel.listFilters.STUDIES.match, valueUpdate: ['afterkeydown', 'input']">
         </form>
         <ul class="nav" style="padding-left: 1em;">
+            <!--
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                   <span data-bind="text: viewModel.listFilters.STUDIES.workflow">WORKFLOW</span>
@@ -115,6 +116,7 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                     </li>
                 </ul>
             </li>
+            -->
             <!--<li class="divider-vertical"></li>-->
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1733,6 +1733,7 @@ body {
 
 </div><!-- /.row -->
 
+<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script type='text/javascript'>
     var studyID = '{{= studyID }}';
     var latestSynthesisSHA = '{{= latestSynthesisSHA }}';
@@ -1749,15 +1750,52 @@ body {
     var API_update_file_PUT_url = '{{=API_update_file_PUT_url}}';
     var API_remove_file_DELETE_url = '{{=API_remove_file_DELETE_url}}';
 
-    // if inbound URL specifies a particular tab or tree, record it here
-    var initialState = {
-     {{ if request.vars.get('tree',None): }}
-      tab: 'Trees',
-      tree: '{{= request.vars['tree'] }}'
-     {{ else: }}
-      tab: '{{= request.vars.get('tab','Metadata') }}',
-     {{ pass }}
+    // If inbound URL specifies tab, tree, or filter settings, record them here
+    var initialState = {{= XML( dict(request.vars) ) }};
+    // set any required defaults (for clean/simple history behavior)
+    if (!('tab' in initialState)) {
+        initialState.tab = 'Metadata';
+    }
+    var listFilterDefaults = {
+        // track these defaults so we can reset them in history
+        'TREES': {
+            'match': ""
+        },
+        'FILES': {
+            'match': ""
+        },
+        'OTUS': {
+            // TODO: add 'pagesize'?
+            'match': "",
+            'scope': "In all trees",
+            'order': "Unmapped OTUs first"
+        },
+        'ANNOTATIONS': {
+            'match': "",
+            'scope': "Anywhere in the study",
+            'submitter': "Submitted by all"
+        }
     };
+    var filterDefaults = null;
+    switch(slugify(initialState.tab)) {
+        case 'trees':
+            filterDefaults = listFilterDefaults.TREES;
+            break;
+        case 'files':
+            filterDefaults = listFilterDefaults.FILES;
+            break;
+        case 'otu-mapping':
+            filterDefaults = listFilterDefaults.OTUS;
+            break;
+    }
+    if (filterDefaults) {
+        // apply any missing filter defaults
+        for (var prop in filterDefaults) {
+            if (!(prop in initialState)) {
+                initialState[prop] = filterDefaults[prop];
+            }
+        }
+    }
 
     var treemachine_domain = "{{=treemachine_domain}}";
     var taxomachine_domain = "{{=taxomachine_domain}}";
@@ -1777,7 +1815,6 @@ body {
     var getDraftTreeSubtreeForNodes_url = "{{=getDraftTreeSubtreeForNodes_url}}";
     var singlePropertySearchForStudies_url = "{{=singlePropertySearchForStudies_url}}";
 </script>
-<script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script src="{{=URL('static','js/study-editor.js')}}"></script>
 
 <!-- hidden template for DOI lookups -->


### PR DESCRIPTION
This addresses #487 and #518, while providing smarter list-filter behavior throughout the curation app:

- The **focal-clade filter** (in study list) works properly and shows the clade name instead of a cryptic ottid.

- The **filter-clearing** (x) widget updates properly.

- All list filters are **history-aware** and update the URL, so browser Back and Forward buttons reflect filter changes. (This tries to be smart, so URLs stay simple with default filters.) 

- Incidentally fixes the intermittent "tree not found" error before showing the tree(!), when incoming URL has a tree id.

All behavior is working now on **devtree**.