### PR TITLE
Add links to each tree in Bibliographic References

### DIFF
--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -77,10 +77,23 @@ def fetch_current_synthesis_source_data():
             else:
                 study_id = '_'.join(source_parts[0:2])
             if len(source_parts) == 4:
+                tree_id = source_parts[2]
                 commit_SHA_in_synthesis = source_parts[3]
             else:
-                commit_SHA_in_synthesis = None
-            contributing_study_info[ study_id ] = commit_SHA_in_synthesis
+                tree_id = source_parts[1]
+                if len(source_parts) == 3:
+                    commit_SHA_in_synthesis = source_parts[2]
+                else:
+                    commit_SHA_in_synthesis = None
+
+            if study_id in contributing_study_info.keys():
+                contributing_study_info[ study_id ]['tree_ids'].append( tree_id )
+            else:
+                contributing_study_info[ study_id ] = {
+                    'tree_ids': [ tree_id, ],
+                    'commit_SHA_in_synthesis': commit_SHA_in_synthesis
+                }
+
 
         # fetch the oti metadata (esp. DOI and full reference text) for each
         fetch_url = method_dict['findAllStudies_url']
@@ -89,7 +102,8 @@ def fetch_current_synthesis_source_data():
             fetch_url = "http:%s" % fetch_url
 
         # as usual, this needs to be a POST (pass empty fetch_args)
-        study_metadata_response = fetch(fetch_url, data={"verbose": True})
+        study_metadata_response = fetch(fetch_url, data={"verbose": True}) 
+        # TODO: add more friendly label to tree metadata? if so, add "includeTreeMetadata":True above
         study_metadata = simplejson.loads( study_metadata_response )
 
         # filter just the metadata for studies contributing to synthesis
@@ -103,8 +117,11 @@ def fetch_current_synthesis_source_data():
             else:
                 prefixed_study_id = study['ot:studyId']
             if prefixed_study_id in contributing_study_info.keys():
-                # add commit SHA to support retrieval of *exact* Nexson from synthesis
-                study['commit_SHA_in_synthesis'] = contributing_study_info[ prefixed_study_id ];
+                contrib_info = contributing_study_info[ prefixed_study_id ]
+                # and commit SHA to support retrieval of *exact* Nexson from synthesis
+                study['commit_SHA_in_synthesis'] = contrib_info['commit_SHA_in_synthesis']
+                # add contributing tree ID(s) so we can directly link to (or download) them
+                study['tree_ids'] = contrib_info['tree_ids']
                 contributing_studies.append( study )
 
         # TODO: sort these alphabetically(?) and render in the page

--- a/webapp/views/about/references.html
+++ b/webapp/views/about/references.html
@@ -33,6 +33,15 @@ div.contributing-studies div.links a {
     margin-bottom: 0.25em;
     margin-left: 1em;
 }
+div.contributing-studies div.links .tree-links {
+    display: none;
+    margin-bottom: 0.25em;
+    margin-left: 2em;
+}
+div.contributing-studies div.links .tree-links a {
+    display: block;
+    margin-left: 0;
+}
 //-->
 </style>
 
@@ -72,7 +81,15 @@ div.contributing-studies div.links a {
               </div>
               <div class="span4 links">
                   <a target="_blank" href="{{= URL(a='curator', c='study', f='view', args=[ study.get('ot:studyId') ]) }}"
-                    >Open in curator application</a>
+                    >Open study in curator application</a>
+                  <a href="#" onclick="toggleTreeLinks(this); return false;"
+                      ><span>Show links to included trees</span> ({{= len(study['tree_ids']) }})</a>
+                  <div class="tree-links">
+                     {{ for tree_id in study['tree_ids']: }}
+                     <a target="_blank" href="{{= URL(a='curator', c='study', f='view', args=[ study.get('ot:studyId') ], vars={'tab':'trees', 'tree': 'tree%s' % tree_id }) }}"
+                        title="Click to see this tree in the curation app">tree{{= tree_id }}</a>
+                     {{ pass }}
+                  </div>
                   <a target="_blank" 
                     href="{{= URL(a='default', c='default', f='argus', args=['ottol@{}/{}'.format( study.get('ot:focalClade'), study.get('ot:focalCladeOTTTaxonName') ) ] ) }}"
                     >Browse focal clade in synthetic tree</a>
@@ -143,5 +160,17 @@ div.contributing-studies div.links a {
         $.each(sortedRefs, function(pos, ref) {
             $refContainer.append(ref);
         });
+    }
+    function toggleTreeLinks( clicked ) {
+        var $clicked = $(clicked);
+        var $prompt = $(clicked).find('span');
+        var $treeLinks = $clicked.next('.tree-links');
+        if ($treeLinks.is(':visible')) {
+            $treeLinks.hide();
+            $prompt.text("Show links to included trees");
+        } else {
+            $treeLinks.show();
+            $prompt.text("Hide links to included trees");
+        }
     }
 </script>


### PR DESCRIPTION
This adds a set of links for each contributing study, showing the raw nexson treeID for each, e.g. 'tree1281'. Clicking the link shows the current tree (NOT necessarily the SHA in synthesis) in the curation app.
Addresses #510.

Before we merge this, [see the above discussion for screenshots and **possible improvements**](https://github.com/OpenTreeOfLife/opentree/issues/510#issuecomment-71589896).