### PR TITLE
Remove faulty priority sorting in References page.

### DIFF
--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -124,9 +124,8 @@ def fetch_current_synthesis_source_data():
                 study['tree_ids'] = contrib_info['tree_ids']
                 contributing_studies.append( study )
 
-        # TODO: sort these alphabetically(?) and render in the page
-        ## contributing_studies.sort(key = lambda x: x.get('ot:studyPublicationReference'))
-        # NO, apparently they're pre-sorted to reflect the importance of each study
+        # sort these alphabetically by first author, then render in the page
+        contributing_studies.sort(key = lambda x: x.get('ot:studyPublicationReference'))
 
         # TODO: encode data to utf-8?
         ## context_names += [n.encode('utf-8') for n in contextnames_json[gname] ]

--- a/webapp/views/about/references.html
+++ b/webapp/views/about/references.html
@@ -47,16 +47,22 @@ div.contributing-studies div.links .tree-links a {
 
 <div class="container">
       <h1 id="main-title">Bibliographic references for the synthetic tree</h1>
+      <div class="row">
+          <div class="span12">
+              <p>The following studies (listed alphabetically by first author) have contributed to the current synthetic tree.</p>
+          </div>
+      </div>
 
       <div class="row">
           <div class="contributing-studies span10 offset1">
               <!-- TODO: Relax the margin-top if we're on a narrow screen (stacked columns), to avoid overlap. -->
-              <p>The following studies have contributed to the current synthetic tree.</p>
 
+              <!-- Hide sorting options until we have a programmatic source for priority order, and ways to show *tree* rank vs. study rank.
               <div class="btn-group">
                 <button id="priority-sort-button" class="btn active" onclick="sortReferences(sortByPriority); return false;">&nbsp; Sort by priority in synthesis &nbsp;</button>
                 <button id="alpha-sort-button" class="btn" onclick="sortReferences(sortByPrimaryAuthor); return false;">&nbsp; Sort alphabetically &nbsp;</button>
               </div>
+              -->
 
              {{ priority = 1 }}
              {{ for study in contributing_studies: }}


### PR DESCRIPTION
The server will now provide the default and only sort, alphabetically by
study's primary author. Addresses #646.

This is [working now on **devtree**](https://devtree.opentreeoflife.org/about/references).