### PR TITLE
Link to study diffs

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -935,7 +935,7 @@ function loadSelectedStudy() {
 
             // add external URLs (on GitHub) for the differences between versions
             if (response['shardName']) {
-                $.each(viewModel.versions, function(i, version) {
+                $.each(viewModel.versions(), function(i, version) {
                     version['publicDiffURL'] = ('//github.com/OpenTreeOfLife/'+ response.shardName +'/commit/'+ version.id);
                 });
             }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -932,6 +932,13 @@ function loadSelectedStudy() {
             viewModel.versions = ko.observableArray(
                 response['versionHistory'] || [ ]
             ).asPaged(20);
+
+            // add external URLs (on GitHub) for the differences between versions
+            if (response['shardName']) {
+                $.each(viewModel.versions, function(i, version) {
+                    version['publicDiffURL'] = ('//github.com/OpenTreeOfLife/'+ response.shardName +'/commit/'+ version.id);
+                });
+            }
             
             // take initial stab at setting search context (for focal clade and OTU mapping)
             inferSearchContextFromAvailableOTUs();

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1791,7 +1791,8 @@ body {
                     <tr>
                         <th width="20%">Date</th>
                         <th width="20%">Curated by</th>
-                        <th width="60%">Comment</th>
+                        <th width="50%">Comment</th>
+                        <th width="10%">Details</th>
                     </tr>
                   </thead>
                   <tbody data-bind="foreach: { data: viewModel.versions.pagedItems(), as: 'version' }">
@@ -1799,6 +1800,15 @@ body {
                         <td><span data-bind="text: version['relative_date'], attr: {'title': version['date']}">?</span></td>
                         <td data-bind="text: version['author_name']">?</td>
                         <td><pre class="rendered-comment" data-bind="text: version['message_subject'] + (version['message_body'] ? '\n\n'+ version['message_body'] : '')">?</pre></td>
+                        <td>
+                          <!-- ko if: version['publicDiffURL'] -->
+                            <a href="" target="_blank" title="See detailed differences on GitHub"
+                               data-bind="attr: {'href': version['publicDiffURL']}">Diff view</a>
+                          <!-- /ko -->
+                          <!-- ko if: !version['publicDiffURL'] -->
+                            &mdash;
+                          <!-- /ko -->
+                        </td>
                     </tr>
                   </tbody>
                 </table>


### PR DESCRIPTION
This provides a detailed view (via GitHub's "diff" URL) for each entry in a study's History tab. This is a partial solution pending the development of a friendlier diff view, as discussed in #551.

Note that this depends on API support in the same-named branch of phylesystem-api, but it will fail gracefully if this is not deployed.