### PR TITLE
Fix broken display of single OTU mapping result.

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1234,11 +1234,12 @@ body {
                                     <i class="icon-remove"></i>
                                 </button>
                             </div>
-                            <strong data-bind="text: proposedMapping(otu)[0].name,
+                            <a data-bind="text: proposedMapping(otu)[0].name,
                                                css: viewModel.ticklers.OTU_MAPPING_HINTS,
                                                attr: getAttrsForMappingOption(proposedMapping(otu)[0])"
-                                    style="color: red"
-                                >PROPOSED LABEL</strong>
+                                    href="#"
+                                    onclick="return false;"
+                                >PROPOSED LABEL</a>
                           <!-- /ko -->
                           <!-- ko if: proposedMapping(otu) && (proposedMapping(otu).length > 1) -->
                            {{ # show available choices for mapping this OTU }}


### PR DESCRIPTION
N.B. I'm replaying this commit (f7a762a5c6096faaa99da1fb849403bf6ba419ae)
onto master, to make a proper pull request.

Use the more standard `A` (vs. `STRONG`) element for a single OTU
mapping result. This gives us the correct color from Bootstrap's CSS,
which expects any matching element to have an `href` attribute.
Fixes #619.