### PR TITLE
Prepare for upgrade to apache 2.4

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -162,7 +162,8 @@ should redirect all traffic to the editable
 github-pages sites. (Be sure to edit the text of this page to reflect the current situation and
 expected downtime.)
 
-This should be done with a **302 Temporary** redirect. Currently, the easiest way to do this is by [un-commenting this line](https://github.com/OpenTreeOfLife/opentree/blob/d35768d9a2233908a1982846870cf57326450525/deploy/setup/apache-config-shared#L15-L16) in our shared apache configuration file. This should be on the server as `/etc/apache2/opentree-shared.conf`.
+This should be done with a **302 Temporary** redirect. Currently, the easiest way to do this is by [un-commenting this 
+line](https://github.com/OpenTreeOfLife/opentree/blob/e62b653b82870d1860c832a2bb1c9bb65ebf23b6/deploy/setup/opentree-shared.conf#L15-L16) in our shared apache configuration file. This should be on the server as `/etc/apache2/opentree.conf`.
 
 To avoid lost work in the [study curation app](http://tree.opentreeoflife.org/curator), 
 we should also disable the creation and editing of studies in the hours before any 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -162,7 +162,7 @@ should redirect all traffic to the editable
 github-pages sites. (Be sure to edit the text of this page to reflect the current situation and
 expected downtime.)
 
-This should be done with a **302 Temporary** redirect. Currently, the easiest way to do this is by [un-commenting this line](https://github.com/OpenTreeOfLife/opentree/blob/d35768d9a2233908a1982846870cf57326450525/deploy/setup/apache-config-shared#L15-L16) in our shared apache configuration file. This should be on the server as `/etc/apache2/opentree-config-shared`.
+This should be done with a **302 Temporary** redirect. Currently, the easiest way to do this is by [un-commenting this line](https://github.com/OpenTreeOfLife/opentree/blob/d35768d9a2233908a1982846870cf57326450525/deploy/setup/apache-config-shared#L15-L16) in our shared apache configuration file. This should be on the server as `/etc/apache2/opentree-shared.conf`.
 
 To avoid lost work in the [study curation app](http://tree.opentreeoflife.org/curator), 
 we should also disable the creation and editing of studies in the hours before any 

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -197,22 +197,43 @@ fi
 # the default 'vhost'.  The opentree config file gets put into
 # place later on in the setup sequence.
 
-if [ -r /etc/apache2/sites-enabled/000-default ]; then
-    sudo rm -f /etc/apache2/sites-enabled/000-default
-fi
-if [ ! -r /etc/apache2/sites-enabled/000-opentree ]; then
-    (cd /etc/apache2/sites-enabled; \
-     sudo ln -sf ../sites-available/opentree ./000-opentree)
-fi
-
-# Enable the HTTPS site only if our SSL certs are found; else disable it
-if [ -r /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem ]; then
-    if [ ! -r /etc/apache2/sites-enabled/001-opentree-ssl ]; then
+if apt-cache policy apache2 | egrep -q "Installed: 2.2"; then
+    # Keep old script transiently; flush this after full transition to 2.4+
+    if [ -r /etc/apache2/sites-enabled/000-default ]; then
+        sudo rm -f /etc/apache2/sites-enabled/000-default
+    fi
+    if [ ! -r /etc/apache2/sites-enabled/000-opentree ]; then
         (cd /etc/apache2/sites-enabled; \
-         sudo ln -sf ../sites-available/opentree-ssl ./001-opentree-ssl)
+         sudo ln -sf ../sites-available/opentree ./000-opentree)
+    fi
+
+    # Enable the HTTPS site only if our SSL certs are found; else disable it
+    if [ -r /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem ]; then
+        if [ ! -r /etc/apache2/sites-enabled/001-opentree-ssl ]; then
+            (cd /etc/apache2/sites-enabled; \
+             sudo ln -sf ../sites-available/opentree-ssl ./001-opentree-ssl)
+        fi
+    else
+         sudo rm -f /etc/apache2/sites-enabled/001-opentree-ssl
     fi
 else
-     sudo rm -f /etc/apache2/sites-enabled/001-opentree-ssl
+    sudo rm -f /etc/apache2/sites-enabled/000-default*
+    sudo rm -f /etc/apache2/sites-enabled/000-opentree
+    sudo rm -f /etc/apache2/sites-enabled/001-opentree-ssl
+    if [ ! -e /etc/apache2/sites-enabled/000-opentree.conf ]; then
+        (cd /etc/apache2/sites-enabled; \
+         sudo ln -sf ../sites-available/opentree.conf ./000-opentree.conf)
+    fi
+
+    # Enable the HTTPS site only if our SSL certs are found; else disable it
+    if [ -r /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem ]; then
+        if [ ! -r /etc/apache2/sites-enabled/001-opentree-ssl.conf ]; then
+            (cd /etc/apache2/sites-enabled; \
+             sudo ln -sf ../sites-available/opentree-ssl.conf ./001-opentree-ssl.conf)
+        fi
+    else
+         sudo rm -f /etc/apache2/sites-enabled/001-opentree-ssl.conf
+    fi
 fi
 
 # ---------- UNPRIVILEGED USER ----------

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -231,7 +231,7 @@ function push_neo4j {
 function restart_apache {
     if [ $DRYRUN = "yes" ]; then echo "[restarting apache]"; return; fi
     scp -p -i "${OPENTREE_IDENTITY}" restart-apache.sh "$ADMIN@$OPENTREE_HOST":
-    ${SSH} "$ADMIN@$OPENTREE_HOST" bash restart-apache.sh "$OT_USER"
+    ${SSH} "$ADMIN@$OPENTREE_HOST" bash restart-apache.sh "$OT_USER" "$OPENTREE_HOST"
 }
 
 function push_opentree {

--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -3,6 +3,10 @@
 OPENTREE_USER=$1
 OPENTREE_HOME=$(bash <<< "echo ~$OPENTREE_USER")
 
+if apt-cache policy apache2 | egrep -q "Installed: 2.2"; then
+
+# Obscolescent code, apache 2.2
+
 if [ ! -r /etc/apache2/sites-available/opentree ] || \
    ! cmp "$OPENTREE_HOME/setup/apache-config-vhost" /etc/apache2/sites-available/opentree; then
     echo "Installing opentree vhost config"
@@ -23,6 +27,34 @@ if [ ! -r /etc/apache2/opentree-config-shared ] || \
     sudo cp -p $TMP /etc/apache2/opentree-config-shared || "Sudo failed"
 fi
 rm $TMP
+
+# -------------------------------------------------------
+
+else
+
+# Modern code, apache 2.4+
+
+if [ ! -r /etc/apache2/sites-available/opentree.conf ] || \
+   ! cmp "$OPENTREE_HOME/setup/opentree.conf" /etc/apache2/sites-available/opentree; then
+    echo "Installing opentree vhost config"
+    sudo cp -p "$OPENTREE_HOME/setup/opentree.conf" /etc/apache2/sites-available/ || "Sudo failed"
+fi
+
+if [ ! -r /etc/apache2/sites-available/opentree-ssl ] || \
+   ! cmp "$OPENTREE_HOME/setup/opentree-ssl.conf" /etc/apache2/sites-available/opentree-ssl.conf; then
+    echo "Installing opentree ssl vhost config"
+    sudo cp -p "$OPENTREE_HOME/setup/opentree-ssl.conf" /etc/apache2/sites-available/ || "Sudo failed"
+fi
+
+TMP=/tmp/$$.tmp
+sed -e s+/home/opentree+$OPENTREE_HOME+ <"$OPENTREE_HOME/setup/opentree-shared.conf" >$TMP
+if [ ! -r /etc/apache2/opentree-shared.conf ] || \
+   ! cmp $TMP /etc/apache2/opentree-shared.conf; then
+    echo "Installing opentree vhosts shared config"
+    sudo cp -p $TMP /etc/apache2/opentree-shared.conf || "Sudo failed"
+fi
+rm $TMP
+fi
 
 echo "Restarting apache httpd..."
 sudo apache2ctl graceful || "Sudo failed"

--- a/deploy/sample.config
+++ b/deploy/sample.config
@@ -14,10 +14,10 @@ OPENTREE_TAG=ot3
 
 # -----
 # OPENTREE_HOST is the host that you're going to initialize or update.
-# This is used as a target for ssh during deployment. Our common pattern is to
-# use domain names starting with the tag value above, e.g., ot3.opentreeoflife.org
+# This is used as a target for ssh during deployment. It is also used
+# as the ServerName in the apache HTTPS vhost configuration.
 
-OPENTREE_HOST=${OPENTREE_TAG}.opentreeoflife.org
+OPENTREE_HOST=ctenophora.opentreeoflife.org
 
 #-----
 # OPENTREE_COMPONENTS is a list of components that are to be intalled

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -1,0 +1,123 @@
+# This file derives from the file /etc/apache2/sites-available/default
+# in apache2 as installed in ubuntu 12.04.
+#
+# Now that we're supporting both HTTP and HTTPS, this file contains all the
+# shared configuration for VirtualHosts in 'opentree.conf' and 'opentree-ssl.conf'. See
+# http://serverfault.com/questions/83669/apache2-with-ssl-do-i-have-to-copy-virtualhost-blocks
+#
+# This file should be periodically reviewed as apache versions advance and
+# 'best practice' for virtual host configurations changes.
+
+    ServerAdmin webmaster@localhost
+
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # TEMPORARY REDIRECT to maintenance page
+    #RedirectMatch 302 ^(.*)$ http://opentreeoflife.github.io/maintenance.html
+
+    # See http://stackoverflow.com/questions/13216837/install-web2py-in-virtual-hosting
+    # NOTE that we can only specify WSGIDaemonProcess once, so this has been
+    # retained in the main HTTP configuration 'opentree.conf'!
+    #WSGIDaemonProcess web2py user=opentree group=opentree display-name=%{GROUP}
+    WSGIProcessGroup web2py
+    WSGIScriptAlias / /home/opentree/web2py/wsgihandler.py
+
+    # We don't want the scriptalias to override mappings for
+    #  treemachine and taxomachine... seems not to.
+
+    <Directory /home/opentree/web2py>
+      AllowOverride None
+      Require all denied
+      <Files wsgihandler.py>
+        Require all granted
+      </Files>
+    </Directory>
+
+    AliasMatch ^/([^/]+)/static/(.*)            /home/opentree/web2py/applications/$1/static/$2
+    <Directory /home/opentree/web2py/applications/*/static/>
+      Require all granted
+    </Directory>
+
+    # See https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs
+
+    # 7474 = treemachine neo4j
+
+    <Location /v2/tree_of_life>
+      Require all granted
+      ProxyPass  http://localhost:7474/db/data/ext/tree_of_life/graphdb
+      ProxyPassReverse  http://localhost:7474/db/data/ext/tree_of_life/graphdb
+    </Location>
+
+    <Location /v2/graph>
+      Require all granted
+      ProxyPass  http://localhost:7474/db/data/ext/graph/graphdb
+      ProxyPassReverse  http://localhost:7474/db/data/ext/graph/graphdb
+    </Location>
+
+    # 7476 = taxomachine neo4j
+
+    <Location /v2/tnrs>
+      Require all granted
+      ProxyPass  http://localhost:7476/db/data/ext/tnrs_v2/graphdb
+      ProxyPassReverse  http://localhost:7476/db/data/ext/tnrs_v2/graphdb
+    </Location>
+
+    <Location /v2/taxonomy>
+      Require all granted
+      ProxyPass  http://localhost:7476/db/data/ext/taxonomy/graphdb
+      ProxyPassReverse  http://localhost:7476/db/data/ext/taxonomy/graphdb
+    </Location>
+
+    # 7478 = oti neo4j
+
+    <Location /v2/studies>
+      Require all granted
+      ProxyPass  http://localhost:7478/db/data/ext/studies/graphdb
+      ProxyPassReverse  http://localhost:7478/db/data/ext/studies/graphdb
+    </Location>
+
+    # phylesystem-api is provided via web2py
+    RewriteEngine on
+    RewriteRule ^/v2/study/(.*) /phylesystem/v1/study/$1 [PT]
+
+    # ------------------------------------------------------------
+    # Explicit routing for /cached/* URLs (in phylesystem-api)
+
+    RewriteEngine on
+    RewriteRule ^/cached/(.*) /phylesystem/default/cached/$1 [PT]
+
+    # ------------------------------------------------------------
+    # v1 API retained for transition period (ending Nov 2014 ?)
+
+    <Location /treemachine/v1>
+      Require all granted
+      ProxyPass  http://localhost:7474/db/data/ext/GoLS/graphdb
+      ProxyPassReverse  http://localhost:7474/db/data/ext/GoLS/graphdb
+    </Location>
+
+    <Location /treemachine/ext>
+      Require all granted
+      ProxyPass  http://localhost:7474/db/data/ext
+    </Location>
+
+    <Location /taxomachine/v1>
+      Require all granted
+      ProxyPass  http://localhost:7476/db/data/ext/TNRS/graphdb
+      ProxyPassReverse  http://localhost:7476/db/data/ext/TNRS/graphdb
+    </Location>
+
+    <Location /taxomachine/ext>
+      Require all granted
+      ProxyPass  http://localhost:7476/db/data/ext
+    </Location>
+
+    <Location /oti/v1>
+      Require all granted
+      ProxyPass  http://localhost:7478/db/data/ext/QueryServices/graphdb
+      ProxyPassReverse  http://localhost:7478/db/data/ext/QueryServices/graphdb
+    </Location>
+
+    <Location /oti/ext>
+      Require all granted
+      ProxyPass  http://localhost:7478/db/data/ext
+    </Location>

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -1,5 +1,8 @@
-# This file derives from the file /etc/apache2/sites-available/default
+# This file started as a clone of apache-config-shared, which in turn
+# derived from the file /etc/apache2/sites-available/default
 # in apache2 as installed in ubuntu 12.04.
+#
+# apache-config-shared is for apache 2.2; this file is for apache 2.4+.
 #
 # Now that we're supporting both HTTP and HTTPS, this file contains all the
 # shared configuration for VirtualHosts in 'opentree.conf' and 'opentree-ssl.conf'. See

--- a/deploy/setup/opentree-ssl.conf
+++ b/deploy/setup/opentree-ssl.conf
@@ -1,3 +1,6 @@
+# This file started as a clone of apache-config-vhost-ssl.
+# apache-config-vhost-ssl is for apache 2.2; this file is for apache 2.4+.
+
 # Adapting SSL settings (second VirtualHost) from /etc/apache2/sites-available/default-ssl 
 # in apache2 as installed in ubuntu 12.04.
 #

--- a/deploy/setup/opentree-ssl.conf
+++ b/deploy/setup/opentree-ssl.conf
@@ -1,0 +1,38 @@
+# Adapting SSL settings (second VirtualHost) from /etc/apache2/sites-available/default-ssl 
+# in apache2 as installed in ubuntu 12.04.
+#
+# We support both HTTP and HTTPS, with two separate files in sites-available.
+# This file holds only the settings unique to the HTTPS VirtualHost, with all
+# shared configuration included from 'apache-confog-shared'. See
+# http://serverfault.com/questions/83669/apache2-with-ssl-do-i-have-to-copy-virtualhost-blocks
+#
+# This file should be periodically reviewed as apache versions advance and
+#  'best practice' for virtual host configurations changes.
+ 
+<IfModule mod_ssl.c>
+<VirtualHost *:443>
+
+    ErrorLog ${APACHE_LOG_DIR}/ssl_error.log
+
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    SSLEngine on
+    SSLCertificateFile         /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem
+    SSLCertificateChainFile    /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem
+    SSLCertificateKeyFile /etc/ssl/private/opentreeoflife.org.key
+
+    #   SSL Engine Options:
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+    </FilesMatch>
+    <Directory /usr/lib/cgi-bin>
+        SSLOptions +StdEnvVars
+    </Directory>
+
+    # OPENTREE SHARED CONFIGURATION
+    Include /etc/apache2/opentree-shared.conf
+
+</VirtualHost>
+</IfModule>

--- a/deploy/setup/opentree-ssl.conf
+++ b/deploy/setup/opentree-ssl.conf
@@ -12,6 +12,9 @@
 <IfModule mod_ssl.c>
 <VirtualHost *:443>
 
+    # This is edited by restart-apache.sh
+    ServerName SERVERNAME_REPLACEME
+
     ErrorLog ${APACHE_LOG_DIR}/ssl_error.log
 
     # Possible values include: debug, info, notice, warn, error, crit,
@@ -19,8 +22,7 @@
     LogLevel warn
 
     SSLEngine on
-    SSLCertificateFile         /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem
-    SSLCertificateChainFile    /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem
+    SSLCertificateFile    /etc/ssl/certs/opentree/STAR_opentreeoflife_org.pem
     SSLCertificateKeyFile /etc/ssl/private/opentreeoflife.org.key
 
     #   SSL Engine Options:

--- a/deploy/setup/opentree.conf
+++ b/deploy/setup/opentree.conf
@@ -1,5 +1,8 @@
-# This file derives from the file /etc/apache2/sites-available/default
+# This file started as a clone of apache-config-vhost, which in turn
+# derived from the file /etc/apache2/sites-available/default
 # in apache2 as installed in ubuntu 12.04.
+#
+# apache-config-vhost is for apache 2.2; this file is for apache 2.4+.
 #
 # We support both HTTP and HTTPS, with two separate files in sites-available.
 # This file holds only the settings unique to the HTTP VirtualHost, with all

--- a/deploy/setup/opentree.conf
+++ b/deploy/setup/opentree.conf
@@ -1,0 +1,39 @@
+# This file derives from the file /etc/apache2/sites-available/default
+# in apache2 as installed in ubuntu 12.04.
+#
+# We support both HTTP and HTTPS, with two separate files in sites-available.
+# This file holds only the settings unique to the HTTP VirtualHost, with all
+# shared configuration included from 'apache-confog-shared'. See
+# http://serverfault.com/questions/83669/apache2-with-ssl-do-i-have-to-copy-virtualhost-blocks
+#
+# This file should be periodically reviewed as apache versions advance and
+#  'best practice' for virtual host configurations changes.
+
+<VirtualHost *:80>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    # Restrict web2py admin pages to admin users on localhost (SSH tunnel)
+    # TODO: Should this apply to the HTTPS VirtualHost as well?
+    <Location /admin>
+      Require ip 127.0.0.1
+    </Location>
+    <LocationMatch ^/([^/]+)/appadmin>
+      Require ip 127.0.0.1
+    </LocationMatch>
+
+    # See http://stackoverflow.com/questions/13216837/install-web2py-in-virtual-hosting
+    #
+    # NOTE that we can only specify WSGIDaemonProcess once, so this directive has been
+    # retained in this file. All other WSGI directives are shared
+    # across both vhosts
+    WSGIDaemonProcess web2py user=opentree group=opentree display-name=%{GROUP}
+
+    # OPENTREE SHARED CONFIGURATION
+    Include /etc/apache2/opentree-shared.conf
+
+</VirtualHost>

--- a/deploy/setup/opentree.conf
+++ b/deploy/setup/opentree.conf
@@ -26,14 +26,15 @@
       Require ip 127.0.0.1
     </LocationMatch>
 
-    # See http://stackoverflow.com/questions/13216837/install-web2py-in-virtual-hosting
-    #
-    # NOTE that we can only specify WSGIDaemonProcess once, so this directive has been
-    # retained in this file. All other WSGI directives are shared
-    # across both vhosts
-    WSGIDaemonProcess web2py user=opentree group=opentree display-name=%{GROUP}
-
     # OPENTREE SHARED CONFIGURATION
     Include /etc/apache2/opentree-shared.conf
 
 </VirtualHost>
+
+# See http://stackoverflow.com/questions/13216837/install-web2py-in-virtual-hosting
+# and http://stackoverflow.com/questions/11991891/daemon-process-cannot-be-accessed-by-this-wsgi-application-mod-wsgi
+#
+# NOTE that we can only specify WSGIDaemonProcess once, so this directive has been
+# retained in this file. All other WSGI directives are shared
+# across both vhosts
+WSGIDaemonProcess web2py user=opentree group=opentree display-name=%{GROUP}

--- a/deploy/setup/ssl-certs/README.md
+++ b/deploy/setup/ssl-certs/README.md
@@ -18,7 +18,7 @@ Note that this script requires `wget` or `curl`, as well as `openssl` to run.
 The result is a new file `STAR_opentreeoflife_org.pem`. This includes the full
 chain of public certificates, and it's the file we actually specify in our
 apache configuration file `001-opentree-ssl`. (See
-[template](https://github.com/OpenTreeOfLife/opentree/blob/master/deploy/setup/apache-config-vhost-ssl)
+[template](https://github.com/OpenTreeOfLife/opentree/blob/master/deploy/setup/opentree-ssl.conf)
 and 
 [installation script](https://github.com/OpenTreeOfLife/opentree/blob/master/deploy/restart-apache.sh)
 for details.)


### PR DESCRIPTION
Prepare for upgrade to apache 2.4

* Cloned (with rename) the apache config files.  For 2.4 we have
  opentree.conf, opentree-ssl.conf, and opentree-shared.conf instead
  of apache-config-vhost, apache-config-vhost-ssl,
  apache-config-shared.  Keeping old files (temporarily) with old
  names so we can continue to deploy with 2.2.
* 'Allow', 'Deny', and 'Order' directives are no longer supported in
  2.4.  Replaced with 'Require'.
