### PR TITLE
Cleanup of single-study page

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -790,3 +790,7 @@ tr.table-shims td {
 tr.after-shims th {
     border-top: 0;
 }
+
+.form-horizontal.metadata-readonly .control-group {
+  margin-bottom: 12px;
+}

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -46,8 +46,6 @@ response.files.append(URL('static','js/d3.phylogram.js'))
 
 {{extend 'layout.html'}}
 
-<a class="main-title-DOI" style="display: none; position: relative; top: -4px;" href="#" target="_blank">{DOI}</a>
-
 <div class="header-quality-panel" style="margin-bottom: 8px; overflow: hidden;">
     <div style="float: left;">
         Study quality &nbsp;
@@ -247,7 +245,7 @@ body {
           <div class="tab-pane" id="Metadata">
            <div class="span8"><!-- main column... -->
             <ul class="suggestion-list"></ul>
-            <form class="form-horizontal wider-fields">
+            <form class="form-horizontal wider-fields{{= (viewOrEdit == 'VIEW') and ' metadata-readonly' or '' }}">
               <div class="control-group">
                 <label class="control-label" for="ot_studyPublicationReference">Publication reference</label>
                 <div class="controls">
@@ -455,6 +453,13 @@ body {
                  </p>
                  <!-- /ko -->
                 {{ pass }}
+                </div>
+              </div>
+
+              <div class="control-group">
+                <label class="control-label" for="ot_curatorName">Study ID</label>
+                <div class="controls">
+                  <p class="static-form-value" data-bind="text: nexml['^ot:studyId']"></p>
                 </div>
               </div>
 


### PR DESCRIPTION
* removed extra DOI/link to conserve space
* added Study ID to the Metadata tab
* tightened leading for read-only Metadata