### PR TITLE
merged About & Credits pages; removed Credits from menu

### DIFF
--- a/webapp/views/about/open_tree_of_life.html
+++ b/webapp/views/about/open_tree_of_life.html
@@ -1,18 +1,80 @@
 {{extend 'layout.html'}}
 
 <div class="container">
-      <h1 id="main-title">About the Open Tree of Life project</h1>
+      <h1 id="main-title">Open Tree of Life</h1>
 
       <div class="row">
           <div class="span10 offset1">
               <p>
-              Open Tree of Life is an NSF funded project that aims to construct a comprehensive, dynamic and digitally-available tree of life by synthesizing published phylogenetic trees along with taxonomic data. 
+              Open Tree of Life aims to construct a comprehensive, dynamic and digitally-available tree of life by synthesizing published phylogenetic trees along with taxonomic data. The project is a collaborative effort between 11 PIs across 10 institutions. Funding is from NSF AVAToL #1208809.
               </p>
-			  <p>The project is a collaborative effort between 11 PIs across 10 institutions. See the <a href="{{=URL('about','credits') }}">Credits</a> page for more information about collaborators and contributors. 
+              <p>For more information, you can read our <a href="http://blog.opentreeoflife.org">blog</a> or see the various ways to <a href="{{=URL('contact','index') }}">contact us or leave feedback</a>. 
               </p>
-			  <p>
-              Funding for OpenTree comes from NSF AVAToL #1208809
-              </p>
+          </div>
+      </div>
+      <div class="row">
+          <div class="span4">
+              <dl class="dl-horizontal">
+                <dt>Postdocs & students </dt>
+                    <dd>Joseph Brown</dd>
+                    <dd>Ruchi Chaudhary</dd>
+                    <dd>Lyndon M. Coghill</dd>
+                    <dd>Jiabin Deng</dd>
+                    <dd>Bryan Drew</dd>
+                    <dd>Romina Gazis</dd>
+                    <dd>Jessica Grant</dd>
+                    <dd>Cody Hinchliff</dd>
+                    <dd>Dail Laughinghouse</dd>
+                    <dd>Emily Jane McTavish</dd>
+                    <dd>Chris Owen</dd>
+                    <dd>others</dd>
+
+                <!-- NOTE: By default, long DT text is truncated to fit on one line. -->
+		<!-- 
+                <dt>This role takes more space to describe than others</dt>
+                    <dd>Firstname Lastname</dd>
+		    -->
+            </dl>
+          </div>
+          <div class="span4">
+              <dl class="dl-horizontal">
+                <dt>Developers</dt>
+                    <dd>Jim Allman</dd>
+                    <dd>Joseph Brown</dd>
+                    <dd>Karen Cranston</dd>
+                    <dd>Cody Hinchliff</dd>
+                    <dd>Mark Holder</dd>
+                    <dd>Jonathan Leto</dd>
+                    <dd>Emily McTavish</dd>
+                    <dd>Peter Midford</dd>
+                    <dd>Richard Ree</dd>
+                    <dd>Jonathan Rees</dd>
+                    <dd>Stephen Smith</dd>
+            </dl>
+          </div>
+          <div class="span4">
+              <dl class="dl-horizontal">
+                <dt>Principal investigators</dt>
+                    <dd>Gordon Burleigh</dd>
+                    <dd>Keith Crandall</dd>
+                    <dd>Karen Cranston</dd>
+                    <dd>Karl Gude</dd>
+                    <dd>David Hibbett</dd>
+                    <dd>Mark Holder</dd>
+                    <dd>Laura Katz</dd>
+                    <dd>Richard Ree</dd>
+                    <dd>Stephen Smith</dd>
+                    <dd>Doug Soltis</dd>
+                    <dd>Tiffani Williams</dd>
+
+                <!-- NOTE the styles + classes used here to handle long DT text without truncating it.
+                <dt style="white-space: normal;">A role that takes more space to describe than some</dt>
+                    <dd>Firstname Lastname</dd>
+                    <dd class="clearfix">Firstname2 Lastname</dd>
+                <dt>Yet another role</dt>
+                    <dd>Firstname Lastname And Even a Third Name, Esq.</dd>
+		    -->
+            </dl>
           </div>
       </div>
 

--- a/webapp/views/about/open_tree_of_life.html
+++ b/webapp/views/about/open_tree_of_life.html
@@ -12,7 +12,7 @@
               <strong>Browse the tree and leave feedback</strong>: Click on nodes to move through the tree, and click on nodes or edges to see more information about taxonomies and phylogenies that contain / support that node. If you have feedback about the relationships that you see, use the "Add Comment" button. 
               </p>
               <p>
-              <strong>Contribute data</strong>: You can contribute to the synthetic tree by uploading trees through our <a href="/curator">curation interface</a>. These can be trees from TreeBASE or trees uploaded from your computer. 
+              <strong>Contribute data</strong>: You can contribute to the synthetic tree by uploading trees through our <a href="/curator">curation interface</a>. These can be trees from TreeBASE or trees uploaded from your computer. There will be a delay before uploaded trees appear in the synthetic tree. Up to summer 2015, the release cycle has been months between new versions of the synthetic tree, but this should shorten in the future. 
               </p>
               <p>For more information, you can read our <a href="http://blog.opentreeoflife.org">blog</a> or see the various ways to <a href="{{=URL('contact','index') }}">contact us or leave feedback</a>. 
               </p>

--- a/webapp/views/about/open_tree_of_life.html
+++ b/webapp/views/about/open_tree_of_life.html
@@ -8,6 +8,12 @@
               <p>
               Open Tree of Life aims to construct a comprehensive, dynamic and digitally-available tree of life by synthesizing published phylogenetic trees along with taxonomic data. The project is a collaborative effort between 11 PIs across 10 institutions. Funding is from NSF AVAToL #1208809.
               </p>
+              <p>
+              <strong>Browse the tree and leave feedback</strong>: Click on nodes to move through the tree, and click on nodes or edges to see more information about taxonomies and phylogenies that contain / support that node. If you have feedback about the relationships that you see, use the "Add Comment" button. 
+              </p>
+              <p>
+              <strong>Contribute data</strong>: You can contribute to the synthetic tree by uploading trees through our <a href="/curator">curation interface</a>. These can be trees from TreeBASE or trees uploaded from your computer. 
+              </p>
               <p>For more information, you can read our <a href="http://blog.opentreeoflife.org">blog</a> or see the various ways to <a href="{{=URL('contact','index') }}">contact us or leave feedback</a>. 
               </p>
           </div>

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -170,7 +170,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                       <li><a href="{{= URL('about','references') }}">Bibliographic references</a></li>
                       <li><a href="https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs" target="_blank">API documentation</a></li>
                       <li><a href="{{= URL('about','developer-resources') }}">Developer resources</a></li>
-                      <li><a href="{{= URL('about','credits') }}">Credits</a></li>
                       <li><a href="{{= URL('about','licenses') }}">Licenses</a></li>
                 </ul>
               </li>


### PR DESCRIPTION
The Credits page had a placeholder for an image that doesn't exist, an incomplete list of curators and no list of students / postdocs. I merged About & Credits and removed reference to Credits in the menu. 