### PR TITLE
Always prompt for license/waiver for new studies

### DIFF
--- a/curator/static/js/study-creation.js
+++ b/curator/static/js/study-creation.js
@@ -72,6 +72,7 @@ function updateImportOptions() {
     var $altLicenseDetails = $('#alternate-license-details'); // set of widgets
     var $altOtherLicenseInfo = $('#other-license-info');  // subset, used only if "Other license' chosen
     var $chosenLicense = $('input[name=data-license]:checked');
+    var $treebaseOnlyElements = $('.treebase-only');
     var authorChoosingToApplyCC0 = ($chosenLicense.attr('id') === 'apply-new-CC0-waiver');
     var altLicenseDetailsRequired = ($chosenLicense.attr('id') === 'study-data-has-existing-license');
     var chosenAltLicense = $('select[name=alternate-license]').val();
@@ -110,6 +111,7 @@ function updateImportOptions() {
         case 'IMPORT_FROM_TREEBASE':
             enableDetails( $treebaseDetailPanel );
             disableDetails( $uploadDetailPanel );
+            $treebaseOnlyElements.show();
 
             // Are we ready to continue?
             if ($.trim($('input[name=treebase-id]').val()) === '') {
@@ -133,6 +135,7 @@ function updateImportOptions() {
         case 'IMPORT_FROM_UPLOAD':
             disableDetails( $treebaseDetailPanel );
             enableDetails( $uploadDetailPanel );
+            $treebaseOnlyElements.hide();
             
             // Are we ready to continue?
             if ($.trim($('input[name=publication-DOI]').val()) === '') {
@@ -144,6 +147,7 @@ function updateImportOptions() {
         case undefined:
             disableDetails( $treebaseDetailPanel );
             disableDetails( $uploadDetailPanel );
+            $treebaseOnlyElements.hide();
 
             creationAllowed = false;
             errMsg = 'You must choose a study creation method (import from TreeBASE, or upload from your computer).';

--- a/curator/static/js/study-creation.js
+++ b/curator/static/js/study-creation.js
@@ -138,27 +138,6 @@ function updateImportOptions() {
             if ($.trim($('input[name=publication-DOI]').val()) === '') {
                 creationAllowed = false;
                 errMsg = 'You must enter a DOI (preferred) or URL to continue.';
-            } else {
-                // Check for a compliant license or waiver
-                if ($chosenLicense.length === 0) {
-                    creationAllowed = false;
-                    errMsg = 'You must select an appropriate waiver or license for these data.';
-                } else if (authorChoosingToApplyCC0 && !($('#agreed-to-CC0').is(':checked'))) {
-                    creationAllowed = false;
-                    errMsg = 'You must agree to release the data under the terms of the CC0 waiver.';
-                } else if (altLicenseDetailsRequired && (chosenAltLicense === '')) {
-                    creationAllowed = false;
-                    errMsg = 'You must select an appropriate waiver or license for these data.';
-                } else if (altOtherLicenseInfoRequired) {
-                    if ($.trim($('input[name=data-license-name]').val()) === '') {
-                        creationAllowed = false;
-                        errMsg = 'You must specify the name and URL of the current data license for these data.';
-                    }
-                    if ($.trim($('input[name=data-license-url]').val()) === '') {
-                        creationAllowed = false;
-                        errMsg = 'You must specify the name and URL of the current data license for these data.';
-                    }
-                }
             }
             break;
 
@@ -176,6 +155,28 @@ function updateImportOptions() {
             console.log(typeof(chosenImportLocation));
     } 
 
+    if (creationAllowed) {
+        // Check for a compliant license or waiver (regardless of import method)
+        if ($chosenLicense.length === 0) {
+            creationAllowed = false;
+            errMsg = 'You must select an appropriate waiver or license for these data.';
+        } else if (authorChoosingToApplyCC0 && !($('#agreed-to-CC0').is(':checked'))) {
+            creationAllowed = false;
+            errMsg = 'You must agree to release the data under the terms of the CC0 waiver.';
+        } else if (altLicenseDetailsRequired && (chosenAltLicense === '')) {
+            creationAllowed = false;
+            errMsg = 'You must select an appropriate waiver or license for these data.';
+        } else if (altOtherLicenseInfoRequired) {
+            if ($.trim($('input[name=data-license-name]').val()) === '') {
+                creationAllowed = false;
+                errMsg = 'You must specify the name and URL of the current data license for these data.';
+            }
+            if ($.trim($('input[name=data-license-url]').val()) === '') {
+                creationAllowed = false;
+                errMsg = 'You must specify the name and URL of the current data license for these data.';
+            }
+        }
+    }
     
     var $continueButton = $('#continue-button');
     if (creationAllowed) {

--- a/curator/views/study/create.html
+++ b/curator/views/study/create.html
@@ -43,7 +43,9 @@ body {
             <ul id="duplicate-study-links" class="static-form-value interesting-value">
             </ul>
         </div>
+    </div>
 
+    <div id="license-or-waiver-options" style="margin-bottom: 1em;">
         <h4>License information</h4>
         <label for="apply-new-CC0-waiver" class="featured-label" style="margin-top: 0px;">
             <input type="radio" id="apply-new-CC0-waiver" name="data-license" value="apply-new-CC0-waiver"/>

--- a/curator/views/study/create.html
+++ b/curator/views/study/create.html
@@ -65,6 +65,7 @@ body {
             <input type="radio" id="study-data-has-existing-license" name="data-license" 
                    value="study-data-has-existing-license"/>
              These data already have an applied waiver or license
+             <span class="treebase-only" style="display: none;">(highly unusual for TreeBASE data)</span>
         </label>
             <div id="alternate-license-details" class="featured-label-child" style="display: none;">
                 <select id="alternate-license" name="alternate-license" 
@@ -84,9 +85,10 @@ body {
                 </div>
             </div>
 
-        <label for="submit-without-CC0" class="featured-label">
+        <label for="submit-without-CC0" class="featured-label" style="text-indent: -20px; padding-left: 20px;">
             <input type="radio" id="submit-without-CC0" name="data-license" value="submit-without-CC0"/>
             These data have no applied waiver or license, and I have no authority to apply a waiver
+             <span class="treebase-only" style="display: none;">(usually true for TreeBASE data)</span>
         </label>
     </div>
 


### PR DESCRIPTION
This addresses #670. We'd been assuming that studies imported from TreeBASE would always
have the CC0 waiver applied, but this is not the case.

NOTE that this changes the creation UI, but the underlying phylesystem API also needed a change! Look for a matching PR from branch `always-prompt-for-new-study-waiver` in **phylesystem-api**.

