### PR TITLE
Fetch supporting study info via AJAX fetch.

### DIFF
--- a/webapp/private/config.example
+++ b/webapp/private/config.example
@@ -51,5 +51,6 @@ getContextsJSON_url = {CACHED_taxomachine_domain}/getContextsJSON
 getNodeIDForOttolID_url = {treemachine_domain}/getNodeIDForottId
 getSynthesisSourceList_url = {treemachine_domain}/getSynthesisSourceList
 findAllStudies_url = {oti_domain}/findAllStudies
+singlePropertySearchForStudies_url = {oti_domain}/singlePropertySearchForStudies
 # Include one phylesystem-api method to download NexSON from Bibliographic References page
 API_load_study_GET_url = {opentree_api_domain}/study/{STUDY_ID}

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -190,6 +190,15 @@ function createArgus(spec) {
                     }
                 }
 
+                if (value.pathToRoot) {
+                    // assign parent IDs up the "root-ward" chain of nodes
+                    var testChild = value;
+                    $.each(value.pathToRoot, function(i, testParent) {
+                        testChild.parentNodeID = testParent.nodeid;
+                        testChild = testParent;  // and move to *its* parent
+                    });
+                }
+
                 // convert to desired JS pseudo-class
                 return $.extend( new ArgusNode(), value );
             }

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -48,6 +48,16 @@ var argus;
 // @TEMP - preserve incoming OTT id and source, so we can demo the Extract Subtree feature
 var incomingOttolID = null;
 
+function getSupportingSourceIDs( node ) {
+    // handle different properties used here (each should hold an array of source-ids)
+    if (typeof node.supportedBy !== 'undefined') {
+        return (node.supportedBy.length > 0) ? node.supportedBy : null;
+    }
+    if (typeof node.supporting_sources !== 'undefined') {
+        return (node.supporting_sources.length > 0) ? node.supporting_sources : null;
+    }
+    return null;
+}
 function updateTreeView( State ) {
     /* N.B. This should respond identically to state changes in HTML5 History,
      * or to explicit calls from older/simpler browsers.
@@ -939,9 +949,10 @@ function showObjectProperties( objInfo, options ) {
                     objID = fullNode.sourceID ? fullNode.sourceID : fullNode.nodeid;
 
                     // add basic edge properties (TODO: handle multiple edges!?)
-                    if (typeof fullNode.supportedBy !== 'undefined') {
+                    var fullNodeSupporters = getSupportingSourceIDs( fullNode );
+                    if (fullNodeSupporters) {
                         if (edgeSection) {
-                            edgeSection.displayedProperties['Supported by'] = fullNode.supportedBy;
+                            edgeSection.displayedProperties['Supported by'] = fullNodeSupporters;
                         } else {
                             console.log('>>> No edgeSection found for this node:');
                             console.log(fullNode);
@@ -1001,9 +1012,16 @@ function showObjectProperties( objInfo, options ) {
     switch (objType) {
         case 'node':
         case 'edge':
-            if (objInfo.supportedBy) {
+            var fullNode = argus.getArgusNodeByID( objID );
+            var objSupporters = null;
+            if (fullNode) {
+                objSupporters = getSupportingSourceIDs( fullNode );
+            } else {
+                objSupporters = getSupportingSourceIDs( objInfo );
+            }
+            if (objSupporters) {
                 // fetch full supporting info, then display it
-                $.each(objInfo.supportedBy, function(i, sourceID) {
+                $.each(objSupporters, function(i, sourceID) {
                     if (sourceID === 'taxonomy') {
                         // this supporting data is already in arguson
                     } else {

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -78,6 +78,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         var getDraftTreeForNodeID_url = "{{=getDraftTreeForNodeID_url}}";
         var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
         var getNodeIDForOttolID_url = "{{=getNodeIDForOttolID_url}}";
+        var singlePropertySearchForStudies_url = "{{=singlePropertySearchForStudies_url}}";
     </script>
     {{pass}}
     <script type="text/javascript">


### PR DESCRIPTION
This information should now load (once only for each supporting study) and appear in the property inspector on-the-fly. Also cleaned up some diagnostic chatter and extra phylo-pic loads. 

'Supported by taxonomy' now also lists the exact version and draft of OTT, with a generic link to taxonomy info and versions.

This is working now and available for review in the synth-tree view on **devtree**.