### PR TITLE
Fix for broken synth-tree login

### DIFF
--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -38,6 +38,7 @@ function delete_all_forms() {
     });
 }
 function capture_form() {
+    // bind and modify widgets 
     jQuery('div.plugin_localcomments a.msg-close').unbind('click').click(function(){
         delete_all_forms();
         return false;
@@ -64,6 +65,11 @@ function capture_form() {
     }
     // always hide expertise checkbox and surrounding label (not currently needed)
     jQuery('div.plugin_localcomments label.expertise-option').hide();
+
+    // update the Login link, if shown
+    if (typeof(fixLoginLinks) === 'function') {
+        fixLoginLinks();
+    }
 
     jQuery('div.plugin_localcomments :submit').unbind('click').click(function(){
         var $form = jQuery(this).closest('form');


### PR DESCRIPTION
We call the existing (JS) function [**fixLoginLinks**](https://github.com/OpenTreeOfLife/opentree/blob/96d25f2d9e87bd0d71b05d04589a5bbedd4d11a8/webapp/static/js/treeview.js#L596-L614) whenever the browser history changes. In the synth-tree viewer, we were calling this prematurely (before the Login link was created); this needs to be called again whenever a new Login link is created along with our comment form.
