### PR TITLE
Api with deprecations

### DIFF
--- a/api_documentation/Documentation.py
+++ b/api_documentation/Documentation.py
@@ -1,106 +1,96 @@
-import pycurl, json, shlex, subprocess
+import pycurl
+import json
+import shlex
+import subprocess
 from StringIO import StringIO
 
-class builder:
-
-    max_response_len = 2000
-
+class Builder(object):
     def __init__(self):
         self.json_storage = StringIO()
-        self.c = pycurl.Curl()    
-
+        self.c = pycurl.Curl()
     def _update_json_storage(self, url):
         self.json_storage.truncate(0)
         self.c.setopt(self.c.URL, url)
         self.c.setopt(self.c.HTTPHEADER, ["Content-type:Application/json"])
         self.c.setopt(self.c.WRITEFUNCTION, self.json_storage.write)
         self.c.perform()
-    
-    def get_detailed_methods_list(self, method_info):
-
-        markdown = StringIO()
-        
-        # if we received a parameters list, use it, otherwise initialize it
-        parameters = parameters if "parameters" in locals() else {}
-
-        # process information from the neo4j web service info, if any        
-        if "neo4j_service_url" in method_info and method_info["neo4j_service_url"] is not None:
-            self._update_json_storage(method_info["neo4j_service_url"])
-#            print self.json_storage.getvalue()
-            service_info = json.loads(self.json_storage.getvalue())
-            method_info["long_description"] = service_info["description"]
-    
-            # process neo4j parameters
-            for p in service_info["parameters"]:
-                parameters[p["name"]] = p
-                
-        # just a kludge to keep from failing if there is no description
-        method_info["long_description"] = method_info["long_description"] if "long_description" in method_info else ""     
-
-        # process parameters for printing
-        required_keys = []
-        optional_keys = []
-        for name, p in parameters.iteritems():
-            if p["optional"] == True:
-                p["style_modifier"] = ""
-                optional_keys.append(name)
-            else:
-                p["style_modifier"] = "**"
-                required_keys.append(name)
-
-        # get the results of the example call if possible
-        e = shlex.split(method_info["example_command"].replace("\\\n",""))
-        if e is not None and len(e) > 0:
-            r = subprocess.Popen(e,stdout=subprocess.PIPE)
-            res = r.communicate()[0]
-#            if len(res) > self.max_response_len:
-#                res = res[0:(self.max_response_len/2)-50] + "\n\n### snipped\n\n" + res[-((self.max_response_len/2)-50):-1]
-            method_info["example_result"] = res
-
-        # now print the preamble
-        markdown.write(self.method_preamble_template.format(**method_info))
-
-        # and the parameters
-        for key_set in [sorted(required_keys), sorted(optional_keys)]:
-            for p in key_set:
-                markdown.write(self.method_parameter_template.format(**parameters[p]))
-
-        # and the example
-        markdown.write(self.method_example_template.format(**method_info))
-        
-        return markdown.getvalue()
-
-    def get_methods_summary(self, method_group):
-    
-        markdown = StringIO()
-
-        markdown.write("## <a name='{g.anchor_name}'></a>{g.title}\n".format(g=method_group))
-        markdown.write(method_group.long_description+"\n\n")
-        markdown.write("| URL                                        | Verb   | Summary                |\n");
-        markdown.write("| -------------------------------------------|--------|------------------------|\n");
-
-        for m in method_group.methods_list:
-            markdown.write("|[`{m[relative_url]}`](#{m[anchor_name]}) | {m[http_verb]} | {m[short_description]} |\n".format(m=m));
-
-        return markdown.getvalue()            
-
-    def get_doc_preamble(self, method_groups):
-
-        markdown = StringIO()
-        
-        mgm = ""
-        for g in method_groups:
-            mgm += self.method_group_list_item_template.format(g=g)
-        markdown.write(self.doc_preamble_template.format(method_groups=mgm))
-
-        return markdown.getvalue()        
-    
     def get_doc_postamble(self):
-        return self.doc_postamble_template
-    
-    doc_preamble_template = """ Do not edit this page! The API documentation is automatically generated using code in [the opentree repo](http://github.com/OpenTreeOfLife/opentree/tree/master/api_documentation). If you have a suggestion to improve this documentation, please submit an issue on the [feedback repo](http://github.com/OpenTreeOfLife/feedback/issues).
+        return _DOC_PREAMBLE_TEMPLATE
+    def get_doc_preamble(self, method_groups):
+        out = StringIO()
+        self.write_doc_preamble(out, method_groups)
+        return out.getvalue()
+    def get_method_details(self, method_info):
+        out = StringIO()
+        self.write_method_details(out, method_info)
+        return out.getvalue()
+    def get_methods_summary(self, method_group):
+        out = StringIO()
+        self.write_methods_summary(out, method_group)
+        return out.getvalue()
+    def write_method_details(self, out, method_info):
+        # process information from the neo4j web service info, if any
+        if method_info.get('deprecated'):
+            out.write(_ANCHOR_TITLE_TEMPLATE.format(**method_info))
+            templ = 'The method "{m[method_name]}" has been deprecated.\n\n'
+            out.write(templ.format(m=method_info))
+            sd = method_info.get('short_description')
+            if sd:
+                out.write(sd + '\n\n')
+        else:
+            if "neo4j_service_url" in method_info and method_info["neo4j_service_url"] is not None:
+                self._update_json_storage(method_info["neo4j_service_url"])
+                service_info = json.loads(self.json_storage.getvalue())
+                method_info["long_description"] = service_info["description"]
+            # just a kludge to keep from failing if there is no description
+            method_info["long_description"] = method_info.get("long_description", '')
+            # get the results of the example call if possible
+            e = shlex.split(method_info["example_command"].replace("\\\n",""))
+            if e is not None and len(e) > 0:
+                r = subprocess.Popen(e,stdout=subprocess.PIPE)
+                res = r.communicate()[0]
+                method_info["example_result"] = res
+            # now print the preamble
+            out.write(_METHOD_PREAMBLE_TEMPLATE.format(**method_info))
+            # and the example
+            out.write(_METHOD_EXAMPLE_TEMPLATE.format(**method_info))
+        link_outs = method_info.get('further_info', [])
+        if link_outs:
+            out.write('\n##### For further information\n\n')
+            for li in link_outs:
+                out.write('  * [{l[link_name]}]({l[url]})\n\n'.format(l=li))
+    def write_methods_summary(self, out, method_group):
+        out.write("## <a name='{g.anchor_name}'></a>{g.title}\n".format(g=method_group))
+        out.write(method_group.long_description + "\n\n")
+        TABLE_HEADER = """| URL                                        | Verb   | Summary                |
+| -------------------------------------------|--------|------------------------|
+"""
+        out.write(TABLE_HEADER)
+        active_templ = "|[`{m[relative_url]}`](#{m[anchor_name]}) | {m[http_verb]} | {m[short_description]} |\n"
+        for m in method_group.methods_list:
+            if not m.get('deprecated'):
+                out.write(active_templ.format(m=m));
+        dep = [i for i in method_group.methods_list if i.get('deprecated')]
+        if dep:
+            out.write('\n\n*Deprecated methods*\n')
+            out.write(TABLE_HEADER)
+            deprecated_templ = "|[`{m[relative_url]}`](#{m[anchor_name]}) |     | *Deprecated*: {m[short_description]} |\n"
+            for m in dep:
+                out.write(deprecated_templ.format(m=m));
+        out.write('\n')
+    def write_doc_preamble(self, out, method_groups):
+        template = "**[{g.title}](#{g.anchor_name})** : {g.short_description}.\n\n"
+        mgm = ''.join([template.format(g=g) for g in method_groups])
+        out.write(_DOC_PREAMBLE_TEMPLATE.format(method_groups=mgm))
 
-This documentation describes version 2.0 of the Open Tree of Life APIs. There is also documentation for [version 1.0](https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs-V1), which is still active but is deprecated and will eventually be retired.  
+_DOC_PREAMBLE_TEMPLATE = """ Do not edit this page! The API documentation is automatically generated using code 
+in [the opentree repo](http://github.com/OpenTreeOfLife/opentree/tree/master/api_documentation). If you have 
+a suggestion to improve this documentation, please submit an issue on the
+[feedback repo](http://github.com/OpenTreeOfLife/feedback/issues).
+
+This documentation describes version 2.0 of the Open Tree of Life APIs. There is also documentation 
+for [version 1.0](https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs-V1), which 
+is still active but is deprecated and will eventually be retired.
 
 The Open Tree of Life APIs include services to access the following types of data:
 
@@ -112,17 +102,20 @@ The base URL for all services:
 
 **Caveats**
 
-* the JSON return values are not consistent between software components. We are working to standardize on the documented [NexSON](http://purl.org/opentree/nexson) format.  
-* [neo4j](http://neo4j.org) implements POST for some methods that really should be GET.  
+* the JSON return values are not consistent between software components. We are working to standardize on the
+documented [NexSON](http://purl.org/opentree/nexson) format.
+* [neo4j](http://neo4j.org) implements POST for some methods that really should be GET.
 
 **Questions / Comments**
 
-If you have questions, or have a problem with any of these methods, please leave an issue in the [feedback issue tracker](https://github.com/OpenTreeOfLife/feedback/issues).\n\n"""
+If you have questions, or have a problem with any of these methods, please leave an issue in 
+the [feedback issue tracker](https://github.com/OpenTreeOfLife/feedback/issues).
 
-    method_group_list_item_template = """**[{g.title}](#{g.anchor_name})** : {g.short_description}.\n\n"""
+"""
 
-    method_preamble_template = """### <a name="{anchor_name}"></a>{method_name}
-
+_ANCHOR_TITLE_TEMPLATE = """### <a name="{anchor_name}"></a>{method_name}
+"""
+_METHOD_PREAMBLE_TEMPLATE = _ANCHOR_TITLE_TEMPLATE + """
 *{short_description}*
 
 ```
@@ -132,12 +125,11 @@ If you have questions, or have a problem with any of these methods, please leave
 {long_description}
 
 ##### Parameters:\n
-*Parameters with bold type definitions are required.*\n\n"""
+*Parameters with bold type definitions are required.*
 
-    method_parameter_template = """{style_modifier}```{name}``` : {type}{style_modifier}<br/>
-{description}\n\n"""
+"""
 
-    method_example_template = """*Example command:*
+_METHOD_EXAMPLE_TEMPLATE = """*Example command:*
 
 ```bash
 $ {example_command}
@@ -146,9 +138,11 @@ $ {example_command}
 *Example result:*    
 ```json
 {example_result}
-```\n\n"""
+```
 
-    doc_postamble_template = """## Other API docs
+"""
+
+_DOC_POSTAMBLE_TEMPLATE = """## Other API docs
 The following links provide information about ongoing development: methods being tested, developed or discussed.  
 
 * [documentation of the datastore API](https://github.com/OpenTreeOfLife/phylesystem-api/blob/master/docs/README.md)
@@ -156,4 +150,6 @@ The following links provide information about ongoing development: methods being
 * [Python library for interacting with OpenTree APIs](https://github.com/OpenTreeOfLife/peyotl)
 * [Overview of methods used internally between OpenTree components](https://github.com/OpenTreeOfLife/phylesystem-api/wiki/overview-of-open-tree-of-life-api-calls)
 
-If you have questions or feedback, leave an [issue on GitHub](https://github.com/OpenTreeOfLife/feedback/issues) or join us on IRC on the #opentreeoflife channel on [Freenode](http://freenode.net/)."""
+If you have questions or feedback, leave an[issue on GitHub](https://github.com/OpenTreeOfLife/feedback/issues)
+or join us on IRC on the #opentreeoflife channel on [Freenode](http://freenode.net/).
+"""

--- a/api_documentation/graph.py
+++ b/api_documentation/graph.py
@@ -21,12 +21,19 @@ methods_list.append({
 methods_list.append({
     "anchor_name" : "source_tree",
     "method_name" : "source_tree",
-    "short_description" : "Return a source tree (including metadata) from the graph of life.",
-    "http_verb" : "POST",
+    "deprecated": True,
+    "short_description": "Source trees used in synthesis are currently only available by a download",
+    "further_info": ({'url': "http://files.opentreeoflife.org/preprocessed/v3.0/", 
+                      'link_name': 'Page with the download links'},
+                     {'url': "https://github.com/OpenTreeOfLife/treemachine/issues/170", 
+                      'link_name': "GitHub issue describing decision to deprecate this service"},
+                    ),
+    #"short_description" : "Return a source tree (including metadata) from the graph of life.",
+    #"http_verb" : "POST",
     "relative_url" : "/graph/source_tree",
-    "neo4j_service_url" : "http://api.opentreeoflife.org/v2/graph/source_tree",
-    "example_command" : """curl -X POST http://api.opentreeoflife.org/v2/graph/source_tree -H "content-type:application/json" -d '{"study_id":"pg_420", "tree_id":"522", "git_sha":"a2c48df995ddc9fd208986c3d4225112550c8452"}'""",
-    "example_result" : "",
+    #"neo4j_service_url" : "http://api.opentreeoflife.org/v2/graph/source_tree",
+    #"example_command" : """curl -X POST http://api.opentreeoflife.org/v2/graph/source_tree -H "content-type:application/json" -d '{"study_id":"pg_420", "tree_id":"522", "git_sha":"a2c48df995ddc9fd208986c3d4225112550c8452"}'""",
+    #"example_result" : "",
 })
 
 # node_info

--- a/api_documentation/make_documentation.py
+++ b/api_documentation/make_documentation.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python
 
-from Documentation import builder
+from Documentation import Builder
 import graph, studies, taxonomy, tnrs, tree_of_life
+import sys
+d = Builder()
 
-d = builder()
-
-def print_markdown(method_group):
-    print(d.get_methods_summary(method_group))
-
+def write_markdown(out, method_group):
+    d.write_methods_summary(out, method_group)
     for m in method_group.methods_list:
-        print(d.get_detailed_methods_list(m))
+        d.write_method_details(out, m)
 
-print(d.get_doc_preamble([tree_of_life,graph,tnrs,taxonomy,studies]))
-print_markdown(tree_of_life)
-print_markdown(graph)
-print_markdown(tnrs)
-print_markdown(taxonomy)
-print_markdown(studies)
-print(d.get_doc_postamble())
+out = sys.stdout
+out.write(d.get_doc_preamble([tree_of_life,graph,tnrs,taxonomy,studies]))
+out.write('\n')
+write_markdown(out, tree_of_life)
+write_markdown(out, graph)
+write_markdown(out, tnrs)
+write_markdown(out, taxonomy)
+write_markdown(out, studies)
+out.write(d.get_doc_postamble())
+out.write('\n')

--- a/api_documentation/make_documentation.py
+++ b/api_documentation/make_documentation.py
@@ -20,3 +20,4 @@ write_markdown(out, taxonomy)
 write_markdown(out, studies)
 out.write(d.get_doc_postamble())
 out.write('\n')
+


### PR DESCRIPTION
some minor refactoring of the script that generates https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs
and added the ability to add
  * `further_info` links about a method, and
  * `deprecated` so that we could document the loss of the `source_tree` method.
