### PR TITLE
Run a background process to clear old sessions

### DIFF
--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -63,3 +63,12 @@ fi
 
 echo "Restarting apache httpd..."
 sudo apache2ctl graceful || "Sudo failed"
+
+echo "(Re)starting web2py session sweeper..."
+# The sessions2trash.py utility script runs in the background, deleting expired
+# sessions every 5 minutes. See documentation at
+#   http://web2py.com/books/default/chapter/29/13/deployment-recipes#Cleaning-up-sessions
+# Find and kill any instance that's already running
+sudo pkill -f sessions2trash
+# Now run a fresh instance in the background
+sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &

--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -72,4 +72,5 @@ echo "(Re)starting web2py session sweeper..."
 sudo pkill -f sessions2trash
 # Now run a fresh instance in the background for each webapp
 sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
-sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py --expiration=14400 &
+# NOTE that we allow up to 24 hrs(!) before study-curation sessions will expire
+sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py --expiration=86400 &

--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -72,4 +72,4 @@ echo "(Re)starting web2py session sweeper..."
 sudo pkill -f sessions2trash
 # Now run a fresh instance in the background for each webapp
 sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
-sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
+sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py --expiration=14400 &

--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -68,7 +68,8 @@ echo "(Re)starting web2py session sweeper..."
 # The sessions2trash.py utility script runs in the background, deleting expired
 # sessions every 5 minutes. See documentation at
 #   http://web2py.com/books/default/chapter/29/13/deployment-recipes#Cleaning-up-sessions
-# Find and kill any instance that's already running
+# Find and kill any sweepers that are already running
 sudo pkill -f sessions2trash
-# Now run a fresh instance in the background
+# Now run a fresh instance in the background for each webapp
 sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
+sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &


### PR DESCRIPTION
Each time we (re)start web2py, we should also launch a background helper that periodically clobbers expired sessions, every 5 minutes by default.