### PR TITLE
Adding a filter 'skip_comments' to get just markup

### DIFF
--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -489,7 +489,10 @@ def index():
     # retrieve related comments, based on the chosen filter
     print("retrieving local comments using this filter:")
     print(filter)
-    if filter == 'synthtree_id,synthtree_node_id':
+    if filter == 'skip_comments':
+        # sometimes we just want the markup/UI (eg, an empty page that's quickly updated by JS)
+        comments = [ ]
+    elif filter == 'synthtree_id,synthtree_node_id':
         comments = get_local_comments({
             "Synthetic tree id": synthtree_id, 
             "Synthetic tree node id": synthtree_node_id})

--- a/webapp/models/plugin_localcomments.py
+++ b/webapp/models/plugin_localcomments.py
@@ -42,7 +42,7 @@ db.plugin_localcomments_comment.created_by.requires = IS_NOT_EMPTY()
 #db.plugin_localcomments_comment.email.requires = IS_EMAIL()
 
 # simplify embedding in a page template
-def plugin_localcomments(filter='synthtree_id,synthtree_node',url='',synthtree_id='',synthtree_node_id='',sourcetree_id='',ottol_id='',target_node_label='',parent_id=None):
+def plugin_localcomments(filter='skip_comments',url='',synthtree_id='',synthtree_node_id='',sourcetree_id='',ottol_id='',target_node_label='',parent_id=None):
     return LOAD('plugin_localcomments',vars=dict(
         filter=filter,  # show messages matching on these fields
         url=url, 

--- a/webapp/views/about/credits.html
+++ b/webapp/views/about/credits.html
@@ -79,7 +79,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/developer_resources.html
+++ b/webapp/views/about/developer_resources.html
@@ -65,7 +65,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/licenses.html
+++ b/webapp/views/about/licenses.html
@@ -220,7 +220,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/materials_and_methods.html
+++ b/webapp/views/about/materials_and_methods.html
@@ -34,7 +34,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/open_tree_of_life.html
+++ b/webapp/views/about/open_tree_of_life.html
@@ -85,7 +85,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/progress.html
+++ b/webapp/views/about/progress.html
@@ -104,9 +104,13 @@ circle.taxo-release-marker {
       <div id="warnings-panel" 
            style="display: none; background-color: #fdd; padding: 1em; border: 1px solid #fcc;"></div>
 
+      <div id="stacked-bar-div"></div>
+
+      <h3 id="comment-header">Comments <i></i></h3>
+      {{=plugin_localcomments(filter='url',url=request.url)}}
+
 </div><!-- end of .container -->
 
-      <div id="stacked-bar-div" />
 <script type="text/javascript">
 // pass statistics as JSON to client for stepping, plotting, etc.
 // NOTE that these are correctly date-sorted from the server!

--- a/webapp/views/about/references.html
+++ b/webapp/views/about/references.html
@@ -122,7 +122,7 @@ div.contributing-studies div.links .tree-links a {
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/synthesis_release.html
+++ b/webapp/views/about/synthesis_release.html
@@ -123,7 +123,7 @@ circle.taxo-release-marker {
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/taxonomy_version.html
+++ b/webapp/views/about/taxonomy_version.html
@@ -61,7 +61,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/the_source_tree_manager.html
+++ b/webapp/views/about/the_source_tree_manager.html
@@ -40,7 +40,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/about/the_synthetic_tree.html
+++ b/webapp/views/about/the_synthetic_tree.html
@@ -40,7 +40,7 @@
       </div>
 
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 

--- a/webapp/views/contact/index.html
+++ b/webapp/views/contact/index.html
@@ -51,7 +51,7 @@
             </table>
 
             <h3 id="comment-header">Comments <i></i></h3>
-            {{=plugin_localcomments(filter='skip_comments',url=request.url)}}
+            {{=plugin_localcomments(filter='url',url=request.url)}}
 
         </div>
     </div>

--- a/webapp/views/contact/index.html
+++ b/webapp/views/contact/index.html
@@ -51,7 +51,7 @@
             </table>
 
             <h3 id="comment-header">Comments <i></i></h3>
-            {{=plugin_localcomments(filter=('url',),url=request.url)}}
+            {{=plugin_localcomments(filter='skip_comments',url=request.url)}}
 
         </div>
     </div>

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -153,7 +153,7 @@
                    # (this will probably be overwritten by tree-view data)
                    url = request.url
                }}
-               {{=plugin_localcomments(filter=('url',),url=url)}}
+               {{=plugin_localcomments(filter='skip_comments',url=url)}}
              </div>
             </div>
            </div>

--- a/webapp/views/subtrees/index.html
+++ b/webapp/views/subtrees/index.html
@@ -72,7 +72,7 @@
           </div>
       </div>
       <h3 id="comment-header">Comments <i></i></h3>
-      {{=plugin_localcomments(filter=('url',),url=request.url)}}
+      {{=plugin_localcomments(filter='url',url=request.url)}}
 
 </div><!-- end of .container -->
 


### PR DESCRIPTION
This gives us the local-comments UI and skips the (laggy) fetch of comments from GitHub. Mainly useful for the synth-tree viewer page, which loads "empty" ASAP and is quickly updated by Javscript.

Also fixed the (old) default filter in most page tempates to be the expected string 'url' instead of a tuple. (This was "working accidentally" on most pages, since the tuple was being ignored but the
default filter was 'url'.)