### PR TITLE
Improved tree properties

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2152,10 +2152,29 @@ body {
          <form class="form-inline" style="overflow: hidden; margin-bottom: 0px;">
           {{ if viewOrEdit == 'EDIT': }}
             <!-- editable tree properties here -->
+
+                <label>Description: </label>
+                <input type="text" data-bind="value: $data['^ot:treeDescription']"
+                    class="input-xxlarge" style="margin-bottom: 2px;"
+                    placeholder="Add a brief note about this tree">
+              <br/>
+                <label>Tree type: </label>
+                <select data-bind="options: treeTypes,
+                    optionsValue: function(item) { 
+                        return item.value;
+                    },
+                    optionsText: function(item) { 
+                        return item.label || item.value;
+                    },
+                    value: $data['^ot:treeType'],
+                    event: { keyup: nudge.TREES, change: nudge.TREES },
+                    css: viewModel.ticklers.TREES
+                    ">TYPE</select>
+
               <div style="padding: 0 4px;">
                 <label>Inference method(s): </label>
                 <!-- Offer preset inference methods, found in http://en.wikipedia.org/wiki/Bayesian_inference_in_phylogeny --> 
-              <div style="position: relative; top: -6px;" 
+              <div style="position: relative; top: -5px;" 
                   data-bind="foreach: {data: inferenceMethods, as: 'method'}">
                 <label class="checkbox inference-method-checkbox" style="padding-left: 20px;" 
                        data-bind="attr: {'for': 'inference-method-'+ $index()}">
@@ -2301,9 +2320,16 @@ body {
 
           {{ else: }}
             <!-- read-only tree properties here -->
-              <div class="pull-left" style="width: 48%;">
+              <div class="pull-left">
+                <label>Description: </label>
+                <strong  data-bind="text: $data['^ot:treeDescription'] || 'None'">TYPE</strong>
+              </div>
+              <div class="pull-left" style="clear: left; width: 48%;">
+                <label>Tree type: </label>
+                <strong data-bind="text: $data['^ot:treeType'] || 'Unspecified'">TYPE</strong>
+              <br/>
                 <label>Inference method(s): </label>
-                <strong data-bind="text: $data['^ot:inferenceMethods'].join(', ') || 'Unspecified'">TYPE</strong>
+                <strong  data-bind="text: $data['^ot:inferenceMethods'].join(', ') || 'Unspecified'">TYPE</strong>
               <br/>
                 <label for="testtest">Root node: </label>
                <!-- TODO: tag(s) for this tree? -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -598,7 +598,7 @@ body {
                       {{ else: }}
                         <th>Tree name (click to view)</th>
                       {{ pass }}
-                        <th>Inference method</th>
+                        <th>Inference method(s)</th>
                         <th>Ingroup clade</th>
                         <th>Tree root</th>
                         <th>OTUs mapped</th>
@@ -633,7 +633,7 @@ body {
                                 Review ambiguous labels
                             </a> 
                         </td>
-                        <td data-bind="text: tree['^ot:curatedType'] || 'Unspecified',
+                        <td data-bind="text: tree['^ot:inferenceMethods'].join(',') || 'Unspecified',
                                 css: viewModel.ticklers.TREES">&nbsp;</td>
                         <td data-bind="text: getInGroupCladeDescriptionForTree(tree),
                                 css: viewModel.ticklers.TREES">&nbsp;</td>
@@ -2153,29 +2153,22 @@ body {
           {{ if viewOrEdit == 'EDIT': }}
             <!-- editable tree properties here -->
               <div style="padding: 0 4px;">
-                <label>Inference method: </label>
+                <label>Inference method(s): </label>
                 <!-- Offer preset inference methods, found in http://en.wikipedia.org/wiki/Bayesian_inference_in_phylogeny --> 
-                <select id="inference-method-select"
-                        onchange="(this); return false;"
-                        data-bind="options: [
-                                       'Bayesian inference ',
-                                       'Maximum likelihood ',
-                                       'Maximum parsimony ',
-                                       'Neighbor-joining ',
-                                       'UPGMA ',
-                                       'Least squares ',
-                                       'Three-taxon analysis',
-                                       'Other (specify)'
-                                   ], 
-                                   optionsCaption: 'Choose a method...',
-                                   event: { change: updateInferenceMethodWidgets }, 
-                                   css: viewModel.ticklers.TREES">
-                </select>
-                <input type="text" id="inference-method-other" 
-                       placeholder="Other (specify)"
-                       data-bind="event: { change: updateInferenceMethodWidgets }, 
-                                  css: viewModel.ticklers.TREES"></input>
-              <br/>
+              <div style="position: relative; top: -6px;" 
+                  data-bind="foreach: {data: inferenceMethods, as: 'method'}">
+                <label class="checkbox inference-method-checkbox" style="padding-left: 20px;" 
+                       data-bind="attr: {'for': 'inference-method-'+ $index()}">
+                    <input type="checkbox"
+                           data-bind="attr: {
+                                        'id': 'inference-method-'+ $index(),
+                                        'value': method['value'] 
+                                      },
+                                      checked: $parent['^ot:inferenceMethods']" /> 
+                    <span data-bind="text: method['label'] || method['value']">&nbsp;</span>
+                </label>
+              </div>
+              
                 <label for="testtest">Root node: </label>
                 <strong data-bind="text: getRootNodeDescriptionForTree($data), 
                                    css: viewModel.ticklers.TREES"></strong>
@@ -2309,8 +2302,8 @@ body {
           {{ else: }}
             <!-- read-only tree properties here -->
               <div class="pull-left" style="width: 48%;">
-                <label>Inference method: </label>
-                <strong data-bind="text: $data['^ot:curatedType'] || 'Unspecified'">TYPE</strong>
+                <label>Inference method(s): </label>
+                <strong data-bind="text: $data['^ot:inferenceMethods'].join(', ') || 'Unspecified'">TYPE</strong>
               <br/>
                 <label for="testtest">Root node: </label>
                <!-- TODO: tag(s) for this tree? -->


### PR DESCRIPTION
These changes reflect our latest thinking in tree properties, as discussed in #552 and #555. Available now for review on **devtree**.

This also does a one-time capture of the deprecated `ot:curatedType` field before discarding it, as described in https://github.com/OpenTreeOfLife/opentree/issues/555#issuecomment-74102857. (This will have no effect if this migration has already been done on the server, which is probably the wiser path.)