### PR TITLE
Add search-by-ID feature for curation study list.

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -258,6 +258,7 @@ function loadStudyList() {
                     viewModel, 
                     function(study) {
                         // match entered text against pub reference (author, title, journal name, DOI)
+                        var studyID = study['ot:studyId'];
                         var pubReference = study['ot:studyPublicationReference'];
                         var pubURL = study['ot:studyPublication'];
                         var pubYear = study['ot:studyYear'];
@@ -267,7 +268,7 @@ function loadStudyList() {
                                      ($.trim(study['ot:focalCladeOTTTaxonName']) !== "")) ?
                                         study['ot:focalCladeOTTTaxonName'] :  // use mapped name if found
                                         study['ot:focalClade']; // fall back to numeric ID (should be very rare)
-                        if (!matchPattern.test(pubReference) && !matchPattern.test(pubURL) && !matchPattern.test(pubYear) && !matchPattern.test(curator) && !matchPattern.test(tags) && !matchPattern.test(clade)) {
+                        if (!matchPattern.test(studyID) && !matchPattern.test(pubReference) && !matchPattern.test(pubURL) && !matchPattern.test(pubYear) && !matchPattern.test(curator) && !matchPattern.test(tags) && !matchPattern.test(clade)) {
                             return false;
                         }
                         // check for filtered workflow state

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -249,7 +249,8 @@ function loadStudyList() {
                 updateListFiltersWithHistory();
 
                 var match = viewModel.listFilters.STUDIES.match(),
-                    matchPattern = new RegExp( $.trim(match), 'i' );
+                    matchPattern = new RegExp( $.trim(match), 'i' ),
+                    wholeWordMatchPattern = new RegExp( '\\b'+ $.trim(match) +'\\b', 'i' );
                 var workflow = viewModel.listFilters.STUDIES.workflow();
                 var order = viewModel.listFilters.STUDIES.order();
 
@@ -268,7 +269,7 @@ function loadStudyList() {
                                      ($.trim(study['ot:focalCladeOTTTaxonName']) !== "")) ?
                                         study['ot:focalCladeOTTTaxonName'] :  // use mapped name if found
                                         study['ot:focalClade']; // fall back to numeric ID (should be very rare)
-                        if (!matchPattern.test(studyID) && !matchPattern.test(pubReference) && !matchPattern.test(pubURL) && !matchPattern.test(pubYear) && !matchPattern.test(curator) && !matchPattern.test(tags) && !matchPattern.test(clade)) {
+                        if (!wholeWordMatchPattern.test(studyID) && !matchPattern.test(pubReference) && !matchPattern.test(pubURL) && !matchPattern.test(pubYear) && !matchPattern.test(curator) && !matchPattern.test(tags) && !matchPattern.test(clade)) {
                             return false;
                         }
                         // check for filtered workflow state

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -171,7 +171,12 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                     <div class="full-study-ref" style="display: none; overflow: visible;">
                         <div Xclass=""
                              data-bind="html: study['ot:studyPublicationReference']">&nbsp;</div>
-                        <div style="Xfont-size: 90%; margin-top: 3px;" data-bind="html: getPubLink(study)">&nbsp;</div>
+                        <div style="margin-top: 3px; overflow: hidden;">
+                            <span style="color: #999; float: right;">
+                                Study ID: <span data-bind="text: study['ot:studyId']">&nbsp;</span>
+                            </span>
+                            <span style="color: #999; float: left;" data-bind="html: getPubLink(study)"> &nbsp;</span>
+                        </div>
 
                         <label style="display: inline-block" data-bind="visible: (study['ot:tag'])">Tags&nbsp;</label>
                         <div class="bootstrap-tagsinput" 


### PR DESCRIPTION
Despite our desire to hide "internal" identifiers, this is very handy to experienced curators (see e.g. #652). As usual, I've tried to discreetly show the searchable value  in the list results, to avoid mysteries.

@snacktavish, this is live for review on **devtree**. N.B. this only shows complete matches! While most other filters will match partial words, here we don't want to mix unwanted results (pg_112, pg_1181, ...) when searching for study pg_11. 