### PR TITLE
Install java 8 if available

### DIFF
--- a/deploy/add-unstable.sh
+++ b/deploy/add-unstable.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Enable retrieval of java 8 from Debian unstable.
+# Copy this script manually to EC2 admin home, and run as admin user.
+# Do this *after* upgrading from wheezy to jessie.
+
+# See http://jaqque.sbih.org/kplug/apt-pinning.html
+# If no /etc/apt/preferences, create one
+if [ ! -e /etc/apt/preferences ]; then
+    cat >/tmp/apt-preferences <<EOF
+Package: *
+Pin: release n=jessie
+Pin-Priority: 700
+EOF
+    sudo cp /tmp/apt-preferences /etc/apt/preferences
+fi
+
+# If unstable not yet allowed, at it as a source
+if ! egrep -q unstable /etc/apt/preferences; then
+    cp /etc/apt/preferences /tmp/apt-preferences
+    cat >>/tmp/apt-preferences <<EOF
+Package: *
+Pin: release a=unstable
+Pin-Priority: 10
+EOF
+    sudo cp /tmp/apt-preferences /etc/apt/preferences
+else
+    echo "- unstable is already in /etc/apt/preferences"
+fi
+
+echo "*** /etc/apt/preferences ***"
+cat /etc/apt/preferences
+echo
+
+# Add unstable to sources.list
+
+if ! egrep unstable /etc/apt/sources.list; then
+    cp /etc/apt/sources.list /tmp/apt-sources-list
+    cat >>/tmp/apt-sources-list <<EOF
+#Unstable
+deb http://cloudfront.debian.net/debian unstable main
+deb-src http://cloudfront.debian.net/debian unstable main
+EOF
+    sudo cp -p /etc/apt/sources.list /etc/apt/sources.list~
+    sudo cp /tmp/apt-sources-list /etc/apt/sources.list
+else
+    echo "- unstable is already in /etc/apt/sources.list"
+fi
+
+echo "*** /etc/apt/sources.list ***"
+cat /etc/apt/sources.list
+echo
+
+# Update packages list
+sudo apt-get update
+

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -163,7 +163,7 @@ fi
 
 if [ `which javac`x != x ] && javac -version 2>&1 | egrep -q 1.8; then
     echo "Java 8 OK"
-elif apt-cache policy openjdk-8-jdk | egrep -q "Installed: (none)"; then
+elif apt-cache policy openjdk-8-jdk | grep -q "Installed.*none"; then
     apt_get_install openjdk-8-jre-headless
     apt_get_install openjdk-8-jdk
     sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -156,8 +156,24 @@ if [ `which virtualenv`x = x ]; then
 fi
 
 # ---------- JAVA ----------
-if [ `which javac`x = x ]; then
-    apt_get_install openjdk-7-jre 
+# N.b. Java 8 isn't available for woody, and is available for jessie
+# only with the addition of unstable to /etc/apt/sources.list and a
+# corresponding prioritization in /etc/apt/preferences (to prevent
+# unstable from taking over the whole system).
+
+if [ `which javac`x != x ] && javac -version 2>&1 | egrep -q 1.8; then
+    echo "Java 8 OK"
+elif apt-cache policy openjdk-8-jdk | egrep -q "Installed: (none)"; then
+    apt_get_install openjdk-8-jre-headless
+    apt_get_install openjdk-8-jdk
+    sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+elif [ `which javac`x != x ] && javac -version 2>&1 | egrep -q 1.7; then
+    echo "Java 7 OK"
+elif [ `which javac`x != x ]; then
+    echo "** Possible wrong version of java"
+else
+    apt_get_install openjdk-7-jre-headless
     apt_get_install openjdk-7-jdk
 fi
 


### PR DESCRIPTION
Tested with java 8 on ot17 / jessie, and with java 7 on ot10 / woody (where it leaves java 7 alone because there is no woody java 8).