### PR TITLE
Add simple study validation on client side.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1681,8 +1681,16 @@ function updateMappingStatus() {
 }
 
 function validateFormData() {
-    // return success (t/f?), or a structure with validation errors
-    // TODO: or use more typical jQuery machinery, or validation plugin?
+    // Return success (t/f?), and handle errors one at a time
+    // or use more typical jQuery machinery, or validation plugin?
+    // check for a study year (non-empty integer)
+    var studyYear = Number(viewModel.nexml["^ot:studyYear"]);
+    if (isNaN(studyYear) || studyYear === 0) {
+        showErrorMessage('Please enter an non-zero integer for the Study Year (in Metadata tab).');
+        return false;
+    }
+    // TODO: Add other validation logic to match changes on the server side.
+    // return true IF no errors were found!
     return true;
 }
 


### PR DESCRIPTION
This will block attempts to save a study that won't pass the server-side validator. 

<img width="723" alt="screen shot 2015-08-19 at 11 00 01 pm" src="https://cloud.githubusercontent.com/assets/446375/9374660/0ce63ebc-46c6-11e5-9999-6dc5b997b963.png">

Currently this is just a check for a non-zero integer in Metadata > **Study Year**. If we add more checks to the server-side validator, we should anticipate them here for friendlier error message.

