### PR TITLE
Hide the footer message area on page load.

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -37,7 +37,7 @@ function showFooterMessage(msg, msgType) {
     footerMessageCloseID = null;
 
     // replace its contents (may include markup!)
-    $flashArea.find('.message').html(msg);
+    $flashArea.html(msg);
 
     // incoming msgType should be one of the preset values below
     var msgTypes = ['info', 'success', 'error'];
@@ -50,7 +50,8 @@ function showFooterMessage(msg, msgType) {
         }
     });
     
-    // enable the close widget
+    // add and enable the close widget
+    $flashArea.append('<button type="button" id="closeflash" class="close" data-dismiss="alert">&times;</button>');
     $flashArea.find('#closeflash')
         .unbind('click')
         .click( hideFooterMessage );

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -297,10 +297,11 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     </div>
 --><!-- topbar -->
 
-    <div class="flash alert">
-        <!--<button type="button" class="close" data-dismiss="alert">&times;</button>-->
-        <span class="message">{{=response.flash or ''}}</span>
-    </div> <!-- notification div (adapted for Bootstrap) -->
+    <div class="flash alert" style="display: none;"
+        >{{ # NOTE that this DIV must be *completely* empty to stay hidden on page load
+            if response.flash: }}
+        <span class="message">{{=response.flash}}</span>
+         {{ pass }}</div> <!-- notification div (adapted for Bootstrap) -->
     
     <!--
     <div class="header">


### PR DESCRIPTION
This is a minor but long-standing annoyance, where web2py code was detecting a "non-empty" footer message and showing it as each page loads in the curation app.

This is available for review on **devtree**. (The only visible difference should be the lack of a pointless yellow footer message when curation pages load.)