### PR TITLE
Mimic History API closely for old/dumb browsers.

### DIFF
--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -615,8 +615,8 @@ function createArgus(spec) {
             var stateObj = $.extend(true, {'nodeName': ''}, o); // deep copy of o, with default values if none supplied
             History.pushState(stateObj, historyStateToWindowTitle(stateObj), historyStateToURL(stateObj));
         } else {
-            // proceed directly to display (ignore browser history)
-            this.displayNode(o);
+            // proceed directly to display (emulate browser history State object)
+            updateTreeView({'data': o});
         }
     };
 


### PR DESCRIPTION
This gives more consistent behavior for browsers with history disabled
(sites blocked from saving data), esp. for tree-view URLs with ott ids.
Fixes #608.