### PR TITLE
Fix supporting-files display (and move old/local annotation messages)

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -6137,6 +6137,10 @@ var nudge = {
         nudgeTickler( 'TREES');
         return true;
     },
+    'SUPPORTING_FILES': function( data, event ) {
+        nudgeTickler( 'SUPPORTING_FILES');
+        return true;
+    },
     'OTU_MAPPING_HINTS': function( data, event ) {
         nudgeTickler( 'OTU_MAPPING_HINTS');
         return true;

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -889,9 +889,16 @@ body {
                     <tr>
                     {{ if viewOrEdit == 'EDIT': }}
                         <td>
-                            <a href="#" target="_blank" data-bind="text: file['@filename'] || '?', attr: { href: file['@url'] || '#' }">
+                          <!-- ko if: file['@url']  -->
+                            <a href="#" target="_blank" data-bind="text: file['@filename'] || '?', attr: { href: file['@url'] }">
                                 Alignment data (urchins).xls
                             </a>
+                          <!-- /ko -->
+                          <!-- ko if: !file['@url'] -->
+                            <span style="color: #999;" data-bind="text: file['@filename'] || '?'" onclick="showErrorMessage('No URL stored for this file!')">
+                                Alignment data (urchins).xls
+                            </span>
+                          <!-- /ko -->
                         </td>
                         <td>
                             <div><textarea data-bind="value: file.description.$"
@@ -908,7 +915,13 @@ body {
                                    placeholder="Tree ID (if source file for a tree)">OPTIONAL_TREE_ID</em>
                            -->
                         </td>
-                        <td><span data-bind="text: getHumanReadableFileSize(file['@size']) || '?'">241 KB</span>
+                        <td>
+                          <!-- ko if: file['@size'] -->
+                            <span data-bind="text: getHumanReadableFileSize(file['@size']) || '?'">241 KB</span>
+                          <!-- /ko -->
+                          <!-- ko if: !file['@size'] -->
+                            &mdash;
+                          <!-- /ko -->
                             <button data-bind="css: viewModel.ticklers.TREES, visible: getAssociatedTrees(file).length > 0"
                                 class="pull-right btn btn-mini btn-danger"
                                 style="opacity: 0.3 !important;"
@@ -922,9 +935,16 @@ body {
                         </td>
                     {{ else: }}
                         <td>
-                            <a href="#" target="_blank" data-bind="text: file['@filename'] || '?', attr: { href: file['@url'] || '#' }">
+                          <!-- ko if: file['@url']  -->
+                            <a href="#" target="_blank" data-bind="text: file['@filename'] || '?', attr: { href: file['@url'] }">
                                 Alignment data (urchins).xls
                             </a>
+                          <!-- /ko -->
+                          <!-- ko if: !file['@url'] -->
+                            <span style="color: #999;" data-bind="text: file['@filename'] || '?'" onclick="showErrorMessage('No URL stored for this file!')">
+                                Alignment data (urchins).xls
+                            </span>
+                          <!-- /ko -->
                         </td>
                         <td>
                             <div data-bind="text: file.description.$">Microsoft Excel spreadsheet</div>
@@ -933,7 +953,14 @@ body {
                                 <strong data-bind="text: getAssociatedTreeLabels(file).join(', ')">&nbsp;</strong>
                             </em>
                         </td>
-                        <td><span data-bind="text: getHumanReadableFileSize(file['@size']) || '?'">241 KB</span></td>
+                        <td>
+                          <!-- ko if: file['@size'] -->
+                            <span data-bind="text: getHumanReadableFileSize(file['@size']) || '?'">241 KB</span>
+                          <!-- /ko -->
+                          <!-- ko if: !file['@size'] -->
+                            &mdash;
+                          <!-- /ko -->
+                        </td>
                     {{ pass }}
                     </tr>
                   </tbody>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -496,10 +496,12 @@ body {
 <!--
                     <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
 -->
-                    <div id="comment-editor"><textarea data-bind="value: viewModel.nexml['^ot:comment']"
-                            placeholder="Enter notes for viewers and other curators here (as markdown)."
-                            rows="8"
-                            class="input-block-level">?</textarea></div>
+                    <div id="comment-editor"><textarea data-bind="value: viewModel.nexml['^ot:comment'], 
+                                                                  valueUpdate: ['afterkeydown', 'input'], 
+                                                                  event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }"
+                                                       placeholder="Enter notes for viewers and other curators here (as markdown)."
+                                                       rows="8"
+                                                       class="input-block-level">?</textarea></div>
                     <div id="comment-preview" class="rendered-comment" style="display: none;">
                     </div>
                 {{ else: }}
@@ -901,11 +903,13 @@ body {
                           <!-- /ko -->
                         </td>
                         <td>
-                            <div><textarea data-bind="value: file.description.$"
-                            placeholder="Describe this file's format and purpose."
-                            rows="2"
-                            class="input-block-level"
-                            style="margin-bottom: 0px;">?</textarea></div>
+                            <div><textarea data-bind="value: file.description.$, 
+                                                      valueUpdate: ['afterkeydown', 'input'], 
+                                                      event: { keyup: nudge.SUPPORTING_FILES, change: nudge.SUPPORTING_FILES }"
+                                           placeholder="Describe this file's format and purpose."
+                                           rows="2"
+                                           class="input-block-level"
+                                           style="margin-bottom: 0px;">?</textarea></div>
                             <em data-bind="if: getAssociatedTrees(file).length > 0">
                                 Source for tree(s):
                                 <strong data-bind="text: getAssociatedTreeLabels(file).join(', ')">&nbsp;</strong>


### PR DESCRIPTION
This started as a set of cosmetic changes intended to improve the supporting-files UI (Files tab in curation app) when we have incomplete file information (see #750).

I've added more code to migrate (move or merge) any old "local" annotation messages to their proper homes inside annotation events of the Nexson `nexml` element. This code works very carefully, only moving those messages it can understand; if any migrations fail, the old message collections are preserved so we can try again later.

I've also added triggers to the file-description **and** curator-notes fields (see #693), so that edits to either will enable the Save button in the curation app.

This is live on **devtree** and ready to merge IMO.