### PR TITLE
Explicit routing for /cached/* URLs

### DIFF
--- a/deploy/setup/apache-config-shared
+++ b/deploy/setup/apache-config-shared
@@ -88,6 +88,12 @@
     RewriteRule ^/v2/study/(.*) /phylesystem/v1/study/$1 [PT]
 
     # ------------------------------------------------------------
+    # Explicit routing for /cached/* URLs (in phylesystem-api)
+
+    RewriteEngine on
+    RewriteRule ^/cached/(.*) /phylesystem/default/cached/$1 [PT]
+
+    # ------------------------------------------------------------
     # v1 API retained for transition period (ending Nov 2014 ?)
 
     <Location /treemachine/v1>


### PR DESCRIPTION
This will fix the routing of clean & simple URLs for cached API calls,
even when phylesystem-api is not the default app in web2py. This fixes
a bug that was revealed by the different configuration of the [devapi](https://github.com/OpenTreeOfLife/deployed-systems/blob/5a4aa88944b88a92ebb15bd8e27f5cda406c498e/development/devapi.config#L41) vs.
[api (production)](https://github.com/OpenTreeOfLife/deployed-systems/blob/master/production/api.config#L45) system. Addresses #591.