### PR TITLE
Static (partial) copy of oti's supporting-studies information

### DIFF
--- a/webapp/controllers/hack.py
+++ b/webapp/controllers/hack.py
@@ -1,0 +1,7285 @@
+def oticache():
+    response.view = 'generic.json'
+    if len(request.args) != 1:
+        raise HTTP(400, 'expecting 1 study ID')
+    d = {
+ "ot_102": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 370810,
+    "ot:focalCladeOTTTaxonName": "Pheucticus",
+    "ot:studyId": "ot_102",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.05.022",
+    "ot:studyPublicationReference": "Pulgar\u00edn-R, Paulo C., Brian Tilston Smith, Robert W. Bryson, Garth M. Spellman, John Klicka. 2013. Multilocus phylogeny and biogeography of the New World Pheucticus grosbeaks (Aves: Cardinalidae). Molecular Phylogenetics and Evolution 69 (3): 1222-1227.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "ot_104": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Can't find a URL for this study (JWB).",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 70684,
+    "ot:focalCladeOTTTaxonName": "Gaviiformes",
+    "ot:studyId": "ot_104",
+    "ot:studyPublication": "",
+    "ot:studyPublicationReference": "Boertmann, D. 1990. Phylogeny of the divers, family Gaviidae (Aves). Steenstrupia 16: 21-36.",
+    "ot:studyYear": 1990
+   }
+  ]
+ },
+ "ot_106": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "ot_106",
+    "ot:studyPublication": "http://mbe.oxfordjournals.org/content/19/5/631.short",
+    "ot:studyPublicationReference": "Matte-Tailliez, Oriane, C\u00e9line Brochier, Patrick Forterre and Herv\u00e9 Philippe. 2002. Archaeal phylogeny based on ribosomal proteins. Molecular Biology and Evolution 19 (5): 631-639.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "ot_110": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "ot_110",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.08.010",
+    "ot:studyPublicationReference": "Schweizer, Manuel, Hadoram Shirihai. 2013. Phylogeny of the Oenanthe lugens complex (Aves, Muscicapidae: Saxicolinae): paraphyly of a morphologically cohesive group within a recent radiation of open-habitat chats. Molecular Phylogenetics and Evolution 69 (3): 450-461.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "ot_112": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 609796,
+    "ot:focalCladeOTTTaxonName": "Apodidae",
+    "ot:studyId": "ot_112",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.02.002",
+    "ot:studyPublicationReference": "P\u00e4ckert, Martin, Jochen Martens, Michael Wink, Anna Feigl, Dieter Thomas Tietze. 2012. Molecular phylogeny of Old World swifts (Aves: Apodiformes, Apodidae, Apus and Tachymarptis) based on mitochondrial and nuclear markers. Molecular Phylogenetics and Evolution 63 (3): 606-616.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "ot_116": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 81461,
+    "ot:focalCladeOTTTaxonName": "Aves",
+    "ot:studyId": "ot_116",
+    "ot:studyPublication": "http://dx.doi.org/10.1038/nature11050",
+    "ot:studyPublicationReference": "Hugall, Andrew F., Devi Stuart-Fox. 2012. Accelerated speciation in colour-polymorphic birds. Nature 485 (7400): 631-634.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "ot_118": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 620981,
+    "ot:focalCladeOTTTaxonName": "Megapodiidae",
+    "ot:studyId": "ot_118",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/jbi.12357",
+    "ot:studyPublicationReference": "Harris, Rebecca B., Sharon M. Birks, Adam D. Leach\u00e9. 2014. Incubator birds: biogeographical origins and evolution of underground nesting in megapodes (Galliformes: Megapodiidae). Journal of Biogeography doi: 10.1111/jbi.12357",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "ot_119": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 109893,
+    "ot:focalCladeOTTTaxonName": "Cracidae",
+    "ot:studyId": "ot_119",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/10635150290102519",
+    "ot:studyPublicationReference": "Pereira, Sergio L., Allan J. Baker, Anita Wajntal. 2002. Combined nuclear and mitochondrial DNA sequences resolve generic relationships within the Cracidae (Galliformes, Aves). Systematic Biology 51 (6): 946-958.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "ot_121": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Subspecies not present in OTT.",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 212171,
+    "ot:focalCladeOTTTaxonName": "Cuculiformes",
+    "ot:studyId": "ot_121",
+    "ot:studyPublication": "http://ukcatalogue.oup.com/product/9780198502135.do",
+    "ot:studyPublicationReference": "Payne, Robert B. The cuckoos. Vol. 15. Oxford University Press, 2005. \nISBN-13: 978-0198502135 ISBN-10: 0198502133",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "ot_122": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 472436,
+    "ot:focalCladeOTTTaxonName": "Phoenicopteridae",
+    "ot:studyId": "ot_122",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-14-36",
+    "ot:studyPublicationReference": "Torres, Chris R, Lisa M Ogawa, Mark AF Gillingham, Brittney Ferrari, Marcel van Tuinen. 2014. A multi-locus inference of the evolutionary diversification of extant flamingos (Phoenicopteridae). BMC Evolutionary Biology 14 (1): 36.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "ot_123": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 540029,
+    "ot:focalCladeOTTTaxonName": "Aegotheles",
+    "ot:studyId": "ot_123",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/s1055-7903(03)00135-0",
+    "ot:studyPublicationReference": "Dumbacher, J. 2003. Phylogeny of the owlet-nightjars (Aves: Aegothelidae) based on mitochondrial DNA sequence. Molecular Phylogenetics and Evolution 29 (3): 540-549.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "ot_124": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 966318,
+    "ot:focalCladeOTTTaxonName": "Otididae",
+    "ot:studyId": "ot_124",
+    "ot:studyPublication": "http://dx.doi.org/10.1006/mpev.2001.1078",
+    "ot:studyPublicationReference": "Pitra, Christian, Dietmar Lieckfeldt, Sylke Frahnert, Joerns Fickel. 2002. Phylogenetic relationships and ancestral areas of the bustards (Gruiformes: Otididae), inferred from mitochondrial DNA and nuclear intron sequences. Molecular Phylogenetics and Evolution 23 (1): 63-74.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "ot_125": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 915652,
+    "ot:focalCladeOTTTaxonName": "Psophiidae",
+    "ot:studyId": "ot_125",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2011.1120",
+    "ot:studyPublicationReference": "Ribas, C. C., A. Aleixo, A. C. R. Nogueira, C. Y. Miyaki, J. Cracraft, 2011. A palaeobiogeographic model for biotic diversification within Amazonia over the past three million years. Proceedings of the Royal Society B: Biological Sciences 279 (1729): 681-689.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_129": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 539141,
+    "ot:focalCladeOTTTaxonName": "Musophagidae",
+    "ot:studyId": "ot_129",
+    "ot:studyPublication": "http://dx.doi.org/10.2989/ostrich.2009.80.1.1.759",
+    "ot:studyPublicationReference": "Njabo, Kevin Y, Michael D Sorenson. 2009. Origin of Bannerman's Turaco Tauraco bannermani in relation to historical climate change and the distribution of West African montane forests. Ostrich 80 (1): 1-7.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_136": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 331999,
+    "ot:focalCladeOTTTaxonName": "Jacanidae",
+    "ot:studyId": "ot_136",
+    "ot:studyPublication": "http://dx.doi.org/10.1642/0004-8038(2000)117[0022:mpojai]2.0.co;2",
+    "ot:studyPublicationReference": "Whittingham, Linda A., Frederick H. Sheldon, Stephen T. Emlen. 2000. Molecular phylogeny of jacanas and its implications for morphologic and biogeographic evolution. The Auk 117 (1): 22-32.",
+    "ot:studyYear": 2000
+   }
+  ]
+ },
+ "ot_137": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 452462,
+    "ot:focalCladeOTTTaxonName": "Sulidae",
+    "ot:studyId": "ot_137",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.11.021",
+    "ot:studyPublicationReference": "Patterson, S.A., J.A. Morris-Pocock, V.L. Friesen. 2011. A multilocus phylogeny of the Sulidae (Aves: Pelecaniformes). Molecular Phylogenetics and Evolution 58 (2): 181-191.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_138": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 363013,
+    "ot:focalCladeOTTTaxonName": "Ciconiidae",
+    "ot:studyId": "ot_138",
+    "ot:studyPublication": "http://dx.doi.org/10.1006/mpev.1997.0431",
+    "ot:studyPublicationReference": "Slikas, Beth. 1997. Phylogeny of the avian family Ciconiidae (storks) based on cytochrome b sequences and DNA\u2013DNA hybridization distances. Molecular Phylogenetics and Evolution 8 (3): 275-300.",
+    "ot:studyYear": 1997
+   }
+  ]
+ },
+ "ot_139": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 480157,
+    "ot:focalCladeOTTTaxonName": "Threskiornithidae",
+    "ot:studyId": "ot_139",
+    "ot:studyPublication": "http://dx.doi.org/10.4238/2013.july.30.11",
+    "ot:studyPublicationReference": "Ramirez, J.L., C.Y. Miyaki, S.N. Del Lama. 2013. Molecular phylogeny of Threskiornithidae (Aves: Pelecaniformes) based on nuclear and mitochondrial DNA. Genetics and Molecular Research 12 (3): 2740-2750.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "ot_140": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 969838,
+    "ot:focalCladeOTTTaxonName": "Phalacrocoracidae",
+    "ot:studyId": "ot_140",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2014.06.020",
+    "ot:studyPublicationReference": "Kennedy, Martyn, Hamish G. Spencer. 2014. Classification of the cormorants of the world. Molecular Phylogenetics and Evolution 79: 249-257.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "ot_142": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Thalassarche chrysostoma is not mapping. Suggested synonym of Diomedea chrysostoma is not generally accepted (http://avibase.bsc-eoc.org/species.jsp?lang=EN&avibaseid=0E4475F65B2A8060).",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 85277,
+    "ot:focalCladeOTTTaxonName": "Diomedeidae",
+    "ot:studyId": "ot_142",
+    "ot:studyPublication": "http://notornis.osnz.org.nz/phylogenetic-analysis-24-named-albatross-taxa-based-full-mitochondrial-cytochrome-b-dna-sequences",
+    "ot:studyPublicationReference": "Chambers, GK, Moeke, C, Steel, R, Trueman, JWH. 2009. Phylogenetic analysis of the 24 named albatross taxa based on full mitochondrial cytochrome b DNA sequences. Notornis 56 (2): 82-94.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_144": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Aethia psittacula not mapped. Proposed synonym Cyclorrhynchus psittacula is not generally accepted (http://avibase.bsc-eoc.org/species.jsp?lang=EN&avibaseid=2B46719DC058D033). Pinguinus impennis in taxonomy as Laridae instead of Alcidae (unmapped here).",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 855478,
+    "ot:focalCladeOTTTaxonName": "Alcidae",
+    "ot:studyId": "ot_144",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.11.020",
+    "ot:studyPublicationReference": "Pereira, Sergio L., Allan J. Baker. 2008. DNA evidence for a Paleocene origin of the Alcidae (Aves: Charadriiformes) in the Pacific and multiple dispersals across northern oceans. Molecular Phylogenetics and Evolution 46 (2): 430-445.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "ot_147": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 539129,
+    "ot:focalCladeOTTTaxonName": "Trogonidae",
+    "ot:studyId": "ot_147",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1420-9101.2008.01679.x",
+    "ot:studyPublicationReference": "Ornelas, J. F., C. Gonzalez, and A. Espinosa De Los Monteros. 2009. Uncorrelated evolution between vocal and plumage coloration traits in the trogons: a comparative study. Journal of Evolutionary Biology 22 (3): 471-484.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_148": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 815968,
+    "ot:focalCladeOTTTaxonName": "Meropidae",
+    "ot:studyId": "ot_148",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.07.004",
+    "ot:studyPublicationReference": "Marks, Ben D., Jason D. Weckstein, Robert G. Moyle. 2007. Molecular phylogenetics of the bee-eaters (Aves: Meropidae) based on nuclear and mitochondrial DNA sequence data. Molecular Phylogenetics and Evolution 45 (1): 23-32.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "ot_149": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 815966,
+    "ot:focalCladeOTTTaxonName": "Todidae",
+    "ot:studyId": "ot_149",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2004.01.004",
+    "ot:studyPublicationReference": "Overton, Lowell C, Douglas D Rhoads. 2004. Molecular phylogenetic relationships based on mitochondrial and nuclear gene sequences for the Todies (Todus, Todidae) of the Caribbean. Molecular Phylogenetics and Evolution 32 (2): 524-538.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "ot_150": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Many subspecies missing from taxonomy. If taxonomy if updated, this study will need to be remapped (i.e. so taxa are not mapped to species and descendant subspecies). For now, type subspecies are mapped to species, other left unmapped. (JWB)",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 291635,
+    "ot:focalCladeOTTTaxonName": "Megalaimidae",
+    "ot:studyId": "ot_150",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.03.004",
+    "ot:studyPublicationReference": "den Tex, Robert-Jan, Jennifer A. Leonard. 2013. A molecular phylogeny of Asian barbets: speciation and extinction in the tropics. Molecular Phylogenetics and Evolution 68 (1): 1-13.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "ot_151": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 815707,
+    "ot:focalCladeOTTTaxonName": "Capito",
+    "ot:studyId": "ot_151",
+    "ot:studyPublication": "http://dx.doi.org/10.1650/0010-5422(2005)107[0527:gvimds]2.0.co;2",
+    "ot:studyPublicationReference": "Armenta, Jessica K., Jason D. Weckstein, Daniel F. Lane. 2005. Geographic variation in mitochondrial DNA sequences of an Amazonian nonpasserine: The Black-spotted Barbet complex. The Condor 107 (3): 527-536.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "ot_152": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1068261,
+    "ot:focalCladeOTTTaxonName": "Ramphastos",
+    "ot:studyId": "ot_152",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2009.08.017",
+    "ot:studyPublicationReference": "Patan\u00e9, Jos\u00e9 S.L., Jason D. Weckstein, Alexandre Aleixo, John M. Bates. 2009. Evolutionary history of Ramphastos toucans: molecular phylogenetics, temporal diversification, and biogeography. Molecular Phylogenetics and Evolution 53 (3): 923-934.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_153": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 291645,
+    "ot:focalCladeOTTTaxonName": "Pteroglossus",
+    "ot:studyId": "ot_153",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.10.016",
+    "ot:studyPublicationReference": "Patel, Swati, Jason D. Weckstein, Jos\u00e9 S.L. Patan\u00e9, John M. Bates, Alexandre Aleixo. 2011. Temporal and spatial diversification of Pteroglossus ara\u00e7aris (Aves: Ramphastidae) in the neotropics: constant rate of diversification does not support an increase in radiation during the Pleistocene. Molecular Phylogenetics and Evolution 58 (1): 105-115.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_154": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 489463,
+    "ot:focalCladeOTTTaxonName": "Ramphastidae",
+    "ot:studyId": "ot_154",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.06.017",
+    "ot:studyPublicationReference": "Lutz, Holly L., Jason D. Weckstein, Jos\u00e9 S.L. Patan\u00e9, John M. Bates, Alexandre Aleixo. 2013. Biogeography and spatio-temporal diversification of Selenidera and Andigena Toucans (Aves: Ramphastidae). Molecular Phylogenetics and Evolution 69 (3): 873-883.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "ot_155": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 291853,
+    "ot:focalCladeOTTTaxonName": "Aulacorhynchus",
+    "ot:studyId": "ot_155",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1463-6409.2011.00475.x",
+    "ot:studyPublicationReference": "Bonaccorso, Elisa, Juan M. Guayasamin, A. Townsend Peterson, Adolfo G. Navarro-Sig\u00fcenza. 2011. Molecular phylogeny and systematics of Neotropical toucanets in the genus Aulacorhynchus (Aves, Ramphastidae). Zoologica Scripta 40 (4): 336-349.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_156": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "ot_156",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/s1055-7903(03)00179-9",
+    "ot:studyPublicationReference": "Moyle, Robert G. 2004. Phylogenetics of barbets (Aves: Piciformes) based on nuclear and mitochondrial DNA sequence data. Molecular Phylogenetics and Evolution 30 (1): 187-200.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "ot_157": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 724182,
+    "ot:focalCladeOTTTaxonName": "Celeus",
+    "ot:studyId": "ot_157",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.05.001",
+    "ot:studyPublicationReference": "Benz, Brett W., Mark B. Robbins. 2011. Molecular phylogenetics, vocalizations, and species limits in Celeus woodpeckers (Aves: Picidae). Molecular Phylogenetics and Evolution 61 (1): 29-44.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_158": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1020136,
+    "ot:focalCladeOTTTaxonName": "Colaptes",
+    "ot:studyId": "ot_158",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.09.011",
+    "ot:studyPublicationReference": "Moore, William S., Lowell C. Overton, Kathleen J. Miglia. 2011. Mitochondrial DNA based phylogeny of the woodpecker genera Colaptes and Piculus, and implications for the history of woodpecker diversification in South America. Molecular Phylogenetics and Evolution 58 (1): 76-84.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_159": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1020138,
+    "ot:focalCladeOTTTaxonName": "Picidae",
+    "ot:studyId": "ot_159",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2006.02.021",
+    "ot:studyPublicationReference": "Benz, Brett W., Mark B. Robbins, A. Townsend Peterson. 2006. Evolutionary history of woodpeckers and allies (Aves: Picidae): placing key taxa on the phylogenetic tree. Molecular Phylogenetics and Evolution 40 (2): 389-399.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "ot_160": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Callocephalon fimbriatum not currently in Cacatuidae in taxonomy. Left unmapped here. (JWB)",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 512919,
+    "ot:focalCladeOTTTaxonName": "Cacatuidae",
+    "ot:studyId": "ot_160",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.03.011",
+    "ot:studyPublicationReference": "White, Nicole E., Matthew J. Phillips, M. Thomas P. Gilbert, Alonzo Alfaro-N\u00fa\u00f1ez, Eske Willerslev, Peter R. Mawson, Peter B.S. Spencer, Michael Bunce. 2011. The evolutionary history of cockatoos (Aves: Psittaciformes: Cacatuidae). Molecular Phylogenetics and Evolution 59 (3): 615-622.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_161": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Alipiopsitta xanthops is in taxonomy, but so is older invalid name Amazona xanthops. (JWB)",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 135928,
+    "ot:focalCladeOTTTaxonName": "Amazona",
+    "ot:studyId": "ot_161",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/s1055-7903(03)00192-1",
+    "ot:studyPublicationReference": "Russello, Michael A, George Amato. 2004. A molecular phylogeny of Amazona: implications for Neotropical parrot biogeography, taxonomy, and conservation. Molecular Phylogenetics and Evolution 30 (2): 421-437.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "ot_162": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 108566,
+    "ot:focalCladeOTTTaxonName": "Prioniturus",
+    "ot:studyId": "ot_162",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1439-0469.2012.00654.x",
+    "ot:studyPublicationReference": "Schweizer, Manuel, Marcel G\u00fcntert, Stefan T. Hertwig. 2012. Phylogeny and biogeography of the parrot genus Prioniturus (Aves: Psittaciformes). Journal of Zoological Systematics and Evolutionary Research 50 (2): 145-156.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "ot_164": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 851006,
+    "ot:focalCladeOTTTaxonName": "Brotogeris",
+    "ot:studyId": "ot_164",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-2699.2009.02131.x",
+    "ot:studyPublicationReference": "Ribas, Camila C., Cristina Y. Miyaki, Joel Cracraft. 2009. Phylogenetic relationships, diversification and biogeography in Neotropical Brotogeris parakeets. Journal of Biogeography 36 (9): 1712-1729.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_165": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 301840,
+    "ot:focalCladeOTTTaxonName": "Forpus",
+    "ot:studyId": "ot_165",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/mec.12118",
+    "ot:studyPublicationReference": "Smith, Brian Tilston, Camila C. Ribas, Bret M. Whitney, Blanca E. Hern\u00c1ndez-ba\u00d1os, John Klicka. 2012. Identifying biases at different spatial and temporal scales of diversification: a case study in the Neotropical parrotlet genus Forpus. Molecular Ecology 22 (2): 483-494.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "ot_166": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1020130,
+    "ot:focalCladeOTTTaxonName": "Psittacidae",
+    "ot:studyId": "ot_166",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1463-6409.2012.00567.x",
+    "ot:studyPublicationReference": " Quintero, Esther, Camila C. Ribas, Joel Cracraft. 2012. The Andean Hapalopsittaca parrots (Psittacidae, Aves): an example of montane-tropical lowland vicariance. Zoologica Scripta 42 (1): 28-43.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "ot_167": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 416103,
+    "ot:focalCladeOTTTaxonName": "Pyrrhura",
+    "ot:studyId": "ot_167",
+    "ot:studyPublication": "http://dx.doi.org/10.1642/0004-8038(2006)123[660:msapod]2.0.co;2",
+    "ot:studyPublicationReference": "Ribas, Camila C., Leo Joseph, Cristina Y. Miyaki. 2006. Molecular systematics and patterns of diversification in Pyrrhura (Psittacidae), with special reference to the picta-leucotis complex. The Auk 123 (3): 660-680.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "ot_168": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 813030,
+    "ot:focalCladeOTTTaxonName": "Pteropus",
+    "ot:studyId": "ot_168",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2014.03.009",
+    "ot:studyPublicationReference": "Almeida, Francisca C., Norberto P. Giannini, Nancy B. Simmons, Kristofer M. Helgen. 2014. Each flying fox on its own branch: a phylogenetic tree for Pteropus and related genera (Chiroptera: Pteropodidae). Molecular Phylogenetics and Evolution 77: 83-95.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "ot_170": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 3599326,
+    "ot:focalCladeOTTTaxonName": "Regulus",
+    "ot:studyId": "ot_170",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s10336-008-0335-5",
+    "ot:studyPublicationReference": "P\u00e4ckert, Martin , Jochen Martens, Lucia Liu Severinghaus. 2009. The Taiwan Firecrest (Regulus goodfellowi) belongs to the Goldcrest assemblage (Regulus regulus s. l.): evidence from mitochondrial DNA and the territorial song of the Regulidae. Journal of Ornithology 150 (1): 205-220.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_172": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1041547,
+    "ot:focalCladeOTTTaxonName": "Passeriformes",
+    "ot:studyId": "ot_172",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-2699.2011.02606.x",
+    "ot:studyPublicationReference": "P\u00e4ckert, Martin, Jochen Martens, Yue-Hua Sun, Lucia Liu Severinghaus, Alexander A. Nazarenko, Ji Ting, Till T\u00f6pfer, Dieter Thomas Tietze. 2011. Horizontal and elevational phylogeographic patterns of Himalayan and Southeast Asian forest passerines (Aves: Passeriformes). Journal of Biogeography 39 (3): 556-573.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_173": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 119892,
+    "ot:focalCladeOTTTaxonName": "Poecile",
+    "ot:studyId": "ot_173",
+    "ot:studyPublication": "http://onlinelibrary.wiley.com/doi/10.1111/evo.12280/full",
+    "ot:studyPublicationReference": "Harris, R.B., M.D. Carling, I.J. Lovette. 2014. The influence sampling design on species tree inference: a new relationship for the New World chickadees (Aves: Poecile). Evolution 68 (2): 501-513.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "ot_174": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 21006,
+    "ot:focalCladeOTTTaxonName": "Rhipidura",
+    "ot:studyId": "ot_174",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1463-6409.2009.00397.x",
+    "ot:studyPublicationReference": "Ny\u00e1ri, \u00c1rp\u00e1d S., Brett W. Benz, Knud A. J\u00f8nsson, Jon Fjelds\u00e5, Robert G. Moyle. 2009. Phylogenetic relationships of fantails (Aves: Rhipiduridae). Zoologica Scripta 38 (6): 553-561.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "ot_176": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 136029,
+    "ot:focalCladeOTTTaxonName": "Tachycineta",
+    "ot:studyId": "ot_176",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.12.014",
+    "ot:studyPublicationReference": "Cerasale, David J., Roi Dor, David W. Winkler, Irby J. Lovette. 2012. Phylogeny of the Tachycineta genus of New World swallows: insights from complete mitochondrial genomes. Molecular Phylogenetics and Evolution 63 (1): 64-71.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "ot_177": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 897677,
+    "ot:focalCladeOTTTaxonName": "Hirundo",
+    "ot:studyId": "ot_177",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.02.008",
+    "ot:studyPublicationReference": "Dor, Roi, Rebecca J. Safran, Frederick H. Sheldon, David W. Winkler, Irby J. Lovette. 2010. Phylogeny of the genus Hirundo and the Barn Swallow subspecies complex. Molecular Phylogenetics and Evolution 56 (1): 409-418.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "ot_178": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 897681,
+    "ot:focalCladeOTTTaxonName": "Hirundinidae",
+    "ot:studyId": "ot_178",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2004.11.008",
+    "ot:studyPublicationReference": "Sheldon, Frederick H., Linda A. Whittingham, Robert G. Moyle, Beth Slikas, David W. Winkler. 2005. Phylogeny of swallows (Aves: Hirundinidae) estimated from nuclear and mitochondrial DNA sequences. Molecular Phylogenetics and Evolution 35 (1): 254-270.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "ot_181": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 78477,
+    "ot:focalCladeOTTTaxonName": "Selachii",
+    "ot:studyId": "ot_181",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.11.018",
+    "ot:studyPublicationReference": "V\u00e9lez-Zuazo, Ximena, Ingi Agnarsson. 2011. Shark tales: a molecular species-level phylogeny of sharks (Selachimorpha, Chondrichthyes). Molecular Phylogenetics and Evolution 58 (2): 207-217.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "ot_182": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 395057,
+    "ot:focalCladeOTTTaxonName": "Nematoda",
+    "ot:studyId": "ot_182",
+    "ot:studyPublication": "http://dx.doi.org/10.1038/32160",
+    "ot:studyPublicationReference": "Blaxter, Mark L., Paul De Ley, James R. Garey, Leo X. Liu, Patsy Scheldeman, Andy Vierstraete, Jacques R. Vanfleteren, Laura Y. Mackey, Mark Dorris, Linda M. Frisse, J. T. Vida, W. Kelley Thomas. 1998. A molecular evolutionary framework for the phylum Nematoda. Nature 392 (6671): 71-75.",
+    "ot:studyYear": 1998
+   }
+  ]
+ },
+ "ot_183": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 395057,
+    "ot:focalCladeOTTTaxonName": "Nematoda",
+    "ot:studyId": "ot_183",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-13-12",
+    "ot:studyPublicationReference": "Sultana, Tahera, Jiyeon Kim, Sang-Hwa Lee, Hyerim Han, Sanghee Kim, Gi-Sik Min, Steven A Nadler, Joogn-Ki Park. 2013. Comparative analysis of complete mitochondrial genome sequences confirms independent origins of plant-parasitic nematodes. BMC Evolutionary Biology 13 (1): 12.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "ot_185": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Previous study was corrupted. Replacing here. (JWB).",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 965954,
+    "ot:focalCladeOTTTaxonName": "Lepidoptera",
+    "ot:studyId": "ot_185",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2014.0970",
+    "ot:studyPublicationReference": "Kawahara, A. Y., J. W. Breinholt. 2014. Phylogenomics provides strong evidence for relationships of butterflies and moths. Proceedings of the Royal Society B: Biological Sciences 281 (1788): 20140970-20140970.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_1022": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 399488,
+    "ot:focalCladeOTTTaxonName": "Pontederiaceae",
+    "ot:studyId": "pg_1022",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/molbev/msr119",
+    "ot:studyPublicationReference": "Ness, R. W. [et al. 2011], Graham, S. W., & Barrett, S. C. H. 2011. Reconciling gene and genome duplication events: Using multiple gene families to infer the phylogeny of the aquatic plant family Pontederiaceae. Mol. Biol. Evol. 28: 3009-3018.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1087": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2146",
+    "ot:focalClade": 560323,
+    "ot:focalCladeOTTTaxonName": "Fabaceae",
+    "ot:studyId": "pg_1087",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364409787602221",
+    "ot:studyPublicationReference": "Stefanovic, S. [et al. 2009], Pfeil, B. E., Palmer, J. D., & Doyle, J. J. 2009. Relationships Among Phaseoloid Legumes Based on Sequences from Eight Chloroplast Regions. Syst. Bot. 34: 115-128.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1094": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S749",
+    "ot:focalClade": 266257,
+    "ot:focalCladeOTTTaxonName": "Sarcostemma",
+    "ot:studyId": "pg_1094",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/BF00985463",
+    "ot:studyPublicationReference": "Liede S., & Tuber A. 2000. Sarcostemma R. Br. (Apocynaceae - Asclepiadoideae) - a Controversial Generic Circumscription Reconsidered: Evidence from trnL-F Spacers. Plant Systematics and Evolution, 225: 133-140.",
+    "ot:studyYear": 2000
+   }
+  ]
+ },
+ "pg_1101": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 1014022,
+    "ot:focalCladeOTTTaxonName": "Rubiaceae",
+    "ot:studyId": "pg_1101",
+    "ot:studyPublicationReference": "Soza, V. L., & Olmstead, R. G. (2010). Molecular systematics of tribe Rubieae (Rubiaceae): Evolution of major clades, development of leaf-like whorls, and biogeography. Taxon, 59(3), 755-771.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1102": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Karen Cranston",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11078",
+    "ot:focalClade": 671540,
+    "ot:focalCladeOTTTaxonName": "Collinsia (genus in tribe Cheloneae)",
+    "ot:studyId": "pg_1102",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000346",
+    "ot:studyPublicationReference": "Baldwin B.G., Kalisz S., & Armbruster W.S. 2011. Phylogenetic perspectives on diversification, biogeography, and floral evolution of Collinsia and Tonella (Plantaginaceae). American Journal of Botany, 98(4): 731-753.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1103": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 285687,
+    "ot:focalCladeOTTTaxonName": "Bignonieae",
+    "ot:studyId": "pg_1103",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1095-8339.2012.01311.x",
+    "ot:studyPublicationReference": "Lohmann, L. G., Bell, C. D., Cali\u00f3, M. F., & Winkworth, R. C. (2013). Pattern and timing of biogeographical history in the Neotropical tribe Bignonieae (Bignoniaceae). Botanical Journal of the Linnean Society, 171(1), 154-170.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_1109": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10016",
+    "ot:focalClade": 317400,
+    "ot:focalCladeOTTTaxonName": "Castilleja",
+    "ot:studyId": "pg_1109",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0800416",
+    "ot:studyPublicationReference": "Tank D., & Olmstead R. 2009. The evolutionary origin of a second radiation of annual Castilleja (Orobanchaceae) species in South America: the role of long distance dispersal and allopolyploidy. American Journal of Botany, 96: 1907-1921.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1118": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12395",
+    "ot:focalClade": 394658,
+    "ot:focalCladeOTTTaxonName": "Nepetoideae",
+    "ot:studyId": "pg_1118",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1100549",
+    "ot:studyPublicationReference": "Drew, B. T., & Sytsma, K. J. (2012). Phylogenetics, biogeography, and staminal evolution in the tribe Mentheae (Lamiaceae). American Journal of Botany, 99(5), 933-953.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_1129": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10282",
+    "ot:focalClade": 1020645,
+    "ot:focalCladeOTTTaxonName": "Solanum",
+    "ot:studyId": "pg_1129",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410X539934",
+    "ot:studyPublicationReference": "Stern, S. R., Weese, T., & Bohs, L. A. (2010). Phylogenetic relationships in Solanum section Androceras (Solanaceae). Systematic botany, 35(4), 885-893.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1130": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 797191,
+    "ot:focalCladeOTTTaxonName": "Nicotiana",
+    "ot:studyId": "pg_1130",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2004.05.002",
+    "ot:studyPublicationReference": "Clarkson, J. J., Knapp, S., Garcia, V. F., Olmstead, R. G., Leitch, A. R., & Chase, M. W. (2004). Phylogenetic relationships in Nicotiana (Solanaceae) inferred from multiple plastid DNA regions. Molecular phylogenetics and evolution, 33(1), 75-90.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_1131": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12254",
+    "ot:focalClade": 1035588,
+    "ot:focalCladeOTTTaxonName": "Saxifragaceae",
+    "ot:studyId": "pg_1131",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.04.010",
+    "ot:studyPublicationReference": "Xiang C., Gitzendanner M.A., Soltis D., Peng H., & Lei L. 2012. Phylogenetic placement of the enigmatic and critically endangered genus Saniculiphyllum (Saxifragaceae) inferred from combined analysis of plastid and nuclear DNA sequences. Molecular Phylogenetics and Evolution, 64: 357-367.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_1133": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11237",
+    "ot:focalClade": 208031,
+    "ot:focalCladeOTTTaxonName": "Rosales",
+    "ot:studyId": "pg_1133",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.04.008",
+    "ot:studyPublicationReference": "Zhang S., Soltis D., Li D., Yang Y., & Yi T. 2011. Multi-gene analysis provides a well-supported phylogeny of Rosales. Molecular Phylogenetics and Evolution, 60(1): 21-8.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1137": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1007",
+    "ot:focalClade": 545823,
+    "ot:focalCladeOTTTaxonName": "Erythronium",
+    "ot:studyId": "pg_1137",
+    "ot:studyPublication": "http://dx.doi.org/10.1043/02-18.1",
+    "ot:studyPublicationReference": "Allen G., Soltis D., & Soltis P. 2003. Phylogeny and biogeography of Erythronium (Liliaceae) inferred from chloroplast matK and nuclear rDNA ITS sequences. Systematic Botany, 28(3): 512-523.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_1252": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11410",
+    "ot:focalClade": 653857,
+    "ot:focalCladeOTTTaxonName": "Anomura",
+    "ot:studyId": "pg_1252",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syr063",
+    "ot:studyPublicationReference": "Tsang, L., Chan T., Ahyong S., & Chu K. 2011. Hermit to king, or hermit to all: Multiple transitions to crab-like forms from hermit crab ancestors. Systematic Biology 60 (5): 616-629.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_126": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1391",
+    "ot:focalClade": 1020645,
+    "ot:focalCladeOTTTaxonName": "Solanum",
+    "ot:studyId": "pg_126",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.93.1.157",
+    "ot:studyPublicationReference": "Levin, R. A., Myers, N. R., & Bohs, L. (2006). Phylogenetic relationships among the \u201cspiny solanums\u201d(Solanum subgenus Leptostemonum, Solanaceae). American Journal of Botany, 93(1), 157-169.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1264": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1550",
+    "ot:focalClade": 113193,
+    "ot:focalCladeOTTTaxonName": "Isoetaceae",
+    "ot:studyId": "pg_1264",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406778388511",
+    "ot:studyPublicationReference": "Hoot, S. B., Taylor, W. C., & Napier, N. S. (2006). Phylogeny and biogeography of Iso\u00ebtes (Iso\u00ebtaceae) based on nuclear and chloroplast DNA sequence data. Systematic botany, 31(3), 449-460.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1268": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13448",
+    "ot:focalClade": 738980,
+    "ot:focalCladeOTTTaxonName": "Anthocerotophyta",
+    "ot:studyId": "pg_1268",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.1213498109",
+    "ot:studyPublicationReference": "Villarreal, J. C., & Renner, S. S. (2012). Hornwort pyrenoids, carbon-concentrating structures, evolved and were lost at least five times during the last 100 million years. Proceedings of the National Academy of Sciences, 109(46), 18873-18878.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_1278": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1574",
+    "ot:focalClade": 56601,
+    "ot:focalCladeOTTTaxonName": "Marchantiophyta",
+    "ot:studyId": "pg_1278",
+    "ot:studyPublication": "http://dx.doi.org/10.1639/0007-2745(2006)109[303:UTEHOT]2.0.CO;2",
+    "ot:studyPublicationReference": "Forrest L., Davis E., Long D., Crandall-stotler B., Clark A., & Hollingsworth M.\r\n2006. Unraveling the evolutionary history of the liverworts (Marchantiophyta): multiple\r\ntaxa, genomes and analyses. The Bryologist, 109(3): 303-334.",
+    "ot:studyYear": 2006,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_131": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1451",
+    "ot:focalClade": 935477,
+    "ot:focalCladeOTTTaxonName": "Trifolium",
+    "ot:studyId": "pg_131",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2006.01.004",
+    "ot:studyPublicationReference": "Ellison N., Liston A., Steiner J., Williams W., & Taylor N. 2006. Molecular phylogenetics of the clover genus (Trifolium--Leguminosae). Molecular Phylogenetics and Evolution, 39(3): 688-705.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1312": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1142",
+    "ot:focalClade": 258885,
+    "ot:focalCladeOTTTaxonName": "Polypodiidae",
+    "ot:studyId": "pg_1312",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364404774195476",
+    "ot:studyPublicationReference": "Schneider, H., Russell, S. J., Cox, C. J., Bakker, F., Henderson, S., Rumsey, F., ... & Vogel, J. C. (2004). Chloroplast phylogeny of asplenioid ferns based on rbcL and trnL-F spacer sequences (Polypodiidae, Aspleniaceae) and its implications for biogeography. Systematic Botany,29(2), 260-274.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_1318": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10671",
+    "ot:focalClade": 667483,
+    "ot:focalCladeOTTTaxonName": "Polypodiaceae",
+    "ot:studyId": "pg_1318",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410X539790",
+    "ot:studyPublicationReference": "Sundue, M. A., Islam, M. B., & Ranker, T. A. (2010). Systematics of grammitid ferns (Polypodiaceae): using morphology and plastid sequence data to resolve the circumscriptions of Melpomene and the polyphyletic genera Lellingeria and Terpsichore. Systematic Botany, 35(4), 701-715.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1336": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1784",
+    "ot:focalClade": 935379,
+    "ot:focalCladeOTTTaxonName": "Brachyura",
+    "ot:studyId": "pg_1336",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.03.022 ",
+    "ot:studyPublicationReference": "Ahyong, S., Lai J., Sharkey D., Colgan D., & Ng P. 2007. Phylogenetics of the brachyuran crabs (Crustacea: Decapoda): the status of Podotremata based on small subunit nuclear ribosomal RNA. Molecular Phylogenetics and Evolution 45 (2): 576-586.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1337": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10107",
+    "ot:focalClade": 1082885,
+    "ot:focalCladeOTTTaxonName": "Endopterygota",
+    "ot:studyId": "pg_1337",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1741-7007-7-34",
+    "ot:studyPublicationReference": "Wiegmann, B., Trautwein M., Kim J., Bertone M., Winterton S., Cassel B., & Yeates D. 2009. Nuclear genes resolve the phylogeny of the holometabolous insects. BMC Biology 7(34): 34.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1338": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10115",
+    "ot:focalClade": 1048707,
+    "ot:focalCladeOTTTaxonName": "Pterygota",
+    "ot:studyId": "pg_1338",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/molbev/msp191",
+    "ot:studyPublicationReference": "Simon, S., Strauss S., Von haeseler A., & Hadrys H. 2009. A phylogenomic approach to resolve the basal pterygote divergence. Molecular Biology and Evolution 26 (12): 2719-2730.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1343": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2236",
+    "ot:focalClade": 154397,
+    "ot:focalCladeOTTTaxonName": "Hexactinella",
+    "ot:studyId": "pg_1343",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2009.01.010",
+    "ot:studyPublicationReference": "Dohrmann, M., Janussen D., Reitner J., Collins A., and Woerheide G. 2009. Phylogeny of glass sponges (Porifera, Hexactinellida): monophyly of Lyssacinosida and position of additional taxa. Molecular Phylogenetics and Evolution 57 (3): 388-405.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_136": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1611",
+    "ot:focalClade": 904624,
+    "ot:focalCladeOTTTaxonName": "Cestrum",
+    "ot:studyId": "pg_136",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406779695979",
+    "ot:studyPublicationReference": "Carlos Montero-Castro, J., Delgado-Salinas, A., De Luna, E., & Eguiarte, L. E. (2006). Phylogenetic Analysisof Cestrum Section Habrothamnus (Solanaceae) Based on Plastid and Nuclear DNA Sequences. Systematic botany, 31(4), 843-850.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1366": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10986",
+    "ot:focalClade": 941620,
+    "ot:focalCladeOTTTaxonName": "Annelida",
+    "ot:studyId": "pg_1366",
+    "ot:studyPublication": "http://dx.doi.org/10.1038/nature09864",
+    "ot:studyPublicationReference": "Struck, T.H., Paul C., Hill N., Hartmann S., H\u00f6sel C., Kube M., Lieb B., Meyer A., Tiedemann R., Purschke G., & Bleidorn C. 2011. Phylogenomic analyses unravel annelid evolution. Nature 471 (7336): 95-98.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1382": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1511",
+    "ot:focalClade": 878953,
+    "ot:focalCladeOTTTaxonName": "Rhodophyceae",
+    "ot:studyId": "pg_1382",
+    "ot:studyPublication": "http://dx.doi.org/10.2216/0031-8884(2005)44[530:MEFRAS]2.0.CO;2",
+    "ot:studyPublicationReference": "Lee S., Lee I., & Suh Y. 2005. Molecular evidence for recognizing Antithamnion sparsum (Ceramiales, Rhodophyta) at the species level. Phycologia, 44: 530-535.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_1384": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2064",
+    "ot:focalClade": 1036836,
+    "ot:focalCladeOTTTaxonName": "Gracilariaceae",
+    "ot:studyId": "pg_1384",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.aquabot.2008.03.008,",
+    "ot:studyPublicationReference": "Guillemin M., Akki S., Givernaud T., Mouradi A., Valero M., & Destombe C. 2008. Molecular characterisation and development of rapid molecular methods to identify species of Gracilariaceae from the Atlantic coast of Morocco. Aquatic Botany,Volume 89, Issue 3, October 2008, Pages 324\u2013330",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_139": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1780",
+    "ot:focalClade": 1080361,
+    "ot:focalCladeOTTTaxonName": "Nierembergia",
+    "ot:studyId": "pg_139",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364409787602249",
+    "ot:studyPublicationReference": "Tate, J. A., Acosta, M. C., McDill, J., Moscone, E. A., Simpson, B. B., & Cocucci, A. A. (2009). Phylogeny and character evolution in Nierembergia (Solanaceae): Molecular, morphological, and cytogenetic evidence. Systematic Botany, 34(1), 198-206.",
+    "ot:studyYear": 2007,
+    "ot:tag": "ingroup added for Fig. 1"
+   }
+  ]
+ },
+ "pg_1391": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1435",
+    "ot:focalClade": 781622,
+    "ot:focalCladeOTTTaxonName": "Dioscorea",
+    "ot:studyId": "pg_1391",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364405775097879",
+    "ot:studyPublicationReference": "Wilkin, P., Schols, P., Chase, M. W., Chayamarit, K., Furness, C. A., Huysmans, S., ... & Thapyai, C. (2005). A plastid gene phylogeny of the yam genus, Dioscorea: roots, fruits and Madagascar. Systematic Botany, 30(4), 736-749.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_14": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Rick Ree",
+    "ot:focalClade": 900321,
+    "ot:focalCladeOTTTaxonName": "Bignoniaceae",
+    "ot:studyId": "pg_14",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0900004",
+    "ot:studyPublicationReference": "Olmstead, Richard G., Michelle L. Zjhra, Lucia G. Lohmann, Susan O. Grose, and Andrew J. Eckert. 2009. A molecular phylogeny and classification of Bignoniaceae. Am. J. Bot. 96, no. 9 (September 1): 1731-1743. doi:10.3732/ajb.0900004.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1401": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1459",
+    "ot:focalClade": 48773,
+    "ot:focalCladeOTTTaxonName": "Dactylorhiza",
+    "ot:studyId": "pg_1401",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2005.11.013",
+    "ot:studyPublicationReference": "Devos, N., Rasp\u00e9, O., Oh, S. H., Tyteca, D., & Jacquemart, A. L. (2006). The evolution of Dactylorhiza (Orchidaceae) allotetraploid complex: insights from nrDNA sequences and cpDNA PCR-RFLP data. Molecular Phylogenetics and Evolution, 38(3) 767\u2013778.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_1407": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1094",
+    "ot:studyId": "pg_1407",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364404772973988",
+    "ot:studyPublicationReference": "Gravendeel B., Eurlings M., Van den berg C., & Cribb P. 2004. Phylogeny of Pleione (Orchidaceae) and parentage analysis of its wild hybrids based on plastid and nrITS sequences and morphological data. Systematic Botany. (14)50-63",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_1408": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10104",
+    "ot:focalClade": 568878,
+    "ot:focalCladeOTTTaxonName": "Orchidaceae",
+    "ot:studyId": "pg_1408",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410790862489",
+    "ot:studyPublicationReference": "Kennedy A.H., & Watson L. 2010. Species Delimitations and Phylogenetic Relationships within in the Fully Myco-heterotrophic Hexalectris (Orchidaceae). Systematic Botany, 35(1): 64-76.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1409": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S169",
+    "ot:focalClade": 568878,
+    "ot:focalCladeOTTTaxonName": "Orchidaceae",
+    "ot:studyId": "pg_1409",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/BF00937844",
+    "ot:studyPublicationReference": "Kurzweil H., Linder H., & Chesselet P. 1991. The phylogeny and evolution of the Pterygodium-Corycium complex (Coryciinae, Orchidaceae). Plant Systematics and Evolution, 175: 161-223",
+    "ot:studyYear": 1991
+   }
+  ]
+ },
+ "pg_1411": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2166",
+    "ot:focalClade": 406696,
+    "ot:focalCladeOTTTaxonName": "Catasetinae",
+    "ot:studyId": "pg_1411",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410792495944",
+    "ot:studyPublicationReference": "Monteiro S., Selbach-schnadelbach A., De oliveira R., & Van den berg C. 2010. Molecular phylogenetics of Galeandra (Orchidaceae: Catasetinae) based on plastid and nuclear DNA sequences. Systematic Botany, 35(3): 476-486.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1414": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1221",
+    "ot:focalClade": 568878,
+    "ot:focalCladeOTTTaxonName": "Orchidaceae",
+    "ot:studyId": "pg_1414",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644054223530",
+    "ot:studyPublicationReference": "Van der niet T., Linder H., Bytebier B., & Bellstedt D. 2004. Molecular arkers reject monophyly of the subgenera of Satyrium (Orchidaceae). Systematic Botany,30(2):263-274",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_142": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11225",
+    "ot:focalClade": 583848,
+    "ot:focalCladeOTTTaxonName": "Asclepias",
+    "ot:studyId": "pg_142",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X605010",
+    "ot:studyPublicationReference": "Fishbein, M., Chuba, D., Ellison, C., Mason-Gamer, R. J., & Lynch, S. P. (2011). Phylogenetic relationships of Asclepias (Apocynaceae) inferred from non-coding chloroplast DNA sequences. Systematic Botany, 36(4), 1008-1023.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1428": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11872",
+    "ot:focalClade": 244265,
+    "ot:focalCladeOTTTaxonName": "Mammalia",
+    "ot:studyId": "pg_1428",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1211028",
+    "ot:studyPublicationReference": "Meredith, R.W., Janecka J., Gatesy J., Ryder O.A., Fisher C., Teeling E., Goodbla A., Eizirik E., Simao T., Stadler T., Rabosky D., Honeycutt R., Flynn J., Ingram C., Steiner C., Williams T., Robinson T., Herrick A., Westerman M., Ayoub N., Springer M., & Murphy W. 2011. Impacts of the Cretaceous Terrestrial Revolution and KPg Extinction on Mammal Diversification. Science 334 (6055): 521-524.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1434": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11314",
+    "ot:focalClade": 355014,
+    "ot:focalCladeOTTTaxonName": "Puya",
+    "ot:studyId": "pg_1434",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0900107",
+    "ot:studyPublicationReference": "Jabaily R.S., & Sytsma K.J. 2010. Phylogenetics of Puya (Bromeliaceae): Placement, Major Lineages, and Evolution of Chilean Species. American Journal of Botany, 97(2): 337-356.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1443": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11468",
+    "ot:focalClade": 108956,
+    "ot:focalCladeOTTTaxonName": "Peperomia",
+    "ot:studyId": "pg_1443",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-2699.2011.02586.x",
+    "ot:studyPublicationReference": "Symmank, L., Samain, M. S., Smith, J. F., Pino, G., Stoll, A., Goetghebeur, P., ... & Wanke, S. (2011). The extraordinary journey of Peperomia subgenus Tildenia (Piperaceae): insights into diversification and colonization patterns from its cradle in Peru to the Trans\u2010Mexican Volcanic Belt. Journal of Biogeography, 38(12), 2337-2349.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1446": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1414",
+    "ot:focalClade": 915107,
+    "ot:focalCladeOTTTaxonName": "Hymenophyllaceae",
+    "ot:studyId": "pg_1446",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406777585775",
+    "ot:studyPublicationReference": "Hennequin, S., Ebihara, A., Ito, M., Iwatsuki, K., & Dubuisson, J. Y. (2006). New insights into the phylogeny of the genus Hymenophyllum sl (Hymenophyllaceae): revealing the polyphyly of Mecodium. Systematic botany, 31(2), 271-284.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1450": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S592",
+    "ot:focalClade": 79111,
+    "ot:focalCladeOTTTaxonName": "Huperzia",
+    "ot:studyId": "pg_1450",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/BF01089229",
+    "ot:studyPublicationReference": "Wikstrm N., Kenrick P., & Chase M. 1999. Epiphytism and terrestrialization in tropical Huperzia (Lycopodiaceae). Plant Systematics and Evolution, 218: 221-243.",
+    "ot:studyYear": 1999
+   }
+  ]
+ },
+ "pg_1453": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10206",
+    "ot:focalClade": 113210,
+    "ot:focalCladeOTTTaxonName": "Isoetes",
+    "ot:studyId": "pg_1453",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406777585856",
+    "ot:studyPublicationReference": "Schuettpelz, E., & Hoot, S. B. (2006). Inferring the root of Iso\u00ebtes: exploring alternatives in the absence of an acceptable outgroup. Systematic Botany, 31(2), 258-270.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1473": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1716",
+    "ot:focalClade": 340301,
+    "ot:focalCladeOTTTaxonName": "Dryopteridaceae",
+    "ot:studyId": "pg_1473",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407781179662",
+    "ot:studyPublicationReference": "Rouhan G., Rakotondrainibe F., & Moran R. 2007. Elaphoglossum nidusoides (Dryopteridaceae), a new species of fern from Madagascar with an unusual phylogenetic position in the Squamipedia group. Systematic Botany,32(2), 227-235.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1474": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Dail Laughinghouse",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1211",
+    "ot:focalClade": 48614,
+    "ot:focalCladeOTTTaxonName": "Phaeophyceae",
+    "ot:studyId": "pg_1474",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1529-8817.2004.03153.x",
+    "ot:studyPublicationReference": "Hiroshi Kawai, Hideaki Sasaki, 2004, ' MORPHOLOGY, LIFE HISTORY, AND MOLECULAR PHYLOGENY OF STSCHAPOVIA FLAGELLARIS (TILOPTERIDALES, PHAEOPHYCEAE) AND THE ERECTION OF THE STSCHAPOVIACEAE FAM. NOV. ', Journal of Phycology, vol. 40, no. 6, pp. 1156-1169",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_1478": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1955",
+    "ot:focalClade": 667483,
+    "ot:focalCladeOTTTaxonName": "Polypodiaceae",
+    "ot:studyId": "pg_1478",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408786500208",
+    "ot:studyPublicationReference": "Salino A., Almeida T., Smith A., Navarro-gomez A., Kreier H., & Schneider H. 2007. A new species of Microgramma (Polypodiaceae) from Brazil and recircumscription of the genus based on phylogenetic evidence. Systematic Botany, 33(4), 630-635.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1483": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2012",
+    "ot:focalClade": 614459,
+    "ot:focalCladeOTTTaxonName": "Zamiaceae",
+    "ot:studyId": "pg_1483",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408784571699",
+    "ot:studyPublicationReference": "Gonz\u00e1lez, D., Vovides, A. P., & B\u00e1rcenas, C. (2008). Phylogenetic relationships of the Neotropical genus Dioon (Cycadales, Zamiaceae) based on nuclear and chloroplast DNA sequence data. Systematic Botany, 33(2), 229-236.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_1518": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13520",
+    "ot:studyId": "pg_1518",
+    "ot:studyPublication": "http://dx.doi.org/10.1639/0007-2745-115.4.557",
+    "ot:studyPublicationReference": "Nelson P. 2012. Parmelina yalungana resurrected and reported from Alaska, China and Russia. The Bryologist,115(4):557-565.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_152": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1092",
+    "ot:focalClade": 1001033,
+    "ot:focalCladeOTTTaxonName": "Coreopsis",
+    "ot:studyId": "pg_152",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644041744419",
+    "ot:studyPublicationReference": "Mort, M. E., Crawford, D. J., & Fairfield, K. N. (2004). Phylogeny and character evolution in California Coreopsis (Asteraceae): insights from morphology and from sequences of the nuclear and plastid genomes. Systematic botany, 29(3), 781-789.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_1522": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S367",
+    "ot:focalClade": 952859,
+    "ot:focalCladeOTTTaxonName": "Columnea",
+    "ot:studyId": "pg_1522",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/2419605",
+    "ot:studyPublicationReference": "Smith J., & Sytsma K. 1994. Evolution in the Andean epiphytic genus Columnea (Gesneriaceae). II. Chloroplast DNA restriction site variation. Systematic Botany, 19: 317-336.",
+    "ot:studyYear": 1994
+   }
+  ]
+ },
+ "pg_1524": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11416",
+    "ot:focalClade": 801077,
+    "ot:focalCladeOTTTaxonName": "Rhipsalideae",
+    "ot:studyId": "pg_1524",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000502",
+    "ot:studyPublicationReference": "Korotkova, N., Borsch, T., Quandt, D., Taylor, N. P., M\u00fcller, K. F., & Barthlott, W. (2011). What does it take to resolve relationships and to identify species with molecular markers? An example from the epiphytic Rhipsalideae (Cactaceae). American Journal of Botany, 98(9), 1549-1572.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1539": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12042",
+    "ot:focalClade": 554313,
+    "ot:focalCladeOTTTaxonName": "Carex",
+    "ot:studyId": "pg_1539",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1558-5646.2012.01624.x.",
+    "ot:studyPublicationReference": "Chung, K. S., Hipp, A. L., & Roalson, E. H. (2012). Chromosome number evolves independently of genome size in a clade with nonlocalized centromeres (Carex: Cyperaceae). Evolution, 66(9), 2708-2722.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_1563": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11535",
+    "ot:focalClade": 753726,
+    "ot:focalCladeOTTTaxonName": "Hymenoptera",
+    "ot:studyId": "pg_1563",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1096-0031.2011.00366.x",
+    "ot:studyPublicationReference": "Sharkey, M., Carpenter J., Vilhelmsen L., Heraty J., Hawks D., Dowling A.P., Schulmeister S., Murray D., Deans A., Ronquist F., Krogmann L., & Wheeler W. 2011. Phylogenetic relationships among superfamilies of Hymenoptera. Cladistics 28 (1): 80-112.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1567": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 719034,
+    "ot:focalCladeOTTTaxonName": "Equisetum",
+    "ot:studyId": "pg_1567",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s10265-007-0088-x",
+    "ot:studyPublicationReference": "Guillon, J. M. (2007). Molecular phylogeny of horsetails (Equisetum) including chloroplast atpB sequences. Journal of plant research, 120(4), 569-574.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1570": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10227",
+    "ot:focalClade": 46248,
+    "ot:focalCladeOTTTaxonName": "Asteraceae",
+    "ot:studyId": "pg_1570",
+    "ot:studyPublication": "http://dx.doi.org/10.2179/09-043.1",
+    "ot:studyPublicationReference": "McKain, M. R., Chapman, M. A., & Ingram, A. L. (2010). Confirmation of the hybrid origin of Eupatorium\u00d7 truncatum (Asteraceae) using nuclear and plastid markers. Castanea, 75(3), 381-387.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1572": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S114",
+    "ot:focalClade": 280129,
+    "ot:focalCladeOTTTaxonName": "Metalasia",
+    "ot:studyId": "pg_1572",
+    "ot:studyPublicationReference": "Karis P. 1989. Systematics of the genus Metalasia (Asteraceae-Gnaphalieae). Opera Botanica, 99: 1-150.",
+    "ot:studyYear": 1989
+   }
+  ]
+ },
+ "pg_1573": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1148",
+    "ot:focalClade": 557775,
+    "ot:focalCladeOTTTaxonName": "Mutisieae",
+    "ot:studyId": "pg_1573",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364404774195610",
+    "ot:studyPublicationReference": "Sancho G. 2004. Phylogenetic relationships in the genus Onoseris (Asteraceae,Mutisieae) inferred from morphology. Systematic Botany, 29(2): 432-447.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_1575": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12331",
+    "ot:focalClade": 46248,
+    "ot:focalCladeOTTTaxonName": "Asteraceae",
+    "ot:studyId": "pg_1575",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/cla.12005",
+    "ot:studyPublicationReference": "Gruenstaeudl, M., Santos\u2010Guerra, A., & Jansen, R. K. (2012). Phylogenetic analyses of Tolpis Adans.(Asteraceae) reveal patterns of adaptive radiation, multiple colonization and interspecific hybridization. Cladistics.1 (2012) 1\u201319",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_1581": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1597",
+    "ot:focalClade": 46248,
+    "ot:focalCladeOTTTaxonName": "Asteraceae",
+    "ot:studyId": "pg_1581",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.0014-3820.2006.tb00522.x",
+    "ot:studyPublicationReference": "Friar E., Prince L., Roalson E., Mcglaughlin M., Cruse-sanders J., Porter J., & Degroot S. 2006. Ecological speciation in the East Maui-endemic Dubautia (Asteraceae) species. Evolution, 60(9), 1777-1792.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1583": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1636",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "pg_1583",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407780360229",
+    "ot:studyPublicationReference": "Marlowe K., & Hufford L. 2006. Taxonomy and biogeography of Gaillardia (Asteraceae): a phylogenetic analysis. Systematic Botany, 32(1), 208-226.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1600": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Looks like the Fig 2 tree from TreeBASE doesn't match the Figure in the article. See [https://github.com/OpenTreeOfLife/feedback/issues/89]() . Emailed authors re:discrepancy. ",
+    "ot:curatorName": "Karen Cranston",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12186",
+    "ot:focalClade": 913935,
+    "ot:focalCladeOTTTaxonName": "Primates",
+    "ot:studyId": "pg_1600",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pgen.1001342 ",
+    "ot:studyPublicationReference": "Perelman, P., Johnson W.E., Roos C., Seu\u00e1nez H.N., Horvath J.E., Moreira M.A., Kessing B.D., Pontius J., Roelke M., Rumpler Y., Schneider M.C., Silva A., O'brien S., & Pecon-slattery J. 2011. A Molecular Phylogeny of Living Primates. PLoS Genetics 7(3): e1001342.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1634": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12003",
+    "ot:focalClade": 574724,
+    "ot:focalCladeOTTTaxonName": "Chiroptera",
+    "ot:studyId": "pg_1634",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/currents.RRN1212",
+    "ot:studyPublicationReference": "Agnarsson, I., Zambrana-torrelio C.M., Flores salda\u00f1a N.P., & May-collado L.M. 2011. A time-calibrated species-level phylogeny of bats (Chiroptera, Mammalia). PLoS Currents: Tree of Life, Version 44.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1646": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Karen Cranston",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2376",
+    "ot:focalClade": 827263,
+    "ot:focalCladeOTTTaxonName": "Caniformia",
+    "ot:studyId": "pg_1646",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-7-216",
+    "ot:studyPublicationReference": "Higdon J. W., Bininda-Emonds O. R. P., Beck R. M. D., Ferguson S. H. 2007. Phylogeny and divergence of the pinnipeds (Carnivora: Mammalia) assessed using a multigene dataset. BMC Evolutionary Biology 8: 216.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1761": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13550",
+    "ot:focalClade": 712383,
+    "ot:focalCladeOTTTaxonName": "Scleractinia",
+    "ot:studyId": "pg_1761",
+    "ot:studyPublicationReference": "Huang, D., & Roy K. 2013. Anthropogenic extinction threats and future loss of evolutionary history in reef corals. Ecology and Evolution, 3 (5): 1184\u20131193.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_1764": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13616",
+    "ot:focalClade": 452465,
+    "ot:focalCladeOTTTaxonName": "Pelecanidae",
+    "ot:studyId": "pg_1764",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.09.034",
+    "ot:studyPublicationReference": "Kennedy, M.,  S.A. Taylor, P. N\u00e1dvorn\u00edk, H. Spencer. 2013. The phylogenetic relationships of the extant pelicans inferred from DNA sequence data. Molecular Phylogenetics and Evolution 66 (1): 215-222.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_1776": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11299",
+    "ot:focalClade": 965954,
+    "ot:focalCladeOTTTaxonName": "Lepidoptera",
+    "ot:studyId": "pg_1776",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syr079",
+    "ot:studyPublicationReference": "Cho, S., Zwick A., Regier J., Mitter C., Cummings M.P., Yao J., Du Z., Zhao H., Kawahara A.Y., Weller S.J., Davis D.R., Baixeras J., Brown J.W., & Parr C. 2011. Can deliberately incomplete gene sample augmentation improve a phylogeny estimate for the advanced moths and butterflies (Hexapoda: Lepidoptera)?. Systematic Biology 60 (6): 782-796.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1786": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2067",
+    "ot:focalClade": 641030,
+    "ot:focalCladeOTTTaxonName": "Hydrozoa",
+    "ot:studyId": "pg_1786",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S0025315408002257",
+    "ot:studyPublicationReference": "Cartwright, P., Evans N., Dunn C., Marques A., Miglietta M., & Collins A. 2008. Phylogenetics of Hydroidolina (Cnidaria, Hydrozoa). Journal of the Marine Biological Association of the United Kingdom 88 (8): 1663-1672.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_1788": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S9968",
+    "ot:focalClade": 5005171,
+    "ot:focalCladeOTTTaxonName": "Siphonophora",
+    "ot:studyId": "pg_1788",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/10635150500354837",
+    "ot:studyPublicationReference": "Dunn, C., Pugh P., & Haddock S. 2005. Molecular phylogenetics of the Siphonophora (Cnidaria), with implications for the evolution of functional specialization. Systematic Biology 54 (6): 916-935.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_1796": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1897",
+    "ot:focalClade": 87194,
+    "ot:focalCladeOTTTaxonName": "Typhlatya",
+    "ot:studyId": "pg_1796",
+    "ot:studyPublication": "http://dx.doi.org/10.111/j.1365-2699.2007.01767.x",
+    "ot:studyPublicationReference": "Hunter, R., Webb M., Iliffe T., & Bremer J. 2007. Phylogeny and historical biogeography of the cave-adapted shrimp genus Typhlatya (Atyidae) in the Caribbean Sea and western Atlantic. Journal of Biogeography 35 (1): 65-75.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1797": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1991",
+    "ot:focalClade": 796652,
+    "ot:focalCladeOTTTaxonName": "Tenrecidae",
+    "ot:studyId": "pg_1797",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-8-102",
+    "ot:studyPublicationReference": "Poux, C., Madsen O., Glos J., Jong W., & Vences M. 2008. Molecular phylogeny and divergence times of Malagasy tenrecs: influence of data partitioning and taxon sampling on dating analyses. BMC Evolutionary Biology 8: 102.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_180": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11083",
+    "ot:focalClade": 481972,
+    "ot:focalCladeOTTTaxonName": "Araceae",
+    "ot:studyId": "pg_180",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000158",
+    "ot:studyPublicationReference": "Cusimano N., Bogner J., Mayo S., Wong S.Y., Hesse M., Hetterscheid W., Keating R.C., & French J. 2011. Relationships within the Araceae: comparison of morphological patterns with molecular phylogenies. American Journal of Botany,  98(4), 654-668.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1821": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 968337,
+    "ot:focalCladeOTTTaxonName": "Helichrysum",
+    "ot:studyId": "pg_1821",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/596332",
+    "ot:studyPublicationReference": "Galbany-Casals, M. [et al. 2009], Garcia-Jacas, N, S\u00e1ez, L., Bened\u00ed, C., & Susanna, A. 2009. Phylogeny, biogeography, and character evolution in Mediterranean, Asiatic and Macaronesian Helichrysum (Asteraceae, Gnaphalieae) inferred from nuclear phylogenetic analyses. Internat. J. Plant Sci. 170: 365-380.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1842": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 372830,
+    "ot:focalCladeOTTTaxonName": "Oxalis",
+    "ot:studyId": "pg_1842",
+    "ot:studyPublicationReference": "Oberlander, K. C., Dreyer, L. L., & Bellstedt, D. U. (2011). Molecular phylogenetics and origins of southern African Oxalis. Taxon, 60(6), 1667-1677.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1843": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 864036,
+    "ot:focalCladeOTTTaxonName": "Euphorbia",
+    "ot:studyId": "pg_1843",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s00606-010-0272-7",
+    "ot:studyPublicationReference": "Zimmermann, N. F. A. [et al. 2010], Ritz, C. M., & Hellwig, F. H. 2010. Further support for the phylogenetic relationships within Euphorbia L. (Euphorbiaceae) from nrITS and trnL-trnF IGS sequence data. Plant Syst. Evol. 286: 39-58.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1849": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1720",
+    "ot:focalClade": 215086,
+    "ot:focalCladeOTTTaxonName": "Formicidae",
+    "ot:studyId": "pg_1849",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.0605858103",
+    "ot:studyPublicationReference": "Brady, S., Schultz T., Fisher B., & Ward P. 2006. Evaluating alternative hypotheses for the early evolution and diversification of ants. Proceedings of the National Academy of Sciences of the United States of America, 103 (48): 18172-18177.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1858": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 3914740,
+    "ot:focalCladeOTTTaxonName": "Chamaesyce",
+    "ot:studyId": "pg_1858",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000496",
+    "ot:studyPublicationReference": "Y. Yang, P. E. Berry. 2011. Phylogenetics of the Chamaesyce clade (Euphorbia, Euphorbiaceae): Reticulate evolution and long-distance dispersal in a prominent C4 lineage. American Journal of Botany 98(9):1486-1503.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1866": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 3350010,
+    "ot:focalCladeOTTTaxonName": "Thesium",
+    "ot:studyId": "pg_1866",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1095-8339.2010.01032.x",
+    "ot:studyPublicationReference": "Moore, T. E. [et al. 2010], Verboom, G. A., & Forest, F. 2010. Phylogenetics and biogeography of the parasitic genus Thesium (Santalaceae), with an emphasis on the Cape of South Africa. Bot. J. Linnean Soc. 162: 435-452.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1867": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11891",
+    "ot:focalClade": 99242,
+    "ot:focalCladeOTTTaxonName": "Cycadaceae",
+    "ot:studyId": "pg_1867",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1209926",
+    "ot:studyPublicationReference": "Nagalingum, N. S., Marshall, C. R., Quental, T. B., Rai, H. S., Little, D. P., & Mathews, S. (2011). Recent synchronous radiation of a living fossil. Science, 334(6057), 796-799.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1868": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1680",
+    "ot:focalClade": 164371,
+    "ot:focalCladeOTTTaxonName": "Marsilea",
+    "ot:studyId": "pg_1868",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407780360256",
+    "ot:studyPublicationReference": "Nagalingum N., Schneider H., & Pryer K. 2007. Molecular phylogenetic relationships and morphological evolution in the heterosporous fern genus Marsilea. Systematic Botany,, 32(1), 16-25.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1870": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1779",
+    "ot:focalClade": 1005930,
+    "ot:focalCladeOTTTaxonName": "Cyprinidae",
+    "ot:studyId": "pg_1870",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-7-38",
+    "ot:studyPublicationReference": "R\u00fcber, L., Kottelat M., Tan H., Ng P., & Britz R. 2007. Evolution of miniaturization and the phylogenetic position of Paedocypris, comprising the world's smallest vertebrate. BMC Evolutionary Biology 7 (38): 1-10.",
+    "ot:studyYear": 2007,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_1872": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1728",
+    "ot:focalClade": 967304,
+    "ot:focalCladeOTTTaxonName": "Gruiformes",
+    "ot:studyId": "pg_1872",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.02.015",
+    "ot:studyPublicationReference": "Fain, M., Krajewski C., & Houde P. 2007. Phylogeny of \"core Gruiformes\" (Aves: Grues) and resolution of the Limpkin-Sungrebe problem. Molecular Phylogenetics and Evolution 43 (2): 515-529.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1887": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2009",
+    "ot:focalClade": 1036185,
+    "ot:focalCladeOTTTaxonName": "Accipitridae",
+    "ot:studyId": "pg_1887",
+    "ot:studyPublication": "http://dx.doi.org/10.1525/auk.2008.06161",
+    "ot:studyPublicationReference": "Lerner, H., Klaver M., & Mindell D. 2008. Molecular phylogenetics of the Buteonine birds of prey (Accipitridae). The Auk 125 (2): 304-315.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_1901": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 659713,
+    "ot:focalCladeOTTTaxonName": "Lentibulariaceae",
+    "ot:studyId": "pg_1901",
+    "ot:studyPublication": "http://dx.doi.org/10.1043/0363-6445-28.1.157",
+    "ot:studyPublicationReference": "Jobson, R. W. [et al. 2003], Playford, J., Cameron, K. M., & Albert, V. A. 2003. Molecular phylogenetics of Lentibulariaceae inferred from plastid rps16 intron and trnL-F sequences: Implications for character evolution and biogeography. Syst. Bot. 28: 157-171.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_1916": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 309271,
+    "ot:focalCladeOTTTaxonName": "Brassicaceae",
+    "ot:studyId": "pg_1916",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s00606-009-0213-5",
+    "ot:studyPublicationReference": "German, D. A. [et al. 2009], Friesen, N., Neuffer, B., Al-Shehbaz, I. A., & Hurka, H. 2009. Contribution to ITS phylogeny of the Brassicaceae, with special reference to some Asian taxa. Plant Syst. Evol. 283: 33-56.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1927": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10124",
+    "ot:focalClade": 698424,
+    "ot:focalCladeOTTTaxonName": "Cetacea",
+    "ot:studyId": "pg_1927",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syp060",
+    "ot:studyPublicationReference": "Steeman, M., Hebsgaard M., Fordyce R., Ho S., Rabosky D., Nielsen R., Rahbek C., Glenner H., S\u00f8rensen M., & Willerslev E. 2009. Radiation of Extant Cetaceans Driven by Restructuring of the Oceans. Systematic Biology 58 (6): 573-585.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1940": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10691",
+    "ot:focalClade": 34905,
+    "ot:focalCladeOTTTaxonName": "Drosophilidae",
+    "ot:studyId": "pg_1940",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S001667231000008X",
+    "ot:studyPublicationReference": "Van der Linde, K., Houle D., Spicer G.S., & Steppan S. 2010. A supermatrix-based molecular phylogeny of the family Drosophilidae. Genetics Research 92 (1): 25-38.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1942": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 1040700,
+    "ot:focalCladeOTTTaxonName": "Salviniaceae",
+    "ot:studyId": "pg_1942",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/519007",
+    "ot:studyPublicationReference": "Metzgar, J. S., Schneider, H., & Pryer, K. M. (2007). Phylogeny and divergence time estimates for the fern genus Azolla (Salviniaceae).International Journal of Plant Sciences, 168(7), 1045-1053",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1944": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10149",
+    "ot:focalClade": 1086303,
+    "ot:focalCladeOTTTaxonName": "Campanulaceae",
+    "ot:studyId": "pg_1944",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410791638306",
+    "ot:studyPublicationReference": "Tank, D., M. Donoghue. 2010. Phylogeny and phylogenetic nomenclature of the Campanulidae based on an expanded set of genes and taxa. Systematic Botany 35 (2): 425-441.",
+    "ot:studyYear": 2010,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_1948": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "chris-owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10917",
+    "ot:focalClade": 494458,
+    "ot:focalCladeOTTTaxonName": "Galatheoidea",
+    "ot:studyId": "pg_1948",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.11.011",
+    "ot:studyPublicationReference": "Schnabel, K.E., S.T. Ahyong, E.W. Maas. 2010. Galatheoidea are not monophyletic \u2013 Molecular and morphological phylogeny of the squat lobsters (Decapoda: Anomura) with recognition of a new superfamily. Molecular Phylogenetics and Evolution 58 (2): 157-168.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_1962": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10714",
+    "ot:focalClade": 757494,
+    "ot:focalCladeOTTTaxonName": "Adoxaceae",
+    "ot:studyId": "pg_1962",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/658927",
+    "ot:studyPublicationReference": "Clement W., & Donoghue M. 2011. Dissolution of Viburnum section Megalotinus (Adoxaceae) of Southeast Asia and its implications for morphological evolution and biogeography. International Journal of Plant Sciences, 172(4): 559-573.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_1966": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11849",
+    "ot:focalClade": 901832,
+    "ot:focalCladeOTTTaxonName": "Maluridae",
+    "ot:studyId": "pg_1966",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syr101",
+    "ot:studyPublicationReference": "Lee, J.Y., Joseph L., & Edwards S. 2011. A species tree for the Australo-Papuan fairy-wrens and allies (Aves: Maluridae). Systematic Biology 61 (2): 253-271.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_197": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1606",
+    "ot:focalClade": 2865182,
+    "ot:focalCladeOTTTaxonName": "Phaseolus",
+    "ot:studyId": "pg_197",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406779695960",
+    "ot:studyPublicationReference": "Delgado-Salinas, A., Bibler, R., & Lavin, M. (2006). Phylogeny of the genus Phaseolus (Leguminosae): a recent diversification in an ancient landscape. Systematic Botany, 31(4), 779-791.",
+    "ot:studyYear": 2006,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_1974": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 904376,
+    "ot:focalCladeOTTTaxonName": "Polygonaceae",
+    "ot:studyId": "pg_1974",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.01.002",
+    "ot:studyPublicationReference": "Sun, Y. [et al. 2012], Wang, A., Wan, D., Wang, Q., & Liu, J. 2012. Rapid radiation of Rheum (Polygonaceae) and parallel evolution of morphological traits. Mol. Phyl. Evol. 63: 150-158.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_1975": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 143408,
+    "ot:focalCladeOTTTaxonName": "Tragopogon",
+    "ot:studyId": "pg_1975",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/00837792.2012.10670912",
+    "ot:studyPublicationReference": "Evgeny V. Mavrodiev, Matthew A. Gitzendanner, Andre K. Calaminus, Riccardo M. Baldini, Pamela S. Soltis, Douglas E. Soltis. 2012. Molecular phylogeny of Tragopogon L. (Asteraceae) based on seven nuclear loci (Adh, GapC, LFY, AP3, PI, ITS, and ETS). Webbia 67(2): 111-137. 2012.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_1979": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1577",
+    "ot:focalClade": 701704,
+    "ot:focalCladeOTTTaxonName": "Arinia",
+    "ot:studyId": "pg_1979",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/10635150600697390",
+    "ot:studyPublicationReference": "Tavares, E.S., Baker A., Pereira S., & Miyaki C. 2006. Phylogenetic relationships and historical biogeography of neotropical parrots (Psittaciformes: Psittacidae: Arini) inferred from mitochondrial and nuclear DNA Sequences. Systematic Biology 55 (3): 454-470.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1981": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11931",
+    "ot:focalClade": 563159,
+    "ot:focalCladeOTTTaxonName": "Felidae",
+    "ot:studyId": "pg_1981",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1122277",
+    "ot:studyPublicationReference": "Johnson, W.E., Eizirik E., Pecon-slattery J., Murphy W., Antunes A., Teeling E., & O'brien S. 2006. The late Miocene radiation of modern Felidae: a genetic assessment. Science 311(5757): 73-77.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_1988": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12224",
+    "ot:focalClade": 656293,
+    "ot:focalCladeOTTTaxonName": "Mantodea",
+    "ot:studyId": "pg_1988",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1096-0031.2009.00263.x",
+    "ot:studyPublicationReference": "Svenson, G.J., & Whiting M. 2009. Reconstructing the origins of praying mantises (Dictyoptera, Mantodea): the roles of Gondwanan vicariance and morphological convergence. Cladistics 25 (5): 468-514.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_1996": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 1054392,
+    "ot:focalCladeOTTTaxonName": "Lomariopsis",
+    "ot:studyId": "pg_1996",
+    "ot:studyPublication": "http://dx.doi.org/10.1663/0007-196X(2007)59[115:PPAOTF]2.0.CO;2",
+    "ot:studyPublicationReference": "Rouhan, G., Hanks, J. G., McClelland, D., & Moran, R. C. (2007). Preliminary phylogenetic analysis of the fern genus Lomariopsis (Lomariopsidaceae). Brittonia, 59(2), 115-128.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_1997": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11548",
+    "ot:focalClade": 186478,
+    "ot:focalCladeOTTTaxonName": "Percidae",
+    "ot:studyId": "pg_1997",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syr052",
+    "ot:studyPublicationReference": "Near, T.J., Bossu C., Bradburd G.S., Carlson R.L., Harrington R.C., Hollingsworth Jr. P.R., Keck B.P., & Etnier D.A. 2011. Phylogeny and temporal diversification of darters (Percidae:  Etheostomatinae). Systematic Biology 60 (5): 565\u0096595.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_20": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10364",
+    "ot:focalClade": 719575,
+    "ot:focalCladeOTTTaxonName": "Galium",
+    "ot:studyId": "pg_20",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000130",
+    "ot:studyPublicationReference": "Soza, V. L., & Olmstead, R. G. (2010). Evolution of breeding systems and fruits in New World Galium and relatives (Rubiaceae). American journal of botany, 97(10), 1630-1646.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_200": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1722",
+    "ot:focalClade": 976278,
+    "ot:focalCladeOTTTaxonName": "Encelia",
+    "ot:studyId": "pg_200",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407782250689",
+    "ot:studyPublicationReference": "Fehlberg, S. D., & Ranker, T. A. (2007). Phylogeny and biogeography of Encelia (Asteraceae) in the sonoran and peninsular deserts based on multiple DNA sequences. Systematic Botany, 32(3), 692-699.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2000": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1001054,
+    "ot:focalCladeOTTTaxonName": "Coffea",
+    "ot:studyId": "pg_2000",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364412x656482",
+    "ot:studyPublicationReference": "Nowak, M. D. [et al. 2012], Davis, A. P., & Yoder, A. D. 2012. Sequence data from new plastid and nuclear COSII regions resolves early diverging lineages in Coffea (Rubiaceae). Syst. Bot. 37: 995-1005.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2001": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 314141,
+    "ot:focalCladeOTTTaxonName": "Astragalus",
+    "ot:studyId": "pg_2001",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s00606-011-0417-3",
+    "ot:studyPublicationReference": "Mehrshid Riahi, Shahin Zarre, Ali Aasghar Maassoumi, Shahrokh Kazempour Osaloo, Martin F. Wojciechowski. 2011. Towards a phylogeny for Astragalus section Caprini (Fabaceae) and its allies based on nuclear and plastid DNA sequences. Plant Syst Evol. 293:119\u2013133.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2004": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10112",
+    "ot:focalClade": 952863,
+    "ot:focalCladeOTTTaxonName": "Cyrtandra",
+    "ot:studyId": "pg_2004",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2009.09.002",
+    "ot:studyPublicationReference": "Clark J., Wagner W., & Roalson E. 2009. Patterns of diversification and ancestral range reconstruction in the Southeast Asian-Pacific angiosperm lineage Cyrtandra (Gesneriaceae). Molecular Phylogenetics and Evolution, 53(3): 982-994.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2032": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12067",
+    "ot:focalClade": 504642,
+    "ot:focalCladeOTTTaxonName": "Acanthaceae",
+    "ot:studyId": "pg_2032",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s12228-012-9244-2",
+    "ot:studyPublicationReference": "Tripp, E. A., & McDade, L. A. (2012). New synonymies for Ruellia (Acanthaceae) of Costa Rica and notes on other neotropical species. Brittonia, 64(3), 305-317.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2039": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 1065300,
+    "ot:focalCladeOTTTaxonName": "Hymenophyllum",
+    "ot:studyId": "pg_2039",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.01.001",
+    "ot:studyPublicationReference": "Hennequin S., Ebihara A., Ito M., Dubuisson J.-Y. & H. Schneider. 2010. Chromosome number evolution in Hymenophyllum (Hymenophyllaceae), with special reference to the subgenus Hymenophyllum. Molecular Phylogenetics and Evolution 55: 47-59.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2042": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S954",
+    "ot:studyId": "pg_2042",
+    "ot:studyPublication": "http://dx.doi.org/10.1639/0007-2745(2003)106[0280:POTBBB]2.0.CO;2",
+    "ot:studyPublicationReference": "Virtanen V. 2003. Phylogeny of the Bartramiaceae (Bryopsida) Based on Morphology and on rbcL, rps4, and trnL-trnF Sequence Data. The Bryologist, 106(2): 280-296.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_2044": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13942",
+    "ot:focalClade": 23373,
+    "ot:focalCladeOTTTaxonName": "Orobanchaceae",
+    "ot:studyId": "pg_2044",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1200448 ",
+    "ot:studyPublicationReference": "McNeal, J. R., Bennett, J. R., Wolfe, A. D., & Mathews, S. (2013). Phylogeny and origins of holoparasitism in Orobanchaceae. American journal of botany, 100(5), 971-983.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2045": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13659",
+    "ot:studyId": "pg_2045",
+    "ot:studyPublicationReference": "Mishler B., Knerr N., Gonzalez-orozco C.E., Thornhill A.H., Laffan S., & Miller J.T. 2013. Phylogenetic Approaches to Biodiversity and Endemism: an Application to Australian Acacia. Nature.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2046": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "These trees (from TreeBASE)do not appear in the paper (the paper uses ML, not NJ or MP). The ML trees from the paper is quite resolved, but we do not have them. I am contacting the author.",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13453",
+    "ot:focalClade": 155230,
+    "ot:focalCladeOTTTaxonName": "Trebouxiophyceae",
+    "ot:studyId": "pg_2046",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/jpy.12039",
+    "ot:studyPublicationReference": "Bock, Christina, Wei Luo, Wolf-Henning Kusber, Eberhard Hegewald, Marie Pa\u017eoutov\u00e1, Lothar Krienitz. 2013. Classification of crucigenoid algae: phylogenetic position of the reinstated genus Lemmermannia, Tetrastrum spp. Crucigenia tetrapedia, and C. lauterbornii (Trebouxiophyceae, Chlorophyta). Journal of Phycology 49 (2): 329-339",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2047": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13806",
+    "ot:focalClade": 1071030,
+    "ot:focalCladeOTTTaxonName": "Cuscuta",
+    "ot:studyId": "pg_2047",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364413x674887",
+    "ot:studyPublicationReference": "Costea M., Garcia I., Docksteder K., & Stefanovic S. 2013. More problems despite bigger flowers: systematics of Cuscuta tinctoria clade (subgenus Grammica, Convolvulaceae) with description of six new species. Systematic Botany.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2048": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13603",
+    "ot:focalClade": 781603,
+    "ot:focalCladeOTTTaxonName": "Allium",
+    "ot:studyId": "pg_2048",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1200641",
+    "ot:studyPublicationReference": "Wheeler, E. J., Mashayekhi, S., McNeal, D. W., Columbus, J. T., & Pires, J. C. (2013). Molecular systematics of Allium subgenus Amerallium (Amaryllidaceae) in North America. American journal of botany, 100(4), 701-711.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2052": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12424",
+    "ot:focalClade": 117847,
+    "ot:focalCladeOTTTaxonName": "Lundia",
+    "ot:studyId": "pg_2052",
+    "ot:studyPublication": "http://www.ingentaconnect.com/content/iapt/tax/2012/00000061/00000002/art00008",
+    "ot:studyPublicationReference": "Kaehler, M., Michelangeli, F. A., & Lohmann, L. G. (2012). Phylogeny of Lundia (Bignoniaceae) based on ndhF and PepC sequences. Taxon, 61(2), 368-380.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2055": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12652",
+    "ot:focalClade": 799969,
+    "ot:focalCladeOTTTaxonName": "Bowdichia",
+    "ot:studyId": "pg_2055",
+    "ot:studyPublication": "http://www.ingentaconnect.com/content/iapt/tax/2012/00000061/00000005/art00012",
+    "ot:studyPublicationReference": "Cardoso D.B., Cavalcante de lima H., Sch?tz rodrigues R., Queiroz L.P., Pennington R., & Lavin M. 2012. The Bowdichia clade of Genistoid legumes: phylogenetic analysis of combined molecular (ITS, matK and trnL intron) and morphological data and a recircumscription of Diplotropis. Taxon, 61(5): 1074?1087.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2057": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12998",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "pg_2057",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1200380",
+    "ot:studyPublicationReference": "Cardoso D.B., Queiroz L.P., Pennington R., Cavalcante de lima H., Fonty E., Wojciechowski M., & Lavin M. 2012. Revisiting the phylogeny of papilionoid legumes: New insights from comprehensively sampled early-branching lineages. American Journal of Botany, 99(12): 1991-2013.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2061": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1022",
+    "ot:focalClade": 338374,
+    "ot:focalCladeOTTTaxonName": "Campydora",
+    "ot:studyId": "pg_2061",
+    "ot:studyPublication": "http://dx.doi.org/10.1163/156854103322746878",
+    "ot:studyPublicationReference": "Mullin P., Harris T., & Powers T. 2003. Systematic status of Campydora Cobb, 1920 (Nematoda: Campydorina). Nematology 5 (5): 699-711.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_2068": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1222",
+    "ot:focalClade": 631829,
+    "ot:focalCladeOTTTaxonName": "Osedax",
+    "ot:studyId": "pg_2068",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1098650",
+    "ot:studyPublicationReference": "Rouse, G., Goffredi S., & Vrijenhoek R. 2004. Osedax: bone-eating marine worms with dwarf males. Science 305 (5684): 668-671.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2076": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11765",
+    "ot:focalClade": 148272,
+    "ot:focalCladeOTTTaxonName": "Garrya",
+    "ot:studyId": "pg_2076",
+    "ot:studyPublication": "http://dx.doi.org/10.3120/0024-9637-58.4.249",
+    "ot:studyPublicationReference": "Burge, D. O. (2011). Molecular Phylogenetics of Garrya (Garryaceae). Madro\u00f1o, 58(4), 249-255.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2077": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11400",
+    "ot:focalClade": 33313,
+    "ot:focalCladeOTTTaxonName": "Podalyria",
+    "ot:studyId": "pg_2077",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X583628",
+    "ot:studyPublicationReference": "Schutte-Vlok, A. L., & Wyk, B. E. V. (2011). A Taxonomic Revision of Podalyria (Fabaceae). Systematic Botany, 36(3), 631-660.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2085": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2078",
+    "ot:focalClade": 481972,
+    "ot:focalCladeOTTTaxonName": "Araceae",
+    "ot:studyId": "pg_2085",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0800073",
+    "ot:studyPublicationReference": "Cabrera L., Salazar G., Chase M., Mayo S., Bogner J., & Davila P. 2008. Phylogenetic relationships of aroids and duckweeds (Araceae) inferred from coding and non-coding plastid DNA. American Journal of Botany, 95: 1153-1165.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_2087": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1125",
+    "ot:focalClade": 1082612,
+    "ot:focalCladeOTTTaxonName": "Austrogoniodes",
+    "ot:studyId": "pg_2087",
+    "ot:studyPublication": "http://dx.doi.org/10.1071/IS03022",
+    "ot:studyPublicationReference": "Banks, J., & Paterson A. 2004. A penguin-chewing louse (Insecta: Phthiraptera) phylogeny derived from morphology. Invertebrate Systematics 18 (1): 89-100.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2092": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1379",
+    "ot:focalClade": 419936,
+    "ot:focalCladeOTTTaxonName": "Albinaria",
+    "ot:studyId": "pg_2092",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1096-3642.2005.00154.x",
+    "ot:studyPublicationReference": "Uit de Weerd, D.R., & Gittenberger E. 2005. Towards a monophyletic genus Albinaria: the first molecular study into the phylogenetic position of eastern Albinaria species. Zoological Journal of the Linnean Society 143 (4): 531-542.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_2098": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1442",
+    "ot:focalClade": 647079,
+    "ot:focalCladeOTTTaxonName": "Stenocercus",
+    "ot:studyId": "pg_2098",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2005.09.007",
+    "ot:studyPublicationReference": "Torres-Carvajal, O., Ii J., & Cadle J. 2005. Phylogenetic relationships of South American lizards of the genus Stenocercus (Squamata: Iguania): a new approach using a general mixture model for gene sequence data. Molecular Phylogenetics and Evolution 39 (1): 171-185.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_21": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10213",
+    "ot:focalClade": 473827,
+    "ot:focalCladeOTTTaxonName": "Solanaceae",
+    "ot:studyId": "pg_21",
+    "ot:studyPublication": "http://www.ingentaconnect.com/content/iapt/tax/2008/00000057/00000004/art00010",
+    "ot:studyPublicationReference": "Olmstead R., Bohs L., Abdel-migid H., Santiago-velent\u00edn E., Garcia V., & Collier S. 2008. A molecular phylogeny of the Solanaceae. Taxon, 57(4): 1159-1181.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_2127": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12754",
+    "ot:focalClade": 39538,
+    "ot:focalCladeOTTTaxonName": "Papilionoideae",
+    "ot:studyId": "pg_2127",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1200276",
+    "ot:studyPublicationReference": "Cardoso D.B., Queiroz L.P., Cavalcante de lima H., Suganuma E., Van den berg C., & Lavin M. 2013. A molecular phylogeny of the Vataireoid legumes underscores floral evolvability that is general to many early-branching papilionoid lineages. American Journal of Botany, 100(2): 403-421.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2128": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S9999",
+    "ot:focalClade": 609811,
+    "ot:focalCladeOTTTaxonName": "Plantago",
+    "ot:studyId": "pg_2128",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0800400",
+    "ot:studyPublicationReference": "Ishikawa N., Yokoyama J., & Tsukaya H. 2009. Molecular evidence of reticulate evolution in the subgenus Plantago (Plantaginaceae). American Journal of Botany, 96(9): 1627-1635.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2140": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1127",
+    "ot:focalClade": 98426,
+    "ot:focalCladeOTTTaxonName": "Annonaceae",
+    "ot:studyId": "pg_2140",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.91.4.590",
+    "ot:studyPublicationReference": "Mols, J. B., Gravendeel, B., Chatrou, L. W., Pirie, M. D., Bygrave, P. C., Chase, M. W., & Ke\u00dfler, P. J. (2004). Identifying clades in Asian Annonaceae: monophyletic genera in the polyphyletic Miliuseae. American Journal of Botany, 91(4), 590-600.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2143": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2213",
+    "ot:focalClade": 190303,
+    "ot:focalCladeOTTTaxonName": "Kentropyx",
+    "ot:studyId": "pg_2143",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-294X.2008.03999.x",
+    "ot:studyPublicationReference": "Collevatti, R., Colli G., Giugliano L., Werneck F., & Werneck F. 2008. Phylogeny, biogeography and evolution of clutch size in South American lizards of the genus Kentropyx (Squamata: Teiidae). Molecular Ecology 18 (2): 262-278.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_2156": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10120",
+    "ot:focalClade": 449186,
+    "ot:focalCladeOTTTaxonName": "Ophryotrocha",
+    "ot:studyId": "pg_2156",
+    "ot:studyPublicationReference": "Wiklund, H., Glover A., & Dahlgren T. 2009. Three new species of Ophryotrocha (Annelida; Dorvilleidae) from a whale-fall in the North East Atlantic. Zootaxa 2228: 43-56.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_216": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11014",
+    "ot:focalClade": 524077,
+    "ot:focalCladeOTTTaxonName": "Hedera",
+    "ot:studyId": "pg_216",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X605100",
+    "ot:studyPublicationReference": "Green, A. F., Ramsey, T. S., & Ramsey, J. (2011). Phylogeny and biogeography of ivies (Hedera spp., Araliaceae), a polyploid complex of woody vines. Systematic Botany, 36(4), 1114-1127.",
+    "ot:studyYear": 2010,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2165": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 41618,
+    "ot:focalCladeOTTTaxonName": "Dryopteris",
+    "ot:studyId": "pg_2165",
+    "ot:studyPublicationReference": "Juslen, Aino, Henry Vare, and Niklas Wikstrom. \"Relationships and evolutionary origins of polyploid Dryopteris (Dryopteridaceae) from Europe inferred using nuclear pgiC and plastid trnL-F sequence data.\" Taxon 60, no. 5 (2011): 1284-1294.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2243": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12200",
+    "ot:focalClade": 757798,
+    "ot:focalCladeOTTTaxonName": "Munididae",
+    "ot:studyId": "pg_2243",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1558-5646.2011.01560.x",
+    "ot:studyPublicationReference": "Cabezas, P., Sanmartin I., Paulay G., Macpherson E., & Machordom A. 2011. Deep under the sea: unraveling the evolutionary history of the deep-sea squat lobster Paramunida (Decapoda, Munididae). Evolution 66 (6): 1878-1896.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_225": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Evgeny Mavrodiev",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1673",
+    "ot:studyId": "pg_225",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.0603335103",
+    "ot:studyPublicationReference": "Qiu, Y.-L., Li, L., Wang, B., Chen, Z., Knoop, V., Groth-Malonek, M., Dombrovska, O., Lee, J., Kent, L., Rest, J. S., Estabrook, G. F., Hendry, T. A., Taylor, D. W., Testa, C. M., Ambros, M., Crandall-Stotler, B., Duff, R. J., Stech, M., Frey, W., Quandt, D., & Davis, C. C. 2006. The deepest divergences in land plants inferred from phylogenomic evidence. Proc. National Acad. Sci. U.S.A. 103: 15511-15516.",
+    "ot:studyYear": 2006,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2323": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12833",
+    "ot:focalClade": 653874,
+    "ot:focalCladeOTTTaxonName": "Bombyliidae",
+    "ot:studyId": "pg_2323",
+    "ot:studyPublication": "http://dx.doi.org/10.3897/zookeys.150.1881",
+    "ot:studyPublicationReference": "Lambkin, C.L., & Bartlett J.S. 2011. Bush Blitz aids description of three new species and a new genus of Australian beeflies (Diptera, Bombyliidae, Exoprosopini). ZooKeys 280 (150): 231-280.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2357": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13316",
+    "ot:focalClade": 73749,
+    "ot:focalCladeOTTTaxonName": "Evaniscus",
+    "ot:studyId": "pg_2357",
+    "ot:studyPublication": "http://dx.doi.org/10.3987/zookeys.223.3572",
+    "ot:studyPublicationReference": "Mullins P.L., Kawada R., Balhoff J.P., & Deans A. 2012. A revision of Evaniscus (Hymenoptera, Evaniidae) using ontology-based semantic phenotype annotation. ZooKeys 223: 1-38.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2359": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12859",
+    "ot:focalClade": 3615249,
+    "ot:focalCladeOTTTaxonName": "Artiodactyla",
+    "ot:studyId": "pg_2359",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.02.015",
+    "ot:studyPublicationReference": "B\u00e4rmann, E.V., R\u00f6ssner G.E., & W\u00f6rheide G. 2013. A revised phylogeny of Antilopini (Bovidae, Artiodactyla) using combined mitochondrial and nuclear genes. Molecular Phylogenetics and Evolution 67 (2): 484-493.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2404": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11939",
+    "ot:focalClade": 1041547,
+    "ot:focalCladeOTTTaxonName": "Passeriformes",
+    "ot:studyId": "pg_2404",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.0401892101",
+    "ot:studyPublicationReference": "Barker F., Cibois A., Schikler P., Feinstein J., and Cracraft J. 2004. Phylogeny and diversification of the largest avian radiation. Proceedings of the National Academy of Sciences of the United States of America 101 (30): 11040-11045.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2405": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1828",
+    "ot:focalClade": 890240,
+    "ot:focalCladeOTTTaxonName": "Phyllodocidae",
+    "ot:studyId": "pg_2405",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.04.015",
+    "ot:studyPublicationReference": "Eklof, J., Pleijel F., & Sundberg P. 2007. Phylogeny of benthic Phyllodocidae (Polychaeta) based on morphological and molecular data. Molecular Phylogenetics and Evolution 45 (1): 261-271.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2415": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14093",
+    "ot:focalClade": 639666,
+    "ot:focalCladeOTTTaxonName": "Testudines",
+    "ot:studyId": "pg_2415",
+    "ot:studyPublicationReference": "Guillon, J., Guery L., Hulin V., & Girondot M. 2012. A large phylogeny of turtles (Testudines) using molecular data. Contributions to Zoology 81 (3): 147-158.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2422": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S407",
+    "ot:focalClade": 210097,
+    "ot:focalCladeOTTTaxonName": "Ascaridoidea",
+    "ot:studyId": "pg_2422",
+    "ot:studyPublication": "http://dx.doi.org/10.1006/mpev.1998.0514",
+    "ot:studyPublicationReference": "Nadler, S., and D. Hudspeth. 1998. Ribosomal DNA and phylogeny of the Ascaridoidea (Nemata: Secernentea): implications for morphological evolution and classification. Molecular Phylogenetics and Evolution 10 (2): 221-236.",
+    "ot:studyYear": 1998
+   }
+  ]
+ },
+ "pg_244": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Evgeny Mavrodiev",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1548",
+    "ot:focalClade": 592507,
+    "ot:focalCladeOTTTaxonName": "Gymnosperma",
+    "ot:studyId": "pg_244",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/10635150600812619",
+    "ot:studyPublicationReference": "Won, H., Renner S. 2006. Dating dispersal and radiation in the gymnosperm Gnetum (Gnetales)\u2014clock calibration when outgroup relationships are uncertain. Systematic Biology 55 (4): 610-622.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_2444": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1833",
+    "ot:focalClade": 363030,
+    "ot:focalCladeOTTTaxonName": "Columbiformes",
+    "ot:studyId": "pg_2444",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/10635150701549672",
+    "ot:studyPublicationReference": "Pereira, S., Johnson K., Clayton D., and Baker A. 2007. Mitochondrial and nuclear DNA sequences support a Cretaceous origin of Columbiformes and a dispersal-driven radiation in the Paleogene. Systematic Biology 56 (4): 656-672.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2454": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1759",
+    "ot:focalClade": 799167,
+    "ot:focalCladeOTTTaxonName": "Thamnophilus",
+    "ot:studyId": "pg_2454",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1558-5646.2007.00039.x",
+    "ot:studyPublicationReference": "Brumfield, R., & Edwards S. 2007. Evolution into and out of the Andes: a Bayesian analysis of historical diversification in Thamnophilus antshrikes. Evolution 61 (2): 346-367.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2460": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Karen Cranston",
+    "ot:focalClade": 35888,
+    "ot:focalCladeOTTTaxonName": "Squamata",
+    "ot:studyId": "pg_2460",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-13-93",
+    "ot:studyPublicationReference": "Pyron, Robert Alexander, Frank T Burbrink, John J Wiens. 2013. A phylogeny and revised classification of Squamata, including 4161 species of lizards and snakes. BMC Evolutionary Biology 13 (1): 93.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2484": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Angela Oliverio",
+    "ot:focalClade": 1064655,
+    "ot:focalCladeOTTTaxonName": "Amoebozoa",
+    "ot:studyId": "pg_2484",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0022780",
+    "ot:studyPublicationReference": "Lahr, D.J.G., J. Grant, T. Nguyen, J.H. Lin, L.A. Katz. 2011. Comprehensive phylogenetic reconstruction of Amoebozoa based on concatenated analyses of SSU-rDNA and actin genes. PLoS ONE 6 (7): e22780.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_251": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1573",
+    "ot:focalClade": 215086,
+    "ot:focalCladeOTTTaxonName": "Formicidae",
+    "ot:studyId": "pg_251",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1124891",
+    "ot:studyPublicationReference": "Moreau, C., Bell C., Vila R., Archibald S., & Pierce N. 2006. Phylogeny of the ants: diversification in the age of angiosperms. Science 312 (101): 101-104.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_2539": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11267",
+    "ot:studyId": "pg_2539",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000404",
+    "ot:studyPublicationReference": "Soltis D., Smith S.A., Cellinese N., Wurdack K.J., Tank D.C., Brockington S.F., Refulio-rodriguez N., Walker J.B., Moore M.J., Carlsward B.S., Bell C., Latvis M., Crawley S., Black C., Diouf D., Xi Z., Rushworth C.A., Gitzendanner M.A., Sytsma K.J., Qiu Y., Hilu K., Davis C., Sanderson M.J., Beaman R.S., Olmstead R., Judd W., Donoghue M., & Soltis P. 2011. Angiosperm phylogeny: 17 genes, 640 taxa. American Journal of Botany, 98(4), 704-730.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2542": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "No trees have confirmed rooting. (JWB)",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 844192,
+    "ot:focalCladeOTTTaxonName": "Bacteria",
+    "ot:studyId": "pg_2542",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0062510",
+    "ot:studyPublicationReference": "Lang, Jenna Morgan, Aaron E. Darling, Jonathan A. Eisen. 2013. Phylogeny of bacterial and archaeal genomes using conserved genes: supertrees and supermatrices. PLoS ONE 8 (4): e62510.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2544": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2073",
+    "ot:focalClade": 1007159,
+    "ot:focalCladeOTTTaxonName": "Hexactinellida",
+    "ot:studyId": "pg_2544",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/10635150802161088",
+    "ot:studyPublicationReference": "Dohrmann, M., Janussen D., Reitner J., Collins A., & Woerheide G. 2008. Phylogeny and evolution of glass sponges (Porifera, Hexactinellida). Systematic Biology 57 (3): 388-405.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_2551": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12889",
+    "ot:focalClade": 501484,
+    "ot:focalCladeOTTTaxonName": "Labroidei",
+    "ot:studyId": "pg_2551",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/sys060",
+    "ot:studyPublicationReference": "Wainwright, P.C., Smith W.L., Price S.A., Tang K.L., Sparks J.S., Ferry L.A., Kuhn K.L., Eytan R.I., & Near T.J. 2012. The evolution of pharyngognathy: a phylogenetic and functional appraisal of the pharyngeal jaw key innovation in labroid fishes and beyond. Systematic Biology 61 (6): 1001-1027.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2553": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Laura Katz",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S923",
+    "ot:focalClade": 5251339,
+    "ot:focalCladeOTTTaxonName": "Euglenophyceae",
+    "ot:studyId": "pg_2553",
+    "ot:studyPublication": "http://dx.doi.org/10.1046/j.1529-8817.2003.02075.x",
+    "ot:studyPublicationReference": "Nudelman M., Rossi M., Conforti V., & Triemer R. 2003. Phylogeny of Euglenophyceae based on SSU rDNA sequences: taxonomic implications. Journal of Phycology, 39(1): 226-235.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_2554": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Laura Katz",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14246",
+    "ot:focalClade": 843528,
+    "ot:focalCladeOTTTaxonName": "Oscillatoriales",
+    "ot:studyId": "pg_2554",
+    "ot:studyPublicationReference": "Engene N., & Paul V.J. 2013. Five Chemically Rich Species of Tropical Marine Cyanobacteria of the Genus Tropicimarinus Gen. Nov. (Oscillatoriales, Cyanobacteria). Journal of Phycology, .",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2556": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Laura Katz",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10169",
+    "ot:focalClade": 1094628,
+    "ot:focalCladeOTTTaxonName": "Myxogastria",
+    "ot:studyId": "pg_2556",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1550-7408.2009.00466.x",
+    "ot:studyPublicationReference": "Fiore-donno A., Kamono A., Chao E., Fukui M., & Cavalier-smith T. 2010. Invalidation of Hyperamoeba by transferring its species to other genera of Myxogastria. Journal of Eukaryotic Microbiology, 57(2): 189-196.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2564": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 667493,
+    "ot:focalCladeOTTTaxonName": "Polystichum",
+    "ot:studyId": "pg_2564",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.94.8.1413",
+    "ot:studyPublicationReference": "Driscoll, H. E., & Barrington, D. S. (2007). Origin of Hawaiian Polystichum (Dryopteridaceae) in the context of a world phylogeny. American Journal of Botany, 94(8), 1413-1424.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2565": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10948",
+    "ot:focalClade": 266533,
+    "ot:focalCladeOTTTaxonName": "Ericoideae",
+    "ot:studyId": "pg_2565",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.02.028",
+    "ot:studyPublicationReference": "Gillespie E.L., & Kron K.A. 2010. Molecular phylogenetic relationships and a revised classification of the subfamily Ericoideae (Ericaceae). Molecular Phylogenetics and Evolution, 56: 343-354.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2573": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 335588,
+    "ot:focalCladeOTTTaxonName": "Archosauria",
+    "ot:studyId": "pg_2573",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rsbl.2012.0331",
+    "ot:studyPublicationReference": "Crawford, N. G., B. C. Faircloth, J. E. McCormack, R. T. Brumfield, K. Winker, T. C. Glenn. 2012. More than 1000 ultraconserved elements provide evidence that turtles are the sister group of archosaurs. Biology Letters 8 (5): 783-786.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2576": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 212189,
+    "ot:focalCladeOTTTaxonName": "Euteleostei",
+    "ot:studyId": "pg_2576",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.1304661110",
+    "ot:studyPublicationReference": "Near, T. J., A. Dornburg, R. I. Eytan, B. P. Keck, W. L. Smith, K. L. Kuhn, J. A. Moore, S. A. Price, F. T. Burbrink, M. Friedman, P. C. Wainwright, 2013, 'Phylogeny and tempo of diversification in the superradiation of spiny-rayed fishes', Proceedings of the National Academy of Sciences, vol. 110, no. 31, pp. 12738-12743",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2577": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 837585,
+    "ot:focalCladeOTTTaxonName": "Galliformes",
+    "ot:studyId": "pg_2577",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0064312",
+    "ot:studyPublicationReference": "Wang, Ning, Rebecca T. Kimball, Edward L. Braun, Bin Liang, Zhengwang Zhang. 2013. Assessing phylogenetic relationships among Galliformes: a multigene phylogeny with expanded taxon sampling in Phasianidae. PLoS ONE 8 (5): e64312.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2585": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 36216,
+    "ot:focalCladeOTTTaxonName": "Tetraodontiformes",
+    "ot:studyId": "pg_2585",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.05.014",
+    "ot:studyPublicationReference": "Santini, Francesco, Laurie Sorenson, Michael E. Alfaro. 2013. A new phylogeny of tetraodontiform fishes (Tetraodontiformes, Acanthomorpha) based on 22 loci. Molecular Phylogenetics and Evolution 69 (1): 177-187.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2587": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10190",
+    "ot:focalClade": 698424,
+    "ot:focalCladeOTTTaxonName": "Cetacea",
+    "ot:studyId": "pg_2587",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2009.08.018",
+    "ot:studyPublicationReference": "McGowen, M., Spaulding M., and Gatesy J. 2009. Divergence date estimation and a comprehensive molecular tree of extant cetaceans. Molecular Phylogenetics and Evolution 53 (3): 891-906.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2589": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 781784,
+    "ot:focalCladeOTTTaxonName": "Gobioidei",
+    "ot:studyId": "pg_2589",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.07.017",
+    "ot:studyPublicationReference": "Agorreta, Ainhoa, Diego San Mauro, Ulrich Schliewen, James L. Van Tassell, Marcelo Kova\u010di\u0107, Rafael Zardoya, Lukas R\u00fcber. 2013. Molecular phylogenetics of Gobioidei and phylogenetic placement of European gobies. Molecular Phylogenetics and Evolution 69 (3): 619-633.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_259": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12174",
+    "ot:focalClade": 372416,
+    "ot:focalCladeOTTTaxonName": "Cercis",
+    "ot:studyId": "pg_259",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.11.016",
+    "ot:studyPublicationReference": "Fritsch, P. W., & Cruz, B. C. (2012). Phylogeny of Cercis based on DNA sequences of nuclear ITS and four plastid regions: Implications for transatlantic historical biogeography. Molecular Phylogenetics and Evolution, 62(3), 816-825.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2591": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Many duplicated taxa between Basileuterus and Myiothlypis. (JWB)",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 3599390,
+    "ot:focalCladeOTTTaxonName": "Parulidae",
+    "ot:studyId": "pg_2591",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.07.018",
+    "ot:studyPublicationReference": "Lovette, Irby J., Jorge L. P\u00e9rez-Em\u00e1n, John P. Sullivan, Richard C. Banks, Isabella Fiorentino, Sergio C\u00f3rdoba-C\u00f3rdoba, Mar\u00eda Echeverry-Galvis, F. Keith Barker, Kevin J. Burns, John Klicka, Scott M. Lanyon, Eldredge Bermingham. 2010. A comprehensive multilocus phylogeny for the wood-warblers and a revised classification of the Parulidae (Aves). Molecular Phylogenetics and Evolution 57 (2): 753-770.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2593": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14160",
+    "ot:focalClade": 567692,
+    "ot:focalCladeOTTTaxonName": "Dermaptera",
+    "ot:studyId": "pg_2593",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0066900",
+    "ot:studyPublicationReference": "Kocarek, P., John V., & Hulva P. 2013. When the body hides the ancestry: phylogeny of morphologically modified epizoic earwigs based on molecular evidence. PLoS ONE 8 (6): e66900.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2594": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13373",
+    "ot:focalClade": 661378,
+    "ot:focalCladeOTTTaxonName": "Diptera",
+    "ot:studyId": "pg_2594",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-3113.2012.00652.x",
+    "ot:studyPublicationReference": "Lambkin, C., Sinclair B., Pape T., Courtney G.W., Skevington J., Meier R., Yeates D., Blagoderov V., & Wiegmann B.M. 2013. The phylogenetic relationships among infraorders and superfamilies of Diptera based on morphological evidence. Systematic Entomology 38 (1): 164-179.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2598": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 147029,
+    "ot:focalCladeOTTTaxonName": "Boraginaceae",
+    "ot:studyId": "pg_2598",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364412x648715",
+    "ot:studyPublicationReference": "Nazaire, M., & Hufford, L. 2012. A broad phylogenetic analysis of Boraginaceae: Implications for the relationships of Mertensia. Syst. Bot. 37: 758-783.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2599": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 662954,
+    "ot:focalCladeOTTTaxonName": "Alaudidae",
+    "ot:studyId": "pg_2599",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.06.005",
+    "ot:studyPublicationReference": "Alstr\u00f6m, Per, Keith N. Barnes, Urban Olsson, F. Keith Barker, Paulette Bloomer, Aleem Ahmed Khan, Masood Ahmed Qureshi, Alban Guillaumet, Pierre-Andr\u00e9 Crochet, Peter G. Ryan. 2013. Multilocus phylogeny of the avian family Alaudidae (larks) reveals complex morphological evolution, non-monophyletic genera and hidden species diversity. Molecular Phylogenetics and Evolution 69 (3): 1043-1056.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2600": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 515153,
+    "ot:focalCladeOTTTaxonName": "Paridae",
+    "ot:studyId": "pg_2600",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.06.019",
+    "ot:studyPublicationReference": "Johansson, Ulf S., Jan Ekman, Rauri C.K. Bowie, Peter Halvarsson, Jan I. Ohlson, Trevor D. Price, Per G.P. Ericson. 2013. A complete multilocus species phylogeny of the tits and chickadees (Aves: Paridae). Molecular Phylogenetics and Evolution 69 (3): 852-860.",
+    "ot:studyYear": 2013,
+    "ot:tag": "rooted;"
+   }
+  ]
+ },
+ "pg_2604": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14049",
+    "ot:focalClade": 419526,
+    "ot:focalCladeOTTTaxonName": "Apoidea",
+    "ot:studyId": "pg_2604",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-13-138",
+    "ot:studyPublicationReference": "Hedtke, S.M., Patiny S., & Danforth B. 2013. The bee tree of life: a supermatrix approach to apoid phylogeny and biogeography. BMC Evolutionary Biology 13: 138.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2608": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13934",
+    "ot:focalClade": 648890,
+    "ot:focalCladeOTTTaxonName": "Saxifragales",
+    "ot:studyId": "pg_2608",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1300044",
+    "ot:studyPublicationReference": "Soltis, D. E., Mort, M. E., Latvis, M., Mavrodiev, E. V., O\u2019Meara, B. C., Soltis, P. S., ... & de Casas, R. R. (2013). Phylogenetic relationships and character evolution analysis of Saxifragales using a supermatrix approach. American journal of botany, 100(5), 916-929.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added for r8s chrongram"
+   }
+  ]
+ },
+ "pg_261": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12746",
+    "ot:focalClade": 792363,
+    "ot:focalCladeOTTTaxonName": "Caesalpinieae",
+    "ot:studyId": "pg_261",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.05.035",
+    "ot:studyPublicationReference": "Manzanilla V., & Bruneau A. 2012. Phylogeny reconstruction in the Caesalpinieae grade\r\n(Leguminosae) based on duplicated copies of the sucrose synthase gene and plastid\r\nmarkers. Molecular Phylogenetics and Evolution. 65: 149\u2013162.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2610": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 429482,
+    "ot:focalCladeOTTTaxonName": "Malpighiales",
+    "ot:studyId": "pg_2610",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.1205818109 ",
+    "ot:studyPublicationReference": "Xi, Z., Ruhfel, B. R., Schaefer, H., Amorim, A. M., Sugumaran, M., Wurdack, K. J., ... & Davis, C. C. (2012). Phylogenomics and a posteriori data partitioning resolve the Cretaceous angiosperm radiation Malpighiales. Proceedings of the National Academy of Sciences, 109(43), 17519-17524.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added for combined gene tree"
+   }
+  ]
+ },
+ "pg_2614": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14395",
+    "ot:focalClade": 569173,
+    "ot:focalCladeOTTTaxonName": "Nicrophorinae",
+    "ot:studyId": "pg_2614",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.07.022",
+    "ot:studyPublicationReference": "Sikes, D.S., & Venables C. 2013. Molecular phylogeny of the burying beetles (Coleoptera: Silphidae: Nicrophorinae). Molecular Phylogenetics and Evolution 69 (3): 552-565.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2624": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 648853,
+    "ot:focalCladeOTTTaxonName": "Veronica",
+    "ot:studyId": "pg_2624",
+    "ot:studyPublicationReference": "M\u00fcller, K., & Albach, D. C. 2010. Evolutionary rates in Veronica L. (Plantaginaceae): Disentangling the influence of life history and breeding system. J. Mol. Evol. 70: 44-56.",
+    "ot:studyYear": 2010,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2625": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 512422,
+    "ot:focalCladeOTTTaxonName": "Utricularia",
+    "ot:studyId": "pg_2625",
+    "ot:studyPublicationReference": "M\u00fcller, K., & Borsch, T. 2005a. Phylogenetics of Utricularia (Lentibulariaceae) and molecular evolution of the trnK intron in a lineage with high substitution rates. Plant Syst. Evol. 250: 39-67.",
+    "ot:studyYear": 2005,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2626": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 317791,
+    "ot:focalCladeOTTTaxonName": "Amaranthaceae",
+    "ot:studyId": "pg_2626",
+    "ot:studyPublication": "http://www.jstor.org/stable/3298649",
+    "ot:studyPublicationReference": "M\u00fcller, K., & Borsch, T. 2005b. Phylogenetics of Amaranthaceae based on matK/trnK sequence data - evidence from parsimony, likelihood, and Bayesian analysis. Ann. Missouri Bot. Gard. 92: 66-102.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_2628": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14253",
+    "ot:focalClade": 436548,
+    "ot:focalCladeOTTTaxonName": "Heteronychia",
+    "ot:studyId": "pg_2628",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/zoj.12070",
+    "ot:studyPublicationReference": "Whitmore, D., Pape T., & Cerretti P. 2013. Phylogeny of Heteronychia: the largest lineage of Sarcophaga (Diptera: Sarcophagidae). Zoological Journal of the Linnean Society 169 (3): 604-639.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2629": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 1062253,
+    "ot:focalCladeOTTTaxonName": "Insecta",
+    "ot:studyId": "pg_2629",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/syen.12028",
+    "ot:studyPublicationReference": "Letsch, H. and S. Simon. 2013. Insect phylogenomics: new insights on the relationships of lower neopteran orders (Polyneoptera). Systematic Entomology 38 (4): 783-793.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_263": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Kristen Swithers",
+    "ot:studyId": "pg_263",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/gbe/evs057",
+    "ot:studyPublicationReference": "Swithers KS, Petrus AK, Secinaro MA, Nesb\u00f8 CL, Gogarten JP, Noll KM, Butzin NC. 2012. Vitamin B12 synthesis and salvage pathways were acquired by horizontal gene transfer to the thermotogales. Genome Biology and Evolution 4 (8): 842-851.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2633": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 592259,
+    "ot:focalCladeOTTTaxonName": "Narcissus",
+    "ot:studyId": "pg_2633",
+    "ot:studyPublicationReference": "R\u00f8nsted, N., Savolainen, V., M\u00f8lgaard, P., & J\u00e4ger, A. K. (2008). Phylogenetic selection of Narcissus species for drug discovery. Biochemical Systematics and Ecology, 36(5), 417-422.",
+    "ot:studyYear": 2008,
+    "ot:tag": "ingroup added for combined gene tree"
+   }
+  ]
+ },
+ "pg_2634": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 258475,
+    "ot:focalCladeOTTTaxonName": "Galanthus",
+    "ot:studyId": "pg_2634",
+    "ot:studyPublicationReference": "R\u00f8nsted, N., Zubov, D., Bruun-Lund, S., & Davis, A. P. (2013).Snowdrops falling slowly into place: An improved phylogeny for Galanthus (Amaryllidaceae). Molecular phylogenetics and evolution.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added for combined gene tree"
+   }
+  ]
+ },
+ "pg_2638": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 648888,
+    "ot:focalCladeOTTTaxonName": "Santalales",
+    "ot:studyId": "pg_2638",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2008.01.016",
+    "ot:studyPublicationReference": "Vidal-Russell, R., & Nickrent, D. L. 2008a. The first mistletoes: Origin of aerial parasitism in Santalales. Mol. Phyl. Evol. 47: 523-537.",
+    "ot:studyYear": 2008,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_264": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10438",
+    "ot:focalClade": 1085825,
+    "ot:focalCladeOTTTaxonName": "Coursetia",
+    "ot:studyId": "pg_264",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X553144",
+    "ot:studyPublicationReference": "Paganucci de queiroz L., & Lavin M. 2011. Coursetia (Leguminosae) From Eastern Brazil: Nuclear Ribosomal and Chloroplast DNA Sequence Analysis reveal the Monophyly of Three Caatinga-inhabiting Species. Systematic Botany, 36(1): 69-79",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2641": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1014022,
+    "ot:focalCladeOTTTaxonName": "Rubiaceae",
+    "ot:studyId": "pg_2641",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/599077",
+    "ot:studyPublicationReference": "Bremer, B., & Eriksson, O. 2009. Time tree of Rubiaceae: Phylogeny and dating the family, subfamilies and tribes. Internat. J. Plant Sci. 170: 766-793.",
+    "ot:studyYear": 2009,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2642": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 216628,
+    "ot:focalCladeOTTTaxonName": "Caryophyllales",
+    "ot:studyId": "pg_2642",
+    "ot:studyPublicationReference": "Sch\u00e4ferhoff, B. [et al. 2009], M\u00fcller, K. F., & Borsch, T. 2009. Caryophyllales phylogenetics: Disentangling Phytolaccaceae and Molluginaceae and description of Microteaceae as a new isolated family. Willdenowia 39: 209-228.",
+    "ot:studyYear": 2009,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2644": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 872975,
+    "ot:focalCladeOTTTaxonName": "Ranunculales",
+    "ot:studyId": "pg_2644",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ppees.2009.01.001",
+    "ot:studyPublicationReference": "Wang, Wei, An-Ming Lu, Yi Ren, Mary E. Endress, Zhi-Duan Chen. 2009. 'Phylogeny and classification of Ranunculales: Evidence from four molecular loci and morphological data. Perspectives in Plant Ecology, Evolution and Systematics 11 (2): 81-110",
+    "ot:studyYear": 2009,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2645": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 964065,
+    "ot:focalCladeOTTTaxonName": "Menispermaceae",
+    "ot:studyId": "pg_2645",
+    "ot:studyPublicationReference": "Wang, W. [et al. 2012], Ortiz, R. D. C., Jacques, F. M. B., Xiang, X.-G., Li, H.-L., Lin, L., Li, R.-Q., Liu, Y., Soltis, P. S., Soltis, D. E. & Chen, Z.-D. 2012. Menispermaceae and the diversification of tropical rainforests near the Cretaceous-Paleogene boundary. New Phytol. 195: 470-478.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2648": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 927429,
+    "ot:focalCladeOTTTaxonName": "Marchantiales",
+    "ot:studyId": "pg_2648",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s00239-010-9348-9",
+    "ot:studyPublicationReference": "Volkmar, U., & Knoop, V. (2010). Introducing intron locus cox1i624 for phylogenetic analyses in bryophytes: on the issue of Takakia as sister genus to all other extant mosses. Journal of molecular evolution, 70(5), 506-518.",
+    "ot:studyYear": 2010,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2653": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 500768,
+    "ot:focalCladeOTTTaxonName": "Percomorpha",
+    "ot:studyId": "pg_2653",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0073535",
+    "ot:studyPublicationReference": "Miya, Masaki, Matt Friedman, Takashi P. Satoh, Hirohiko Takeshima, Tetsuya Sado, Wataru Iwasaki, Yusuke Yamanoue, Masanori Nakatani, Kohji Mabuchi, Jun G. Inoue, Jan Yde Poulsen, Tsukasa Fukunaga, Yukuto Sato, Mutsumi Nishida. 2013. Evolutionary Origin of the Scombridae (Tunas and Mackerels): Members of a Paleogene Adaptive Radiation with 14 Other Pelagic Fish Families. PLoS ONE 8 (9): e73535.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2654": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 563241,
+    "ot:focalCladeOTTTaxonName": "Leiognathidae",
+    "ot:studyId": "pg_2654",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-294X.2011.05112.x",
+    "ot:studyPublicationReference": "Chakrabarty, Prosanta, Matthew P. Davis, W. Leo Smith, Zachary H. Baldwin, John S. Sparks. 2011. Is sexual selection driving diversification of the bioluminescent ponyfishes (Teleostei: Leiognathidae)? Molecular Ecology 20 (13): 2818-2834.",
+    "ot:studyYear": 2011,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2655": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 811925,
+    "ot:focalCladeOTTTaxonName": "Cichlidae",
+    "ot:studyId": "pg_2655",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2013.1733",
+    "ot:studyPublicationReference": "Friedman, M., B. P. Keck, A. Dornburg, R. I. Eytan, C. H. Martin, C. D. Hulsey, P. C. Wainwright, T. J. Near. 2013. Molecular and fossil evidence place the origin of cichlid fishes long after Gondwanan rifting. Proceedings of the Royal Society B: Biological Sciences 280 (1770): 20131733",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added"
+   }
+  ]
+ },
+ "pg_2656": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "\"Alouatta nigerrima\" seems to be missing from OTT, despite being a good species (e.g. http://www.iucnredlist.org/details/136332/0)",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 913935,
+    "ot:focalCladeOTTTaxonName": "Primates",
+    "ot:studyId": "pg_2656",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0049521",
+    "ot:studyPublicationReference": "Springer, Mark S., Robert W. Meredith, John Gatesy, Christopher A. Emerling, Jong Park, Daniel L. Rabosky, Tanja Stadler, Cynthia Steiner, Oliver A. Ryder, Jan E. Jane\u010dka, Colleen A. Fisher, William J. Murphy. 2012. Macroevolutionary dynamics and historical biogeography of primate diversification inferred from a species supermatrix. PLoS ONE 7 (11): e49521.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2657": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 500768,
+    "ot:focalCladeOTTTaxonName": "Percomorpha",
+    "ot:studyId": "pg_2657",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.01.011",
+    "ot:studyPublicationReference": "Near, Thomas J., Michael Sandel, Kristen L. Kuhn, Peter J. Unmack, Peter C. Wainwright, Wm. Leo Smith. 2012. Nuclear gene-inferred phylogenies resolve the relationships of the enigmatic Pygmy Sunfishes, Elassoma (Teleostei: Percomorpha). Molecular Phylogenetics and Evolution 63 (2): 388-395.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2659": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 285818,
+    "ot:focalCladeOTTTaxonName": "Otophysi",
+    "ot:studyId": "pg_2659",
+    "ot:studyPublicationReference": "Chen, Wei-Jen, S\u00e9bastien Lavou\u00e9, and Richard L. Mayden. 2013. Evolutionary origin and early biogeography of otophysan fishes (Ostariophysi: Teleostei). Evolution 67 (8): 2218\u20132239.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2661": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 648892,
+    "ot:focalCladeOTTTaxonName": "Ericales",
+    "ot:studyId": "pg_2661",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/427198",
+    "ot:studyPublicationReference": "Sch\u00f6nenberger, J. [et al. 2005], Anderberg, A. A., & Sytsma, K. J. 2005. Molecular phylogenetics and patterns of floral evolution in the Ericales. Internat. J. Plant Sci. 166: 265-288.",
+    "ot:studyYear": 2005,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2664": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 596629,
+    "ot:focalCladeOTTTaxonName": "Ditrysia",
+    "ot:studyId": "pg_2664",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0058568",
+    "ot:studyPublicationReference": "Regier, JC, Mitter C, Zwick A, Bazinet AL, Cummings MP, et al. (2013) A large-scale, higher-level, molecular phylogenetic study of the insect order Lepidoptera (moths and butterflies). PLoS ONE 8 (3): e58568",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2667": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 592849,
+    "ot:focalCladeOTTTaxonName": "Kiwaidae",
+    "ot:studyId": "pg_2667",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2013.0718",
+    "ot:studyPublicationReference": "Roterman, CN, Copley JT, Linse KT, Tyler PA, Rogers AD. 2013 The biogeography of the yeti crabs (Kiwaidae) with notes on the phylogeny of the Chirostyloidea (Decapoda: Anomura). Proceedings of the Royal Society B 280 (1764): 20130718",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2669": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1074933,
+    "ot:focalCladeOTTTaxonName": "Lamioideae",
+    "ot:studyId": "pg_2669",
+    "ot:studyPublication": "http://www.ingentaconnect.com/content/iapt/tax/2011/00000060/00000002/art00015",
+    "ot:studyPublicationReference": "Bendiksby, M., Thorbek, L., Scheen, A. C., Lindqvist, C., & Ryding, O. (2011). An updated phylogeny and classification of Lamiaceae subfamily Lamioideae. Taxon, 60(2), 471-484.",
+    "ot:studyYear": 2011,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_267": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S9962",
+    "ot:focalClade": 807784,
+    "ot:focalCladeOTTTaxonName": "Ateleia",
+    "ot:studyId": "pg_267",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1095-8339.2009.01016",
+    "ot:studyPublicationReference": "Ireland H., Kite G., Veitch N., Chase M., Schrire B., Lavin M., & Pennington R. 2010.\r\nBiogeographic, ecological, and morphological structure of a phylogenetic analysis\r\nof Ateleia (Swartzieae-Leguminosae) derived from combined molecular and morphological/chemical\r\ndata. Botanical Journal of the Linnean Society, 162(1): 39-53.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2670": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 76859,
+    "ot:focalCladeOTTTaxonName": "Atyidae",
+    "ot:studyId": "pg_2670",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.12.015",
+    "ot:studyPublicationReference": "von Rintelen K, Page TJ, Cai Y, Roe K, Stelbrink B, Kuhajda BR, Iliffe TM, Hughes J, von Rintelen T. 2012. Drawn to the dark side: a molecular phylogeny of freshwater shrimps (Crustacea: Decapoda: Caridea: Atyidae) reveals frequent cave invasions and challenges current taxonomic hypotheses. Mol Phylogenet Evol. 2012 Apr;63(1):82-96.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2671": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 76861,
+    "ot:focalCladeOTTTaxonName": "Caridina",
+    "ot:studyId": "pg_2671",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.07.002",
+    "ot:studyPublicationReference": "von Rintelen, Kristina, Thomas von Rintelen, and Matthias Glaubrecht. 2007. Molecular phylogeny and diversification of freshwater shrimps (Decapoda, Atyidae, Caridina) from ancient Lake Poso (Sulawesi, Indonesia) \u2014 the importance of being colourful. Molecular Phylogenetics and Evolution 45 (3): 1033-1041.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2673": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 43426,
+    "ot:focalCladeOTTTaxonName": "Parastacidae",
+    "ot:studyId": "pg_2673",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-2699.2010.02374.x",
+    "ot:studyPublicationReference": "Toon, A., P\u00e9rez\u2010Losada, M., Schweitzer, C. E., Feldmann, R. M., Carlson, M., & Crandall, K. A. (2010). Gondwanan radiation of the Southern Hemisphere crayfishes (Decapoda: Parastacidae): evidence from fossils and molecules. Journal of Biogeography 37 (12): 2275-2290.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2674": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 550675,
+    "ot:focalCladeOTTTaxonName": "Fallicambarus",
+    "ot:studyId": "pg_2674",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/zsc.12006",
+    "ot:studyPublicationReference": "Ainscough, B. J., Breinholt, J. W., Robison, H. W., & Crandall, K. A. (2013). Molecular phylogenetics of the burrowing crayfish genus Fallicambarus (Decapoda: Cambaridae). Zoologica Scripta.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2675": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 876591,
+    "ot:focalCladeOTTTaxonName": "Cambarus",
+    "ot:studyId": "pg_2675",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0046105",
+    "ot:studyPublicationReference": "Breinholt, JW, Porter ML, Crandall KA (2012) Testing phylogenetic hypotheses of the subgenera of the freshwater crayfish genus Cambarus (Decapoda: Cambaridae). PLoS ONE 7 (9): e46105",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2676": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 235752,
+    "ot:focalCladeOTTTaxonName": "Scyllaridae",
+    "ot:studyId": "pg_2676",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.09.019",
+    "ot:studyPublicationReference": "Yang, C. H., Bracken-Grissom, H., Kim, D., Crandall, K. A., & Chan, T. Y. (2012). Phylogenetic relationships, character evolution, and taxonomic implications within the slipper lobsters (Crustacea: Decapoda: Scyllaridae). Molecular Phylogenetics and Evolution 62 (1): 237-250.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2677": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 653857,
+    "ot:focalCladeOTTTaxonName": "Anomura",
+    "ot:studyId": "pg_2677",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-13-128",
+    "ot:studyPublicationReference": "Bracken-Grissom, Heather D., Maren E. Cannon, Patricia Cabezas, Rodney M. Feldmann, Carrie E. Schweitzer, Shane T. Ahyong, Darryl L. Felder, Rafael Lemaitre, and Keith A. Crandall. 2013. A comprehensive and integrative reconstruction of evolutionary history for Anomura (Crustacea: Decapoda). BMC Evolutionary Biology 13 (1): 128.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2678": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 451020,
+    "ot:focalCladeOTTTaxonName": "Echinodermata",
+    "ot:studyId": "pg_2678",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syr044",
+    "ot:studyPublicationReference": "Janies, D., Voight, J., Daly, M., (2011) Echinoderm phylogeny including Xyloplax, a progenetic asteroid. Systematic Biology 604 (4): 420-438.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2682": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 28229,
+    "ot:focalCladeOTTTaxonName": "Procarididae",
+    "ot:studyId": "pg_2682",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1463-6409.2009.00410.x",
+    "ot:studyPublicationReference": "Bracken, H. D., De Grave, S., Toon, A., Felder, D. L., & Crandall, K. A. 2010. Phylogenetic position, systematic status, and divergence time of the Procarididea (Crustacea: Decapoda). Zoologica Scripta 39 (2): 198-212.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2683": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 212710,
+    "ot:focalCladeOTTTaxonName": "Dendrobranchiata",
+    "ot:studyId": "pg_2683",
+    "ot:studyPublication": "http://dx.doi.org/10.1002/ece3.347",
+    "ot:studyPublicationReference": "Bracken\u2010Grissom, H. D., Felder, D. L., Vollmer, N. L., Martin, J. W., & Crandall, K. A. (2012). Phylogenetics links monster larva to deep\u2010sea shrimp. Ecology and Evolution 2 (10): 2367-2373.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2684": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 397138,
+    "ot:focalCladeOTTTaxonName": "Hyaenidae",
+    "ot:studyId": "pg_2684",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2005.10.017",
+    "ot:studyPublicationReference": "Koepfli, Klaus-Peter, Susan M. Jenks, Eduardo Eizirik, Tannaz Zahirpour, Blaire Van Valkenburgh, Robert K. Wayne. 2006. Molecular systematics of the Hyaenidae: Relationships of a relictual lineage resolved by a molecular supermatrix. Molecular Phylogenetics and Evolution 38 (3): 603-620.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_2685": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 348043,
+    "ot:focalCladeOTTTaxonName": "Mustelidae",
+    "ot:studyId": "pg_2685",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1741-7007-6-10",
+    "ot:studyPublicationReference": "Koepfli, Klaus-Peter, Kerry A Deere, Graham J Slater, Colleen Begg, Keith Begg, Lon Grassman, Mauro Lucherini, Geraldine Veron, Robert K Wayne. 2008. Multigene phylogeny of the Mustelidae: Resolving relationships, tempo and biogeographic history of a mammalian adaptive radiation. BMC Biology 6 (1): 10.",
+    "ot:studyYear": 2008,
+    "ot:tag": "ingroup added"
+   }
+  ]
+ },
+ "pg_2687": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 749626,
+    "ot:focalCladeOTTTaxonName": "Phocidae",
+    "ot:studyId": "pg_2687",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2009.1783",
+    "ot:studyPublicationReference": "Fulton, T. L., C. Strobeck. 2010. Multiple markers and multiple individuals refine true seal phylogeny and bring molecules and morphology back in line. Proceedings of the Royal Society B: Biological Sciences 277 (1684): 1065-1070.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2688": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 864593,
+    "ot:focalCladeOTTTaxonName": "Rodentia",
+    "ot:studyId": "pg_2688",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-12-88",
+    "ot:studyPublicationReference": "Fabre, Pierre-Henri, Lionel Hautier, Dimitar Dimitrov, Emmanuel J P Douzery. 2012. A glimpse on the pattern of rodent diversification: a phylogenetic approach. BMC Evolutionary Biology 12 (1): 88.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2689": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 878988,
+    "ot:focalCladeOTTTaxonName": "Lupinus",
+    "ot:studyId": "pg_2689",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syr126",
+    "ot:studyPublicationReference": "Drummond, C. S., Eastwood, R. J., Miotto, S. T., & Hughes, C. E. (2012). Multiple continental radiations and correlates of diversification in Lupinus (Leguminosae): testing for key innovation with incomplete taxon sampling. Systematic Biology 61(3), 443-460.",
+    "ot:studyYear": 2012,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2690": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 560323,
+    "ot:focalCladeOTTTaxonName": "Fabaceae",
+    "ot:studyId": "pg_2690",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.91.11.1846",
+    "ot:studyPublicationReference": "Wojciechowski M., Lavin M., & Sanderson M. 2004. A phylogeny of legumes (Leguminosae) based on analysis of the plastid matK gene resolves many well-supported subclades within the family. American Journal of Botany, 91: 1846-1862.",
+    "ot:studyYear": 2004,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2691": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 872571,
+    "ot:focalCladeOTTTaxonName": "Procyonidae",
+    "ot:studyId": "pg_2691",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2006.10.003",
+    "ot:studyPublicationReference": "Koepfli, Klaus-Peter, Matthew E. Gompper, Eduardo Eizirik, Cheuk-Chung Ho, Leif Linden, Jesus E. Maldonado, Robert K. Wayne. 2007. Phylogeny of the Procyonidae (Mammalia: Carnivora): Molecules, morphology and the Great American Interchange. Molecular Phylogenetics and Evolution 43 (3): 1076-1095.",
+    "ot:studyYear": 2007,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2695": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 297458,
+    "ot:focalCladeOTTTaxonName": "Ursidae",
+    "ot:studyId": "pg_2695",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-8-220",
+    "ot:studyPublicationReference": "Krause, Johannes, Tina Unger, Aline No\u00e7on, Anna-Sapfo Malaspinas, Sergios-Orestis Kolokotronis, Mathias Stiller, Leopoldo Soibelzon, Helen Spriggs, Paul H Dear, Adrian W Briggs, Sarah CE Bray, Stephen J O'Brien, Gernot Rabeder, Paul Matheus, Alan Cooper, Montgomery Slatkin, Svante P\u00e4\u00e4bo, Michael Hofreiter. 2008. Mitochondrial genomes reveal an explosive radiation of extinct and extant bears near the Miocene-Pliocene boundary. BMC Evolutionary Biology 8 (1): 220.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_2696": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 67816,
+    "ot:focalCladeOTTTaxonName": "Demospongiae",
+    "ot:studyId": "pg_2696",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pone.0050437",
+    "ot:studyPublicationReference": "Hill, Malcolm S., April L. Hill, Jose Lopez, Kevin J. Peterson, Shirley Pomponi, Maria C. Diaz, Robert W. Thacker, Maja Adamska, Nicole Boury-Esnault, Paco C\u00e1rdenas, Andia Chaves-Fonnegra, Elizabeth Danka, Bre-Onna De Laine, Dawn Formica, Eduardo Hajdu, Gisele Lobo-Hajdu, Sarah Klontz, Christine C. Morrow, Jignasa Patel, Bernard Picton, Davide Pisani, Deborah Pohlmann, Niamh E. Redmond, John Reed, Stacy Richey, Ana Riesgo, Ewelina Rubin, Zach Russell, Klaus R\u00fctzler, Erik A. Sperling, Michael di Stefano, James E. Tarver, Allen G. Collins. 2013. Reconstruction of family-level phylogenetic relationships within Demospongiae (Porifera) using nuclear encoded housekeeping genes. PLoS ONE 8 (1): e50437.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_270": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2186",
+    "ot:focalClade": 563854,
+    "ot:focalCladeOTTTaxonName": "Indigofereae",
+    "ot:studyId": "pg_270",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0800185",
+    "ot:studyPublicationReference": "Schrire, B. D. [et al. 2009], Lavin, M., Barker, N. P., & Forest, F. 2009. Phylogeny of the tribe Indigofereae (Leguminosae-Papilionoideae): Geographically structured more in succulent-rich and temperate settings than in grass-rich environments. American J. Bot. 96: 816-852.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2707": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 640561,
+    "ot:focalCladeOTTTaxonName": "Icteridae",
+    "ot:studyId": "pg_2707",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.11.009",
+    "ot:studyPublicationReference": "Powell, Alexis F.L.A., F. Keith Barker, Scott M. Lanyon, Kevin J. Burns, John Klicka, Irby J. Lovette. 2014. A comprehensive species-level molecular phylogeny of the New World blackbirds (Icteridae). Molecular Phylogenetics and Evolution 71: 94-112.",
+    "ot:studyYear": 2014,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2708": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 641033,
+    "ot:focalCladeOTTTaxonName": "Cnidaria",
+    "ot:studyId": "pg_2708",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-13-5",
+    "ot:studyPublicationReference": "Kayal, E., Roure, B., Philippe, H., Collins, A. G., & Lavrov, D. V. 2013. Cnidarian phylogenetic relationships as revealed by mitogenomics. BMC Evolutionary Biology 13 (1): 5.",
+    "ot:studyYear": 2013,
+    "ot:tag": "rooted;"
+   }
+  ]
+ },
+ "pg_2709": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:focalClade": 67816,
+    "ot:focalCladeOTTTaxonName": "Demospongiae",
+    "ot:studyId": "pg_2709",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/icb/ict078",
+    "ot:studyPublicationReference": "Redmond, N. E., Morrow, C. C., Thacker, R. W., Diaz, M. C., Boury-Esnault, N., C\u00e1rdenas, P., Hajdu, E., Lobo-Hajdu, G., Picton, B.E., Pomponi, S.A., Kayal, E., Collins, A. G. 2013. Phylogeny and systematics of Demospongiae in light of new small-subunit ribosomal DNA (18S) sequences. Integrative and Comparative Biology 53 (3): 388-415.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_271": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1718",
+    "ot:focalClade": 299382,
+    "ot:focalCladeOTTTaxonName": "Polygalaceae",
+    "ot:studyId": "pg_271",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1558-5646.2007.00138",
+    "ot:studyPublicationReference": "Forest, F., Chase, M. W., Persson, C., Crane, P. R., & Hawkins, J. A. (2007). The role of biotic and abiotic factors in evolution of ant dispersal in the milkwort family (Polygalaceae). Evolution, 61(7), 1675-1694.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_2710": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 691846,
+    "ot:focalCladeOTTTaxonName": "Metazoa",
+    "ot:studyId": "pg_2710",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1242592",
+    "ot:studyPublicationReference": "Ryan, J. F., K. Pang, C. E. Schnitzler, A.-D. Nguyen, R. T. Moreland, D. K. Simmons, B. J. Koch, W. R. Francis, P. Havlak, S. A. Smith, N. H. Putnam, S. H. D. Haddock, C. W. Dunn, T. G. Wolfsberg, J. C. Mullikin, M. Q. Martindale, A. D. Baxevanis. 2013. The genome of the ctenophore Mnemiopsis leidyi and its implications for cell type evolution. Science 342 (6164): 1242592-1242592.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2711": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 591361,
+    "ot:focalCladeOTTTaxonName": "Henophidia",
+    "ot:studyId": "pg_2711",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.11.011",
+    "ot:studyPublicationReference": "Reynolds, R. Graham, Matthew L. Niemiller, Liam J. Revell. 2014. Toward a Tree-of-Life for the boas and pythons: Multilocus species-level phylogeny with unprecedented taxon sampling. Molecular Phylogenetics and Evolution 71: 201-213.",
+    "ot:studyYear": 2014,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2712": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 1008296,
+    "ot:focalCladeOTTTaxonName": "rosids",
+    "ot:studyId": "pg_2712",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.0813376106 ",
+    "ot:studyPublicationReference": "Wang, Hengchang, Michael J. Moore, Pamela S. Soltis, Charles D. Bell, Samuel F. Brockington, Roolse Alexandre, Charles C. Davis, Maribeth Latvis, Steven R. Manchester, and Douglas E. Soltis. 2009. Rosid radiation and the rapid rise of angiosperm-dominated forests. Proceedings of the National Academy of Sciences 106, no. 10 (March 10): 3853 -3858. doi:10.1073/pnas.0813376106.",
+    "ot:studyYear": 2009,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2713": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Dail Laughinghouse",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10238",
+    "ot:focalClade": 231664,
+    "ot:focalCladeOTTTaxonName": "Arthrospira",
+    "ot:studyId": "pg_2713",
+    "ot:studyPublication": "http://dx.doi.org/10.2216/09-71.1",
+    "ot:studyPublicationReference": "Dadheech P., Ballot A., Casper P., Kotut K., Novelo E., Lemma B., Pr?schold T., & Krienitz L. 2010. Phylogenetic relationship and divergence among planktonic strains of Arthrospira (Oscillatoriales, Cyanobacteria) of African, Asian and American origin deduced by 16S?23S ITS and phycocyanin operon sequences. Phycologia, 49(4): 361-372.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2715": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Dail Laughinghouse",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11359",
+    "ot:focalClade": 996421,
+    "ot:focalCladeOTTTaxonName": "Archaea",
+    "ot:studyId": "pg_2715",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/molbev/msr098",
+    "ot:studyPublicationReference": "M. Groussin, M. Gouy, 2011, 'Adaptation to Environmental Temperature Is a Major Determinant of Molecular Evolutionary Rates in Archaea', Molecular Biology and Evolution, vol. 28, no. 9, pp. 2661-2674",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2731": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S370",
+    "ot:focalClade": 996421,
+    "ot:focalCladeOTTTaxonName": "Archaea (domain in cellular organisms)",
+    "ot:studyId": "pg_2731",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.93.17.9188",
+    "ot:studyPublicationReference": "Barns, S. M., C. F. Delwiche, J. D. Palmer, N. R. Pace. 1996. Perspectives on archaeal diversity, thermophily and monophyly from environmental rRNA sequences. Proceedings of the National Academy of Sciences 93 (17): 9188-9193.",
+    "ot:studyYear": 1996
+   }
+  ]
+ },
+ "pg_2737": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Dail Laughinghouse",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 368777,
+    "ot:focalCladeOTTTaxonName": "Nostocales",
+    "ot:studyId": "pg_2737",
+    "ot:studyPublication": "http://dx.doi.org/10.2216/11-32.1",
+    "ot:studyPublicationReference": "Vera Regina Werner, Haywood Dail Laughinghouse IV, Marli F\u00e1tima Fiore, C\u00e9lia Leite Sant'Anna, Caroline Hoff, Kleber Renan de Souza Santos, Emanuel Bruno Neuhaus, Renato Jos\u00e9 Reis Molica, Ricardo Yukio Honda, Ricardo Omar Echenique, 2012, 'Morphological and molecular studies of Sphaerospermopsis torques-reginae (Cyanobacteria, Nostocales) from South American water blooms', Phycologia, vol. 51, no. 2, pp. 228-238",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2738": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 843528,
+    "ot:focalCladeOTTTaxonName": "Oscillatoriales",
+    "ot:studyId": "pg_2738",
+    "ot:studyPublication": "http://www.fottea.cz/_contents/F12-2-2012-12.pdf",
+    "ot:studyPublicationReference": "Kling, Hedy J., H. Dail Laughinghouse IV, Jan \u0160marda, Ji\u0159\u00ed Kom\u00e1rek, Judy \nAcreman, Karl Bruun, Sue B. Watson & Feng Chen. 2012.  A new red colonial Pseudanabaena (Cyanoprokaryota, Oscillatoriales) from North American large lakes. Fottea, Olomouc, 12 (2): 327\u2013339.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2739": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Files available here: http://www.biomedcentral.com/1471-2148/11/45/additional",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 225495,
+    "ot:focalCladeOTTTaxonName": "Cyanobacteria",
+    "ot:studyId": "pg_2739",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-11-45",
+    "ot:studyPublicationReference": "Schirrmeister, Bettina E, Alexandre Antonelli, Homayoun C Bagheri. 2011. The origin of multicellularity in cyanobacteria. BMC Evolutionary Biology 11 (1): 45.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2741": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 842867,
+    "ot:focalCladeOTTTaxonName": "Catarrhini",
+    "ot:studyId": "pg_2741",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2010.0663",
+    "ot:studyPublicationReference": "Tarver, J. E., P. C. J. Donoghue, M. J. Benton. 2011. Is evolutionary history repeatedly rewritten in light of new fossil discoveries? Proceedings of the Royal Society B: Biological Sciences 278 (1705): 599-604.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2742": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10082",
+    "ot:focalClade": 621380,
+    "ot:focalCladeOTTTaxonName": "Dinophyceae",
+    "ot:studyId": "pg_2742",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.protis.2009.06.004",
+    "ot:studyPublicationReference": "G\u00f3mez F., Moreira D., & L\u00f3pez-garc\u00eda P. 2009. Neoceratium gen. nov., a New Genus for All Marine Species Currently Assigned to Ceratium (Dinophyceae). Protist, 161(1): 35-54.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_275": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10157",
+    "ot:focalClade": 601168,
+    "ot:focalCladeOTTTaxonName": "Celastraceae",
+    "ot:studyId": "pg_275",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410791638289",
+    "ot:studyPublicationReference": "Coughenour J., Simmons M., Lombardi J., & Cappa J. 2010. Phylogeny of Celastraceae subfamily Salacioideae and tribe Lophopetaleae Inferred from Morphological Characters and Nuclear and Plastid Genes. Systematic Botany, 35(2): 358-367",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2753": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Karen Cranston",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11451",
+    "ot:focalClade": 424023,
+    "ot:focalCladeOTTTaxonName": "Enterobacteriaceae",
+    "ot:studyId": "pg_2753",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1741-7007-9-87",
+    "ot:studyPublicationReference": "Filip Husn\u00edk, Tom\u00e1\u0161 Chrudimsk\u00fd, V\u00e1clav Hyp\u0161a, 2011, 'Multiple origins of endosymbiosis within the Enterobacteriaceae (\u03b3-Proteobacteria): convergence of complex phylogenetic approaches', BMC Biology, vol. 9, no. 1, p. 87",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2757": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14910",
+    "ot:focalClade": 248067,
+    "ot:focalCladeOTTTaxonName": "Proteobacteria",
+    "ot:studyId": "pg_2757",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2013.2146",
+    "ot:studyPublicationReference": "Sachs J.L., Skophammer R.G., Bansal N., & Stajich J.E. 2013. Evolutionary origins and diversification of proteobacterial mutualists. Proceedings of the Royal Society B: Biological Sciences, .",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2798": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 494366,
+    "ot:focalCladeOTTTaxonName": "Sphenisciformes",
+    "ot:studyId": "pg_2798",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rsbl.2013.0748",
+    "ot:studyPublicationReference": "Subramanian, S., G. Beans-Picon, S. K. Swaminathan, C. D. Millar, D. M. Lambert. 2013. Evidence for a recent origin of penguins. Biology Letters 9 (6): 20130748-20130748.",
+    "ot:studyYear": 2013,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2805": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1020133,
+    "ot:focalCladeOTTTaxonName": "Psittaciformes",
+    "ot:studyId": "pg_2805",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/molbev/msn160",
+    "ot:studyPublicationReference": "Wright, T. F., E. E. Schirtzinger, T. Matsumoto, J. R. Eberhard, G. R. Graves, J. J. Sanchez, S. Capelli, H. Muller, J. Scharpegge, G. K. Chambers, R. C. Fleischer. 2008. A multilocus molecular phylogeny of the parrots (Psittaciformes): support for a Gondwanan origin during the Cretaceous. Molecular Biology and Evolution 25 (10): 2141-2156.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_2807": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12658",
+    "ot:focalClade": 471793,
+    "ot:focalCladeOTTTaxonName": "Alpheidae",
+    "ot:studyId": "pg_2807",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.04.015",
+    "ot:studyPublicationReference": "Anker, A., & Baeza J. 2012. Molecular and morphological phylogeny of hooded shrimps, genera Betaeus and Betaeopsis (Decapoda, Alpheidae): testing the Center of Origin biogeographic model and evolution of life history traits. Molecular Phylogenetics and Evolution 64 (3): 401-415.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2808": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Chris Owen",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14330",
+    "ot:focalClade": 92496,
+    "ot:focalCladeOTTTaxonName": "Lysmata",
+    "ot:studyId": "pg_2808",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.05.013",
+    "ot:studyPublicationReference": "Baeza, J. 2013. Baeza, J.A. 2013. Multi-locus molecular phylogeny of broken-back shrimps (genus Lysmata and allies): a test of the 'Tomlinson-Ghiselin' hypothesis explaining the evolution of simultaneous hermaphroditism. Molecular Evolution and Phylogenetics 69 (1): 46-62.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2811": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 130014,
+    "ot:focalCladeOTTTaxonName": "Vespidae",
+    "ot:studyId": "pg_2811",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2014.01.007",
+    "ot:studyPublicationReference": "Lopez-Osorio, Federico, Kurt M. Pickett, James M. Carpenter, Bryan A. Ballif, Ingi Agnarsson. 2014. Phylogenetic relationships of yellowjackets inferred from nine loci (Hymenoptera: Vespidae, Vespinae, Vespula and Dolichovespula). Molecular Phylogenetics and Evolution 73: 190-201.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2816": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 913935,
+    "ot:focalCladeOTTTaxonName": "Primates",
+    "ot:studyId": "pg_2816",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2014.02.023",
+    "ot:studyPublicationReference": "Pozzi, Luca, Jason A. Hodgson, Andrew S. Burrell, Kirstin N. Sterner, Ryan L. Raaum, Todd R. Disotell. 2014. Primate phylogenetic relationships and divergence dates inferred from complete mitochondrial genomes. Molecular Phylogenetics and Evolution 75: 165-183.",
+    "ot:studyYear": 2014,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2820": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 916750,
+    "ot:focalCladeOTTTaxonName": "Streptophyta",
+    "ot:studyId": "pg_2820",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-14-23",
+    "ot:studyPublicationReference": "Ruhfel, Brad R, Matthew A Gitzendanner, Pamela S Soltis, Douglas E Soltis, J Burleigh. 2014. From algae to angiosperms\u2013inferring the phylogeny of green plants (Viridiplantae) from 360 plastid genomes. BMC Evolutionary Biology 14 (1): 23",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2822": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 304358,
+    "ot:focalCladeOTTTaxonName": "Eukaryota",
+    "ot:studyId": "pg_2822",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.1110633108",
+    "ot:studyPublicationReference": "Parfrey, L. W., D. J. G. Lahr, A. H. Knoll, L. A. Katz. 2011. Estimating the timing of early eukaryotic diversification with multigene molecular clocks. Proceedings of the National Academy of Sciences 108 (33): 13624-13629.",
+    "ot:studyYear": 2011,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2825": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 847764,
+    "ot:focalCladeOTTTaxonName": "Xenarthra",
+    "ot:studyId": "pg_2825",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.11.008",
+    "ot:studyPublicationReference": "Delsuc, Fr\u00e9d\u00e9ric, Mariella Superina, Marie-Ka Tilak, Emmanuel J.P. Douzery, Alexandre Hassanin. 2012. Molecular phylogenetics unveils the ancient evolutionary origins of the enigmatic fairy armadillos. Molecular Phylogenetics and Evolution 62 (2): 673-680.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2827": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1091",
+    "ot:focalClade": 727571,
+    "ot:focalCladeOTTTaxonName": "Ilex",
+    "ot:studyId": "pg_2827",
+    "ot:studyPublicationReference": "Gottlieb A., Giberti G., & Poggio L. 2003. Molecular analyses of the genus Ilex (Aquifoliaceae) in southern South America, evidence from AFLP and ITS sequence data. American Journal of Botany, null.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_2828": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Stephen Smith",
+    "ot:focalClade": 1042135,
+    "ot:focalCladeOTTTaxonName": "Caprifoliaceae",
+    "ot:studyId": "pg_2828",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1365-2699.2009.02160.x",
+    "ot:studyPublicationReference": "Smith, SA. 2009. Taking into account phylogenetic and divergence-time uncertainty in a parametric biogeographical analysis of the Northern Hemisphere plant clade Caprifolieae. Journal of Biogeography.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_283": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1421",
+    "ot:focalClade": 841511,
+    "ot:focalCladeOTTTaxonName": "Celastrales",
+    "ot:studyId": "pg_283",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406775971778",
+    "ot:studyPublicationReference": "Zhang, L. B., & Simmons, M. P. (2006). Phylogeny and delimitation of the Celastrales inferred from nuclear and plastid genes. Systematic Botany, 31(1), 122-137.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_2830": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1161",
+    "ot:focalClade": 476932,
+    "ot:focalCladeOTTTaxonName": "Brassaiopsis",
+    "ot:studyId": "pg_2830",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364405775097761",
+    "ot:studyPublicationReference": "Mitchell, Anthony, Jun Wen. 2005. Phylogeny of Brassaiopsis (Araliaceae) in Asia Based on Nuclear ITS and 5S-NTS DNA Sequences. Systematic Botany 30 (4): 872-886",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_2831": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12841",
+    "ot:focalClade": 401103,
+    "ot:focalCladeOTTTaxonName": "Escallonia",
+    "ot:studyId": "pg_2831",
+    "ot:studyPublicationReference": "Sede S.M., Durnhofer S.I., Morello S., & Zapata F. 2012. Phylogeny of Escallonia (Escalloniaceae) based on plastid DNA sequence data. Botanical Journal of the Linnean Society, .",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2832": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1126",
+    "ot:focalClade": 509332,
+    "ot:focalCladeOTTTaxonName": "Crassulaceae",
+    "ot:studyId": "pg_2832",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644041744329",
+    "ot:studyPublicationReference": "Mayuzumi S., & Ohba H. 2004. The phylogenetic position of eastern Asian Sedoideae (Crassulaceae) inferred from chloroplast and nuclear DNA. Systematic Botany, null.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2833": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1128",
+    "ot:focalClade": 16033,
+    "ot:focalCladeOTTTaxonName": "Metatheria",
+    "ot:studyId": "pg_2833",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S0952836904005539",
+    "ot:studyPublicationReference": "Cardillo, Marcel, Olaf R. P. Bininda-Emonds, Elizabeth Boakes, Andy Purvis. 2004. A species-level phylogenetic supertree of marsupials. Journal of Zoology 264 (1): 11-31.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2834": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 16033,
+    "ot:focalCladeOTTTaxonName": "Metatheria",
+    "ot:studyId": "pg_2834",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.gene.2004.07.040",
+    "ot:studyPublicationReference": "Nilsson, Maria A., Ulfur Arnason, Peter B.S. Spencer, Axel Janke. 2004. Marsupial relationships and a timeline for marsupial radiation in South Gondwana. Gene 340 (2): 189-196.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2838": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "Focal clade says \"Pleocyemata\", but looks like \"Decapoda\" (JWB).",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 736321,
+    "ot:focalCladeOTTTaxonName": "Pleocyemata",
+    "ot:studyId": "pg_2838",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syu008",
+    "ot:studyPublicationReference": "Bracken-Grissom, Heather D., Shane T. Ahyong, Richard D. Wilkinson, Rodney M. Feldmann, Carrie E. Schweitzer, Jesse W. Breinholt, Matthew Bendall, Ferran Palero, Tin-Yam Chan, Darryl L. Felder, Rafael Robles, Ka-Hou Chu, Ling-Ming Tsang, Dohyup Kim, Joel W. Martin, and Keith A. Crandall. 2014.  \r\nThe emergence of the lobsters: phylogenetic relationships, morphological evolution and divergence time comparisons of an ancient group (Decapoda: Achelata, Astacidea, Glypheidea, Polychelida). Systematic Biology: syu008v1-syu008.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2841": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13860",
+    "ot:focalClade": 928468,
+    "ot:focalCladeOTTTaxonName": "Sparganium",
+    "ot:studyId": "pg_2841",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1300048 ",
+    "ot:studyPublicationReference": "Sulmann J.D., Drew B.T., Drummond C., Hayasaka E., & Sytsma K.J. 2013. Systematics, Biogeography, and Character Evolution of Sparganium (Typhaceae) ? Diversification of a Widespread, Aquatic Lineage. American Journal of Botany, 100(10): 2023?2039.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2842": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1040184,
+    "ot:focalCladeOTTTaxonName": "Thecostraca",
+    "ot:studyId": "pg_2842",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1741-7007-7-15",
+    "ot:studyPublicationReference": "P\u00e9rez-Losada, M, H\u00f8eg JT, Crandall KA. 2009. Remarkable convergent evolution in specialized parasitic Thecostraca (Crustacea). BMC Biology 7: 15.",
+    "ot:studyYear": 2009,
+    "ot:tag": "barnacles"
+   }
+  ]
+ },
+ "pg_2843": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 222358,
+    "ot:focalCladeOTTTaxonName": "Talpidae",
+    "ot:studyId": "pg_2843",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.10.002",
+    "ot:studyPublicationReference": "He, Kai, Akio Shinohara, Xue-Long Jiang, Kevin L. Campbell. 2014. Multilocus phylogeny of talpine moles (Talpini, Talpidae, Eulipotyphla) and its implications for systematics. Molecular Phylogenetics and Evolution 70: 513-521.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2844": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 222367,
+    "ot:focalCladeOTTTaxonName": "Talpa",
+    "ot:studyId": "pg_2844",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.01.038",
+    "ot:studyPublicationReference": "Colangelo, P., A.A. Bannikova, B. Kry\u0161tufek, V.S. Lebedev, F. Annesi, E. Capanna, A. Loy. 2010. Molecular systematics and evolutionary biogeography of the genus Talpa (Soricomorpha: Talpidae). Molecular Phylogenetics and Evolution 55 (2): 372-380.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2845": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 603925,
+    "ot:focalCladeOTTTaxonName": "Sittidae",
+    "ot:studyId": "pg_2845",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s10336-014-1063-7",
+    "ot:studyPublicationReference": "Pasquet,  Eric, F. Keith Barker, Jochen Martens, Annie Tillier, Corinne Cruaud, Alice Cibois. 2014.  Evolution within the nuthatches (Sittidae: Aves, Passeriformes): molecular phylogeny, biogeography, and ecological perspectives. Journal of Ornithology 155 (3):755-765.",
+    "ot:studyYear": 2014,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_2849": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13483",
+    "ot:focalClade": 2814282,
+    "ot:focalCladeOTTTaxonName": "Amphora commutata",
+    "ot:studyId": "pg_2849",
+    "ot:studyPublication": "http://dx.doi.org/10.2216/12-072.1",
+    "ot:studyPublicationReference": "Sato, S. 2013. Morphology and life history of Amphora commutata (Bacillariophyta) I: The vegetative cell and phylogenetic position. Phycologia, 52(2).",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2850": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 938413,
+    "ot:focalCladeOTTTaxonName": "Columbidae",
+    "ot:studyId": "pg_2850",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.08.019",
+    "ot:studyPublicationReference": "Cibois, Alice, Jean-Claude Thibault, C\u00e9line Bonillo, Christopher E. Filardi, Dick Watling, Eric Pasquet. 2014. Phylogeny and biogeography of the fruit doves (Aves: Columbidae). Molecular Phylogenetics and Evolution 70: 442-453.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2851": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S15454",
+    "ot:focalClade": 899157,
+    "ot:focalCladeOTTTaxonName": "Kinosternidae",
+    "ot:studyId": "pg_2851",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2014.03.025",
+    "ot:studyPublicationReference": "Spinks, Phillip Q., Robert C. Thomson, M\u00fcge Gidi\u015f, H. Bradley Shaffer. 2014. Multilocus phylogeny of the New-World mud turtles (Kinosternidae) supports the traditional classification of the group. Molecular Phylogenetics and Evolution",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2853": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 810751,
+    "ot:focalCladeOTTTaxonName": "Trochilidae",
+    "ot:studyId": "pg_2853",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.cub.2014.03.016",
+    "ot:studyPublicationReference": "McGuire, Jimmy A., Christopher C. Witt, J.V. Remsen, Ammon Corl, Daniel L. Rabosky, Douglas L. Altshuler, Robert Dudley. 2014. Molecular phylogenetics and the diversification of hummingbirds. Current Biology 24 (8): 910-916.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_2857": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 263138,
+    "ot:focalCladeOTTTaxonName": "Gyps",
+    "ot:studyId": "pg_2857",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s10336-008-0359-x",
+    "ot:studyPublicationReference": "Arshad, Muhammad, Javier Gonzalez, Abdel Aziz El-Sayed, Tim Osborne, Michael Wink. 2009. Phylogeny and phylogeography of critically endangered Gyps species based on nuclear and mitochondrial markers. Journal of Ornithology 150 (2): 419-430.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2859": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 839752,
+    "ot:focalCladeOTTTaxonName": "Muroidea",
+    "ot:studyId": "pg_2859",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syt050",
+    "ot:studyPublicationReference": "Schenk, John J., Kevin C. Rowe, and Scott J. Steppan. 2013. Ecological opportunity and incumbency in the diversification of repeated continental colonizations by muroid rodents. Systematic Biology 62 (6): 837-864.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2860": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 765193,
+    "ot:focalCladeOTTTaxonName": "Anatidae",
+    "ot:studyId": "pg_2860",
+    "ot:studyPublication": "http://dx.doi.org/10.1098/rspb.2011.2599",
+    "ot:studyPublicationReference": "Fulton, T. L., B. Letts, B. Shapiro. 2012. Multiple losses of flight and recent speciation in steamer ducks. Proceedings of the Royal Society B: Biological Sciences 279 (1737): 2339-2346.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2861": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 541924,
+    "ot:focalCladeOTTTaxonName": "Elephantidae",
+    "ot:studyId": "pg_2861",
+    "ot:studyPublication": "http://dx.doi.org/10.1371/journal.pbio.1000564",
+    "ot:studyPublicationReference": "Rohland, Nadin, David Reich, Swapan Mallick, Matthias Meyer, Richard E. Green, Nicholas J. Georgiadis, Alfred L. Roca, Michael Hofreiter. 2010. Genomic DNA Sequences from Mastodon and Woolly Mammoth Reveal Deep Speciation of Forest and Savanna Elephants. PLoS Biology 8 (12): e1000564.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2864": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 480119,
+    "ot:focalCladeOTTTaxonName": "Platalea",
+    "ot:studyId": "pg_2864",
+    "ot:studyPublication": "http://www.mapress.com/zootaxa/2010/f/z02603p060f.pdf",
+    "ot:studyPublicationReference": "Chesser, R. Terry, Carol K. L. Yeung, Cheng-Te Yao, Xiu-Hua Tian, Shou-Hsien Li. 2010. Molecular phylogeny of the spoonbills (Aves: Threskiornithidae) based on mitochondrial DNA. Zootaxa 2603: 53-60.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2866": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 241841,
+    "ot:focalCladeOTTTaxonName": "Anseriformes",
+    "ot:studyId": "pg_2866",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1469-7998.2009.00622.x",
+    "ot:studyPublicationReference": "Gonzalez, J., H. D\u00fcttmann, M. Wink. 2009. Phylogenetic relationships based on two mitochondrial genes and hybridization patterns in Anatidae. Journal of Zoology 279 (3): 310-318.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2869": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 489457,
+    "ot:focalCladeOTTTaxonName": "Bucerotidae",
+    "ot:studyId": "pg_2869",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2013.02.012",
+    "ot:studyPublicationReference": "Gonzalez, Juan-Carlos T., Ben C. Sheldon, Nigel J. Collar, Joseph A. Tobias. 2013. A comprehensive molecular phylogeny for the hornbills (Aves: Bucerotidae). Molecular Phylogenetics and Evolution 67 (2): 468-483.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2870": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 1015202,
+    "ot:focalCladeOTTTaxonName": "Micrastur",
+    "ot:studyId": "pg_2870",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.05.008",
+    "ot:studyPublicationReference": "Fuchs, J\u00e9r\u00f4me, Steven Chen, Jeff A. Johnson, David P. Mindell. 2011. Pliocene diversification within the South American forest falcons (Falconidae: Micrastur). Molecular Phylogenetics and Evolution 60 (3): 398-407.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_2871": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 212186,
+    "ot:focalCladeOTTTaxonName": "Falconidae",
+    "ot:studyId": "pg_2871",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1474-919X.2012.01222.x",
+    "ot:studyPublicationReference": "Fuchs, J\u00e9r\u00f4me, Jeff A. Johnson, David P. Mindell. 2012. Molecular systematics of the caracaras and allies (Falconidae: Polyborinae) inferred from mitochondrial and nuclear sequence data. Ibis 154 (3): 520-532.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2872": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 275127,
+    "ot:focalCladeOTTTaxonName": "Caprimulgidae",
+    "ot:studyId": "pg_2872",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2010.01.023",
+    "ot:studyPublicationReference": "Han, Kin-Lan, Mark B. Robbins, Michael J. Braun. 2010. A multi-gene estimate of phylogeny in the nightjars and nighthawks (Caprimulgidae). Molecular Phylogenetics and Evolution 55 (2): 443-453.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2875": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 631323,
+    "ot:focalCladeOTTTaxonName": "Oriolus",
+    "ot:studyId": "pg_2875",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1600-0587.2010.06167.x",
+    "ot:studyPublicationReference": "J\u00f8nsson, Knud A., Rauri C. K. Bowie, Robert G. Moyle, Martin Irestedt, Les Christidis, Janette A. Norman, Jon Fjelds\u00e5. 2010. Phylogeny and biogeography of Oriolidae (Aves: Passeriformes). Ecography 33 (2): 232-241.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_2876": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 292469,
+    "ot:focalCladeOTTTaxonName": "Tinamidae",
+    "ot:studyId": "pg_2876",
+    "ot:studyPublication": "https://sora.unm.edu/sites/default/files/journals/on/v015s/p0293-p0300.pdf",
+    "ot:studyPublicationReference": "Bertelli, Sara, Ana Luz Porzecanski. 2004. Tinamou (Tinamidae) systematics: a preliminary combined analysis of morphology and molecules. 2004. Ornithologia Neotropical 15: 293-299",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_2878": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "zbolander",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 635145,
+    "ot:focalCladeOTTTaxonName": "Lepechinia",
+    "ot:studyId": "pg_2878",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1095-8339.2012.01325.x",
+    "ot:studyPublicationReference": "Drew, Bryan T., Kenneth J. Sytsma. 2013. The South American radiation of Lepechinia (Lamiaceae): phylogenetics, divergence times and evolution of dioecy. Botanical Journal of the Linnean Society 171 (1): 171-190.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2879": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 246594,
+    "ot:focalCladeOTTTaxonName": "Bryophyta",
+    "ot:studyId": "pg_2879",
+    "ot:studyPublicationReference": "Cox, Cymon J., Bernard Goffinet, Norman J. Wickett, Sandra B. Boles, and A. Jonathan Shaw. 2010. Moss diversity: a molecular phylogenetic analysis of genera. Phytotaxa 9: 175-195.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_288": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2150",
+    "ot:focalClade": 929953,
+    "ot:focalCladeOTTTaxonName": "Croton",
+    "ot:studyId": "pg_288",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.04.013",
+    "ot:studyPublicationReference": "Riina R., Berry P., & Ee B. 2009. Molecular phylogenetics of the dragon's blood Croton\r\nsection Cyclostigma (Euphorbiaceae), a polyphyletic assemblage unraveled.\r\nSystematic Botany, 34(2): 360-374.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2881": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Joseph Brown",
+    "ot:focalClade": 705358,
+    "ot:focalCladeOTTTaxonName": "Anolis",
+    "ot:studyId": "pg_2881",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1232392",
+    "ot:studyPublicationReference": "Mahler, D. L., T. Ingram, L. J. Revell, J. B. Losos. 2013. Exceptional Convergence on the Macroevolutionary Landscape in Island Lizard Radiations. Science 341 (6143): 292-295.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2891": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Mark T. Holder",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 225495,
+    "ot:focalCladeOTTTaxonName": "Cyanobacteria",
+    "ot:studyId": "pg_2891",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1574-6941.2012.01299.x",
+    "ot:studyPublicationReference": "Janaina Rigonato, Danillo Oliveira Alvarenga, Fernando Dini Andreote, Armando Cavalcante Franco Dias, Itamar Soares Melo, Angela Kent, Marli F\u00e1tima Fiore, 2012, 'Cyanobacterial diversity in the phyllosphere of a mangrove forest', FEMS Microbiology Ecology, vol. 80, no. 2, pp. 312-322",
+    "ot:studyYear": 2012,
+    "ot:tag": "test-edit-tag"
+   }
+  ]
+ },
+ "pg_2892": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Dail Laughinghouse",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 225495,
+    "ot:focalCladeOTTTaxonName": "Cyanobacteria",
+    "ot:studyId": "pg_2892",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1462-2920.2012.02830.x",
+    "ot:studyPublicationReference": "Janaina Rigonato, Angela D. Kent, Danillo O. Alvarenga, Fernando D. Andreote, Raphael M. Beirigo, Pablo Vidal-Torrado, Marli F. Fiore, 2013, 'Drivers of cyanobacterial diversity and community composition in mangrove soils in south-east Brazil', Environmental Microbiology, vol. 15, no. 4, pp. 1103-1114",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2896": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 144818,
+    "ot:focalCladeOTTTaxonName": "Selaginellaceae",
+    "ot:studyId": "pg_2896",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.89.3.506",
+    "ot:studyPublicationReference": "P. Korall, P. Kenrick. 2002. Phylogenetic relationships in Selaginellaceae based on RBCL sequences. American Journal of Botany 89(3):506-517.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_2898": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13672",
+    "ot:focalClade": 1070157,
+    "ot:focalCladeOTTTaxonName": "Osmolindsaea",
+    "ot:studyId": "pg_2898",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364413X674896",
+    "ot:studyPublicationReference": "Lehtonen S., Tuomisto H., Rouhan G., & Christenhusz M. 2013. Taxonomic Revision of the Fern Genus Osmolindsaea (Lindsaeaceae). Systematic Botany, 38(4): 887-900.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2901": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11363",
+    "ot:focalClade": 190621,
+    "ot:focalCladeOTTTaxonName": "Thalictrum",
+    "ot:studyId": "pg_2901",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.01.009",
+    "ot:studyPublicationReference": "Soza, V. L., Brunet, J., Liston, A., Salles Smith, P., & Di Stilio, V. S. (2012). Phylogenetic insights into the correlates of dioecy in meadow-rues ( Thalictrum, Ranunculaceae). Molecular phylogenetics and evolution, 63(1), 180-192.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_2906": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13716",
+    "ot:focalClade": 964055,
+    "ot:focalCladeOTTTaxonName": "Aquilegia",
+    "ot:studyId": "pg_2906",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/nph.12163",
+    "ot:studyPublicationReference": "Fior S., Li M., Oxelman B., Viola R., Hodges S.A., Ometto L., & Varotto C. 2013. Spatiotemporal reconstruction of the Aquilegia rapid radiation through next-generation sequencing of rapidly evolving cpDNA regions. New Phytologist, 198: 579-592.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2909": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13986",
+    "ot:focalClade": 398217,
+    "ot:focalCladeOTTTaxonName": "Exochaenium",
+    "ot:studyId": "pg_2909",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/aob/mct097",
+    "ot:studyPublicationReference": "Kissling, J., & Barrett, S. C. (2013). Variation and evolution of herkogamy in Exochaenium (Gentianaceae): implications for the evolution of distyly. Annals of botany, 112(1), 95-102.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_2912": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S14957",
+    "ot:focalClade": 809556,
+    "ot:focalCladeOTTTaxonName": "Calliandra",
+    "ot:studyId": "pg_2912",
+    "ot:studyPublication": "http://dx.doi.org/10.12705/626.2",
+    "ot:studyPublicationReference": "Souza E.R., Lewis G.P., Forest F., Schnadelbach A.S., Van den berg C., & Queiroz L.P. 2013. Phylogeny of Calliandra (Leguminosae: Mimosoideae) based on nuclear and plastid molecular markers. TAXON, 62(6): 1201-1220.",
+    "ot:studyYear": 2013
+   }
+  ]
+ },
+ "pg_292": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2253",
+    "ot:focalClade": 39538,
+    "ot:focalCladeOTTTaxonName": "Papilionoideae",
+    "ot:studyId": "pg_292",
+    "ot:studyPublication": "http://dx.doi.org/10.1071/BT08091",
+    "ot:studyPublicationReference": "Sede, S. M., Tosto, D., Talia, P., Luckow, M., Poggio, L., & Fortunato, R. (2009). Phylogenetic relationships among southern South American species of Camptosema, Galactia and Collaea (Diocleinae: Papilionoideae: Leguminosae) on the basis of molecular and morphological data. Australian Journal of Botany, 57(1), 76-86.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_2926": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 81443,
+    "ot:focalCladeOTTTaxonName": "Palaeognathae",
+    "ot:studyId": "pg_2926",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1251981",
+    "ot:studyPublicationReference": "Mitchell, K. J., B. Llamas, J. Soubrier, N. J. Rawlence, T. H. Worthy, J. Wood, M. S. Y. Lee, A. Cooper. 2014. Ancient DNA reveals elephant birds and kiwi are sister taxa and clarifies ratite bird evolution. Science 344 (6186): 898-900.",
+    "ot:studyYear": 2014
+   }
+  ]
+ },
+ "pg_293": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11700",
+    "ot:focalClade": 452610,
+    "ot:focalCladeOTTTaxonName": "Mimosa",
+    "ot:studyId": "pg_293",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000520",
+    "ot:studyPublicationReference": "Simon, M. F. [et al. 2011], Grether, R., de Queiroz, L. P., S\u00e4rkinen, T. E., Dutra, V. F., & Hughes, C. E. 2011. The evolutionary history of Mimosa (Leguminosae): Toward a phylogeny of the sensitive plants. American J. Bot. 98: 1201-1221.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_294": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10601",
+    "ot:focalClade": 792364,
+    "ot:focalCladeOTTTaxonName": "Detarieae",
+    "ot:studyId": "pg_294",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410792495863",
+    "ot:studyPublicationReference": "Redden, K. M. [et al. 2010], Herendeen, P. S., Wurdack, K. J., & Bruneau, A. 2010. Phylogenetic relationships of the northeatern South American Brownea clade of tribe Detarieae (Leguminosae: Caesalpinioideae) based on morphology and molecular data. Syst. Bot. 35: 524-533.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_30": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1739",
+    "ot:focalClade": 35784,
+    "ot:focalCladeOTTTaxonName": "Illicium",
+    "ot:studyId": "pg_30",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407781179734",
+    "ot:studyPublicationReference": "Morris, A. B., Bell, C. D., Clayton, J. W., Judd, W. S., Soltis, D. E., & Soltis, P. S. (2007). Phylogeny and divergence time estimation in Illicium with implications for New World biogeography. Systematic botany, 32(2), 236-249.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_312": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Kristen Swithers",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11689",
+    "ot:focalClade": 2927065,
+    "ot:focalCladeOTTTaxonName": "Excavata",
+    "ot:studyId": "pg_312",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.protis.2011.12.007",
+    "ot:studyPublicationReference": "Takishita, K., Martin K., Komatsuzaki H., Yabuki A., Inagaki Y., Cepicka I., Smejkalova P., Silberman J.D., Hashimoto T., Roger A.J., and Simpson A.G. 2011. Multigene phylogenies of diverse Carpediemonas-like organisms identify the closest relatives of 'amitochondriate' diplomonads and retortamonads. Protist 163 (3): 344-355.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_313": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "",
+    "ot:focalClade": 266745,
+    "ot:focalCladeOTTTaxonName": "Stramenopiles",
+    "ot:studyId": "pg_313",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.protis.2009.01.001",
+    "ot:studyPublicationReference": "Grant, Jessica, Yonas I. Tekle, O. Roger Anderson, David J. Patterson, Laura A. Katz. 2009. Multigene evidence for the placement of a heterotrophic amoeboid lineage Leukarachnion sp. among photosynthetic stramenopiles. Protist 160 (3): 376-385.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_32": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1852",
+    "ot:focalClade": 459096,
+    "ot:focalCladeOTTTaxonName": "Valerianella",
+    "ot:studyId": "pg_32",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2007.03.013",
+    "ot:studyPublicationReference": "Bell, C. D. (2007). Phylogenetic placement and biogeography of the North American species of Valerianella (Valerianaceae: Dipsacales) based on chloroplast and nuclear DNA. Molecular phylogenetics and evolution, 44(3), 929-941.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_330": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10609",
+    "ot:focalClade": 1028940,
+    "ot:focalCladeOTTTaxonName": "Santalum",
+    "ot:studyId": "pg_330",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364410X539899",
+    "ot:studyPublicationReference": "Harbaugh, D. T., Oppenheimer, H. L., Wood, K. R., & Wagner, W. L. (2010). Taxonomic revision of the endangered Hawaiian red-flowered sandalwoods (Santalum) and discovery of an ancient hybrid species. Systematic botany, 35(4), 827-838.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_332": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11084",
+    "ot:studyId": "pg_332",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X583664",
+    "ot:studyPublicationReference": "Sanchez, Adriana, and Kathleen A. Kron. \"Phylogenetic Relationships of Triplaris and Ruprechtia: Re-Delimitation of the Recognized Genera and Two New Genera for Tribe Triplarideae (Polygonaceae).\" Systematic Botany 36.3 (2011): 702-710.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_335": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S833",
+    "ot:focalClade": 348529,
+    "ot:focalCladeOTTTaxonName": "Magnaporthe",
+    "ot:studyId": "pg_335",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761719",
+    "ot:studyPublicationReference": "Couch B., & Kohn L. 2002. A multilocus gene genealogy concordant with host preference indicates segregation of a new species, Magnaporthe oryzae, from M. grisea. Mycologia, 94(4): 683-693.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_338": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S843",
+    "ot:focalClade": 332572,
+    "ot:focalCladeOTTTaxonName": "Cudonia",
+    "ot:studyId": "pg_338",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761715",
+    "ot:studyPublicationReference": "Wang Z., Binder M., & Hibbett D. 2002. A new species of Cudonia based on mophological and molecular data. Mycologia, 94(4): 641-650.",
+    "ot:studyYear": 2002,
+    "ot:tag": "MP"
+   }
+  ]
+ },
+ "pg_339": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S822",
+    "ot:focalClade": 646175,
+    "ot:focalCladeOTTTaxonName": "Leptosphaeria",
+    "ot:studyId": "pg_339",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761714",
+    "ot:studyPublicationReference": "Camara M., Palm M., Van berkum P., & O'neill N. 2002. Molecular phylogeny of Leptosphaeria and Phaeosphaeria. Mycologia, 94(4): 630-640.",
+    "ot:studyYear": 2002,
+    "ot:tag": "MP"
+   }
+  ]
+ },
+ "pg_340": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:focalClade": 741639,
+    "ot:focalCladeOTTTaxonName": "Neotyphodium",
+    "ot:studyId": "pg_340",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761720",
+    "ot:studyPublicationReference": "Moon C., Miles C., Jrlfors U., & Schardl C. 2002. The evolutionary origins of three new Neotyphodium endophyte species from grasses indigenous to the Southern Hemisphere. Mycologia, 94(4): 694-711.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_343": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S825",
+    "ot:focalClade": 236816,
+    "ot:focalCladeOTTTaxonName": "Corethromyces bicolor",
+    "ot:studyId": "pg_343",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761782",
+    "ot:studyPublicationReference": "Weir A., & Hughes M. 2002. The taxonomic status of Corethromyces bicolor from New Zealand, as inferred from morphological, developmental, and molecular studies. Mycologia, 94(3): 483-493.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_348": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S831",
+    "ot:focalClade": 111534,
+    "ot:focalCladeOTTTaxonName": "Rhizopogon",
+    "ot:studyId": "pg_348",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761712",
+    "ot:studyPublicationReference": "Grubisha L., Trappe J., Molina R., & Spatafora J. 2002. Biology of the ectomycorrhizal genus Rhizopogon. VI. Re-examination of infrageneric relationships inferred from phylogenetic analyses of ITS sequences. Mycologia, 94(4): 607-619.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_349": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S847",
+    "ot:focalClade": 536378,
+    "ot:focalCladeOTTTaxonName": "Retiboletus",
+    "ot:studyId": "pg_349",
+    "ot:studyPublication": "http://dx.doi.org/10.1002/1522-239X(200205)113:1/2&lt;30::AID-FEDR30&gt;3.0.CO;2-D",
+    "ot:studyPublicationReference": "Binder M., & Bresinsky A. 2002. Retiboletus, a new genus for a species-complex in the Boletaceae producing retipolides. Feddes Repertorium, 113(1-2): 30-40.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_353": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S987",
+    "ot:focalClade": 550772,
+    "ot:focalCladeOTTTaxonName": "Aspergillus",
+    "ot:studyId": "pg_353",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761925",
+    "ot:studyPublicationReference": "Klich, M. A., J. W. Cary, S. B. Beltz, and C. A. Bennett. \"Phylogenetic and morphological analysis of Aspergillus ochraceoroseus.\" Mycologia 95, no. 6 (2003): 1252-1260.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_358": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S983",
+    "ot:focalClade": 941287,
+    "ot:focalCladeOTTTaxonName": "Ceratocystis pirilliformis",
+    "ot:studyId": "pg_358",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762015",
+    "ot:studyPublicationReference": "Barnes I., Roux J., Wingfield B., Dudzinski M., Old K., & Wingfield M.J. 2003. Ceratocystis pirilliformis, a new species from Eucalyptus nitens in Australia. Mycologia 95, no. 5 (2003): 865-871.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_361": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S996",
+    "ot:focalClade": 838968,
+    "ot:focalCladeOTTTaxonName": "Fusarium",
+    "ot:studyId": "pg_361",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761939",
+    "ot:studyPublicationReference": "Skovgaard K., Rosendahl S., O'donnell K., & Nirenberg H. 2003. Fusarium commune is a new species identified by morphological and molecular phylogenetic data. Mycologia, 95(4): 630-636.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_366": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S863",
+    "ot:focalClade": 52711,
+    "ot:focalCladeOTTTaxonName": "Hypochnicium punctulatum",
+    "ot:studyId": "pg_366",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761961",
+    "ot:studyPublicationReference": "Nilsson R., & Hallenberg N. 2003. Phylogeny of the Hypochnicium punctulatum complex as inferred from ITS sequence data. Mycologia, 95(1): 54-60.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_367": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S899",
+    "ot:focalClade": 376122,
+    "ot:focalCladeOTTTaxonName": "Armillaria",
+    "ot:studyId": "pg_367",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762039",
+    "ot:studyPublicationReference": "Coetzee M., Wingfield B., Bloomer P., Ridley G., & Wingfield M.J. 2003. Molecular identification and phylogeny of Armillaria isolates from South America and Indo-Malaysia. Mycologia, 95(2): 285-293.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_368": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S908",
+    "ot:focalClade": 484268,
+    "ot:focalCladeOTTTaxonName": "Macrolepiota",
+    "ot:studyId": "pg_368",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761886",
+    "ot:studyPublicationReference": "Vellinga E., De kok R., & Bruns T. 2003. Phylogeny and taxonomy of Macrolepiota (Agaricaceae). Mycologia, 95(3): 442-456.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_369": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S912",
+    "ot:focalClade": 955082,
+    "ot:focalCladeOTTTaxonName": "Rhizopogon vinicolor",
+    "ot:studyId": "pg_369",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761890",
+    "ot:studyPublicationReference": "Kretzer A., Luoma D., Molina R., & Spatafora J. 2003. Taxonomy of the Rhizopogon vinicolor species complex based on analysis of ITS sequences and microsatellite loci. Mycologia, 95(3): 480-487.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_37": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1797",
+    "ot:focalClade": 350866,
+    "ot:focalCladeOTTTaxonName": "Rhus",
+    "ot:studyId": "pg_37",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407781179635",
+    "ot:studyPublicationReference": "Yi, T., Miller, A. J., & Wen, J. (2007). Phylogeny of Rhus (Anacardiaceae) based on sequences of nuclear Nia-i3 intron and chloroplast trnC-trnD. Systematic botany, 32(2), 379-391.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_370": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S922",
+    "ot:focalClade": 412999,
+    "ot:studyId": "pg_370",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S0953756203007585",
+    "ot:studyPublicationReference": "Peintner U., Moser M., Agretious thomas K., & Manimohan P. 2003. First records of ectomycorrhizal Cortinarius species (Agaricales, Basidiomycetes) from tropical India and their phylogenetic position based on rDNA ITS sequences. Mycological Research, 107(4): 485-494.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_372": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S992",
+    "ot:focalClade": 685643,
+    "ot:focalCladeOTTTaxonName": "Boletus",
+    "ot:studyId": "pg_372",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S0953756203007901",
+    "ot:studyPublicationReference": "Peintner U., Ladurner H., and Simonini G. 2003. Xerocomus cisalpinus sp. nov. and the delimitation of species in the Xerocomus chrysenteron complex based on morphology and rDNA-LSU sequences. Mycological Research 107 (6): 659-679.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_373": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S933",
+    "ot:focalClade": 1084807,
+    "ot:focalCladeOTTTaxonName": "Penicillium brocae",
+    "ot:studyId": "pg_373",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761973",
+    "ot:studyPublicationReference": "Peterson S., Perez J., Vega F., & Infante F. 2003. Penicillium brocae, a new species associated with the coffee berry borer in Chiapas, Mexico. Mycologia, 95(1): 141-147.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_374": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1286",
+    "ot:focalClade": 250591,
+    "ot:focalCladeOTTTaxonName": "Penicillium",
+    "ot:studyId": "pg_374",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762145",
+    "ot:studyPublicationReference": "Peterson S., Bayer E., & Wicklow D. 2004. Penicillium thiersii, Penicillium angulare and Penicillium decaturense, new species isolated from wood-decay fungi in North America and their phylogenetic placement from multilocus DNA sequence analysis. Mycologia, 96 (6): 1280-1293.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_375": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1284",
+    "ot:focalClade": 1085553,
+    "ot:focalCladeOTTTaxonName": "Colletotrichum",
+    "ot:studyId": "pg_375",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762144",
+    "ot:studyPublicationReference": "Lubbe, Carolien M., Sandra Denman, Paul F. Cannon, JZ Ewald Groenewald, Sandra C. Lamprecht, and Pedro W. Crous. \"Characterization of Colletotrichum species associated with diseases of Proteaceae.\" Mycologia 96, no. 6 (2004): 1268-1279.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_376": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1103",
+    "ot:focalClade": 33893,
+    "ot:focalCladeOTTTaxonName": "Botryosphaeria",
+    "ot:studyId": "pg_376",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762087",
+    "ot:studyPublicationReference": "Slippers, Bernard, Gerda Fourie, Pedro W. Crous, Teresa A. Coutinho, Brenda D. Wingfield, and Michael J. Wingfield. \"Multiple gene sequences delimit Botryosphaeria australis sp. nov. from B. lutea.\" Mycologia 96, no. 5 (2004): 1030-1041.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_38": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1878",
+    "ot:focalClade": 885838,
+    "ot:focalCladeOTTTaxonName": "Heliotropium",
+    "ot:studyId": "pg_38",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408784571635",
+    "ot:studyPublicationReference": "Luebert, F., & Wen, J. (2008). Phylogenetic analysis and evolutionary diversification of Heliotropium sect. Cochranea (Heliotropiaceae) in the Atacama Desert. Systematic Botany, 33(2), 390-402.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_380": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1223",
+    "ot:focalClade": 597717,
+    "ot:focalCladeOTTTaxonName": "Lasiosphaeria",
+    "ot:studyId": "pg_380",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762093",
+    "ot:studyPublicationReference": "Miller A.N., & Huhndorf S. 2004. Using phylogenetic species recognition to delimit species boundaries within Lasiosphaeria. Mycologia, 96(5): 1104-1125.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_382": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1215",
+    "ot:focalClade": 103001,
+    "ot:focalCladeOTTTaxonName": "Cryphonectria",
+    "ot:studyId": "pg_382",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762083",
+    "ot:studyPublicationReference": "Myburg, Henrietta, Marieka Gryzenhout, Brenda D. Wingfield, R. Jay Stipes, and Michael J. Wingfield. \"Phylogenetic relationships of Cryphonectria and Endothia species, based on DNA sequence data and morphology.\" Mycologia 96, no. 5 (2004): 990-1001.",
+    "ot:studyYear": 2004,
+    "ot:tag": "terminals contain geographic info"
+   }
+  ]
+ },
+ "pg_385": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1300",
+    "ot:focalClade": 530190,
+    "ot:focalCladeOTTTaxonName": "Begonia",
+    "ot:studyId": "pg_385",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644054782297",
+    "ot:studyPublicationReference": "Forrest, L. L., Hughes, M., & Hollingsworth, P. M. (2005). A phylogeny of Begonia using nuclear ribosomal sequence data and morphological characters. Systematic botany, 30(3), 671-682.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_386": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12245",
+    "ot:focalClade": 1081686,
+    "ot:focalCladeOTTTaxonName": "Brunfelsia",
+    "ot:studyId": "pg_386",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2012.02.026",
+    "ot:studyPublicationReference": "Filipowicz N.H., & Renner S.S. 2012. Brunfelsia (Solanaceae): A genus evenly divided between South America and radiations on Cuba and other antillean islands. Molecular Phylogenetics and Evolution. 64: 1-11.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_387": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1140",
+    "ot:focalClade": 641832,
+    "ot:focalCladeOTTTaxonName": "Ajellomycetaceae",
+    "ot:studyId": "pg_387",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762114",
+    "ot:studyPublicationReference": "Untereiner, Wendy A., James A. Scott, Fran\u00e7oise A. Naveau, Lynne Sigler, Jason Bachewich, and Andrea Angus. \"The Ajellomycetaceae, a new family of vertebrate-associated Onygenales.\" Mycologia 96, no. 4 (2004): 812-821.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_388": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1099",
+    "ot:focalClade": 183728,
+    "ot:focalCladeOTTTaxonName": "Hirsutella",
+    "ot:studyId": "pg_388",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3762126",
+    "ot:studyPublicationReference": "Seifert, Keith A., and Hillary Boulay. \"Hirsutella uncinata, a new hyphomycete from Australia.\" Mycologia 96, no. 4 (2004): 929-934.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_389": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1107",
+    "ot:focalClade": 437372,
+    "ot:focalCladeOTTTaxonName": "Kohninia",
+    "ot:studyId": "pg_389",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761994",
+    "ot:studyPublicationReference": "Holst-jensen A., Vralstad T., & Schumacher T. 2004. Kohninia linnaeicola - a new genus and species of the Sclerotiniaceae pathogenic to Linnaea borealis. Mycologia, 96: 136-143.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_393": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Karen Cranston",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1154",
+    "ot:focalClade": 647376,
+    "ot:focalCladeOTTTaxonName": "Pucciniomycetes",
+    "ot:studyId": "pg_393",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S0953756204009359",
+    "ot:studyPublicationReference": "Lutz M., Bauer R., Begerow D., & Oberwinkler F. 2004. Tuberculina-Thanatophytum/rhizoctonia crocorum-Helicobasidium: a unique mycoparasitic-phytoparasitic life strategy. Mycological Research, 108(3): 227-238.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_394": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1806",
+    "ot:focalClade": 1006254,
+    "ot:focalCladeOTTTaxonName": "Cucumis",
+    "ot:studyId": "pg_394",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-7-58",
+    "ot:studyPublicationReference": "Renner S.S., Schaefer H., & Kocyan A. 2007. Phylogenetics of Cucumis (Cucurbitaceae): C. sativus (cucumber) belongs in an Asian/Australian clade far from C. melo (melon). BMC Evolutionary Biology, 7: 58.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_397": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1002",
+    "ot:focalClade": 464790,
+    "ot:focalCladeOTTTaxonName": "Alternaria",
+    "ot:studyId": "pg_397",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/3761993",
+    "ot:studyPublicationReference": "Peever T., Su G., Carpenter-boggs L., & Timmer L. 2003. Molecular systematics of citrus-associated Alternaria species. Mycologia, 96(1): 119-134.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_399": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1170",
+    "ot:focalClade": 305904,
+    "ot:focalCladeOTTTaxonName": "Parmeliaceae",
+    "ot:studyId": "pg_399",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.1.150",
+    "ot:studyPublicationReference": "Blanco, Oscar, Ana Crespo, Pradeep K. Divakar, John A. Elix, and H. Thorsten Lumbsch. \"Molecular phylogeny of parmotremoid lichens (Ascomycota, Parmeliaceae).\" Mycologia 97, no. 1 (2005): 150-159.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_400": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1193",
+    "ot:focalClade": 33893,
+    "ot:focalCladeOTTTaxonName": "Botryosphaeria",
+    "ot:studyId": "pg_400",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.1.99",
+    "ot:studyPublicationReference": "Slippers, Bernard, Greg I. Johnson, Pedro W. Crous, Teresa A. Coutinho, Brenda D. Wingfield, and Michael J. Wingfield. \"Phylogenetic and morphological re-evaluation of the Botryosphaeria species causing diseases of Mangifera indica.\" Mycologia 97, no. 1 (2005): 99-110.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_402": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1306",
+    "ot:focalClade": 550772,
+    "ot:focalCladeOTTTaxonName": "Aspergillus",
+    "ot:studyId": "pg_402",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.2.425",
+    "ot:studyPublicationReference": "Cary, J. W., M. A. Klich, and S. B. Beltz. \"Characterization of aflatoxin-producing fungi outside of Aspergillus section Flavi.\" Mycologia 97.2 (2005): 425-432.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_403": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1237",
+    "ot:focalClade": 535927,
+    "ot:focalCladeOTTTaxonName": "Monacrosporium drechsleri",
+    "ot:studyId": "pg_403",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.2.405",
+    "ot:studyPublicationReference": "Meyer, Susan LF, Lynn K. Carta, and Stephen A. Rehner. \"Morphological variability and molecular phylogeny of the nematophagous fungus Monacrosporium drechsleri.\" Mycologia 97.2 (2005): 405-415.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_404": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1316",
+    "ot:focalClade": 776513,
+    "ot:focalCladeOTTTaxonName": "Nalanthamala psidii",
+    "ot:studyId": "pg_404",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.2.375",
+    "ot:studyPublicationReference": "Schroers, H-J., M. M. Geldenhuis, Michael J. Wingfield, M. H. Schoeman, Y-F. Yen, W-C. Shen, and B. D. Wingfield. \"Classification of the guava wilt fungus Myxosporium psidii, the palm pathogen Gliocladium vermoesenii and the persimmon wilt fungus Acremonium diospyri in Nalanthamala.\" Mycologia 97, no. 2 (2005): 375-395.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_405": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1247",
+    "ot:focalClade": 33893,
+    "ot:focalCladeOTTTaxonName": "Botryosphaeria",
+    "ot:studyId": "pg_405",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.5.1111",
+    "ot:studyPublicationReference": "Luque, Jordi, Soledad Martos, and Alan JL Phillips. \"Botryosphaeria viticola sp. nov. on grapevines: a new species with a Dothiorella anamorph.\" Mycologia 97.5 (2005): 1111-1121.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_407": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1335",
+    "ot:focalClade": 250591,
+    "ot:focalCladeOTTTaxonName": "Penicillium",
+    "ot:studyId": "pg_407",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.3.659",
+    "ot:studyPublicationReference": "Peterson, Stephen W., Fernando E. Vega, Francisco Posada, and Chifumi Nagai. \"Penicillium coffeae, a new endophytic species isolated from a coffee plant and its phylogenetic relationship to P. fellutanum, P. thiersii and P. brocae based on parsimony analysis of multilocus DNA sequences.\" Mycologia 97, no. 3 (2005): 659-666.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_408": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1356",
+    "ot:focalClade": 1085553,
+    "ot:focalCladeOTTTaxonName": "Colletotrichum",
+    "ot:studyId": "pg_408",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.3.641",
+    "ot:studyPublicationReference": "Du M., Schardl C., Nuckles E., & Vaillancourt L. 2005. Using Mating-Type Gene Sequences for Improved Phylogenetic Resolution of Colletotrichum Species Complexes. Mycologia, 97: 641-658.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_41": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1860",
+    "ot:focalClade": 454109,
+    "ot:focalCladeOTTTaxonName": "Feddea",
+    "ot:studyId": "pg_41",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408783887348",
+    "ot:studyPublicationReference": "Cariaga, K. A., Pruski, J. F., Oviedo, R., Anderberg, A. A., Lewis, C. E., & Francisco-Ortega, J. (2008). Phylogeny and systematic position of Feddea (Asteraceae: Feddeeae): a taxonomically enigmatic and critically endangered genus endemic to Cuba. Systematic Botany, 33(1), 193-202.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_411": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1419",
+    "ot:focalClade": 33893,
+    "ot:focalCladeOTTTaxonName": "Botryosphaeria",
+    "ot:studyId": "pg_411",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.5.1111",
+    "ot:studyPublicationReference": "Luque, Jordi, Soledad Martos, and Alan JL Phillips. \"Botryosphaeria viticola sp. nov. on grapevines: a new species with a Dothiorella anamorph.\" Mycologia 97.5 (2005): 1111-1121.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_412": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Rick Ree",
+    "ot:focalClade": 994093,
+    "ot:focalCladeOTTTaxonName": "Coniferophyta",
+    "ot:studyId": "pg_412",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.1213621109",
+    "ot:studyPublicationReference": "Leslie, A. B., J. M. Beaulieu, H. S. Rai, P. R. Crane, M. J. Donoghue, S. Mathews. 2012. Hemisphere-scale differences in conifer evolutionary dynamics. Proceedings of the National Academy of Sciences. 109 (40): 16217-16221.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_414": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1426",
+    "ot:focalClade": 359501,
+    "ot:focalCladeOTTTaxonName": "Trichoderma",
+    "ot:studyId": "pg_414",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.6.1365",
+    "ot:studyPublicationReference": "Jaklitsch W.M., Komon M., Kubicek C., & Druzhinina I. 2006. Hypocrea voglmayrii sp. nov. from the Austrian Alps represents a new phylogenetic clade in Hypocrea/Trichoderma. Mycologia, null.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_415": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1604",
+    "ot:studyId": "pg_415",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.6.1287",
+    "ot:studyPublicationReference": "Yanagida N., Irie T., Tanaka E., Teramoto C., Kuwabara K., & Tajimi A. 2005. New choke diseases and their molecular phylogenetic analysis in Agropyron ciliare var. minus and Agropyron tsukushiense var. transiens. Mycologia, 97: 1287-1291.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_420": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2108",
+    "ot:focalClade": 81461,
+    "ot:focalCladeOTTTaxonName": "Aves",
+    "ot:studyId": "pg_420",
+    "ot:studyPublication": "http://dx.doi.org/10.1126/science.1157704",
+    "ot:studyPublicationReference": "Hackett, S. J., R. T. Kimball, S. Reddy, R. C. K. Bowie, E. L. Braun, M. J. Braun, J. L. Chojnowski, W. A. Cox, K.-L. Han, J. Harshman, C. J. Huddleston, B. D. Marks, K. J. Miglia, W. S. Moore, F. H. Sheldon, D. W. Steadman, C. C. Witt, T. Yuri. 2008. A Phylogenomic Study of Birds Reveals Their Evolutionary History. Science 320 (5884): 1763-1768.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_421": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Stephen Smith",
+    "ot:focalClade": 802117,
+    "ot:focalCladeOTTTaxonName": "Mollusca",
+    "ot:studyId": "pg_421",
+    "ot:studyPublication": "http://dx.doi.org/10.1038/nature10526",
+    "ot:studyPublicationReference": "Smith, Stephen A., Nerida G. Wilson, Freya E. Goetz, Caitlin Feehery, S\u00f3nia C. S. Andrade, Greg W. Rouse, Gonzalo Giribet and Casey W. Dunn. 2011. Resolving the evolutionary relationships of molluscs with phylogenomic tools. Nature 480, 364\u2013367.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_423": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jonathan Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11742",
+    "ot:focalClade": 544595,
+    "ot:focalCladeOTTTaxonName": "Amphibia",
+    "ot:studyId": "pg_423",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.06.012",
+    "ot:studyPublicationReference": "Pyron, R.A., & Wiens J.J. 2011. A large-scale phylogeny of Amphibia including over 2800 species, and a revised classification of extant frogs, salamanders, and caecilians. Molecular Phylogenetics Evolution 61 (2): 543-583.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_424": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10254",
+    "ot:focalClade": 1042135,
+    "ot:focalCladeOTTTaxonName": "Caprifoliaceae",
+    "ot:studyId": "pg_424",
+    "ot:studyPublication": "http://dx.doi.org/10.1093/sysbio/syq011",
+    "ot:studyPublicationReference": "Stephen A. Smith, & Michael Donoghue. 2010. Combining historical biogeography with niche modeling in the Caprifolium clade of Lonicera (Caprifoliaceae, Dipsacales). Systematic Biology, 59(3): 322-341.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_43": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1476",
+    "ot:focalClade": 225992,
+    "ot:focalCladeOTTTaxonName": "Hoya",
+    "ot:studyId": "pg_43",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2006.01.022",
+    "ot:studyPublicationReference": "Wanntorp L., Kocyan A., & Renner S. 2006. Wax Plants Disentangled: A Phylogeny of Hoya (Asclepioideae, Apocynaceae) Inferred from Nuclear and Chloroplast Sequences. Molecular phylogenetics and evolution, 39(3), 722-733.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_430": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2112",
+    "ot:focalClade": 624536,
+    "ot:focalCladeOTTTaxonName": "Anamika",
+    "ot:studyId": "pg_430",
+    "ot:studyPublication": "http://dx.doi.org/10.1017/S0953756205003758",
+    "ot:studyPublicationReference": "Yang Z., Matheny P., Ge Z., Slot J., & Hibbett D. 2005. New Asian species of the genus Anamika (euagarics, hebelomatoid clade) based on morphology and ribosomal DNA sequences. Mycological Research, 109: 1259-1267.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_437": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Joseph W. Brown",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S31488",
+    "ot:focalClade": 661378,
+    "ot:focalCladeOTTTaxonName": "Diptera",
+    "ot:studyId": "pg_437",
+    "ot:studyPublication": "http://dx.doi.org/10.1073/pnas.1012675108",
+    "ot:studyPublicationReference": "Wiegmann, B. M., M. D. Trautwein, I. S. Winkler, N. B. Barr, J.-W. Kim, C. Lambkin, M. A. Bertone, B. K. Cassel, K. M. Bayless, A. M. Heimberg, B. M. Wheeler, K. J. Peterson, T. Pape, B. J. Sinclair, J. H. Skevington, V. Blagoderov, J. Caravas, S. N. Kutty, U. Schmidt-Ott, G. E. Kampmeier, F. C. Thompson, D. A. Grimaldi, A. T. Beckenbach, G. W. Courtney, M. Friedrich, R. Meier, D. K. Yeates. 2011. Episodic radiations in the fly tree of life. Proceedings of the National Academy of Sciences. 108 (14): 5690-5695.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_441": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2140",
+    "ot:focalClade": 22820,
+    "ot:focalCladeOTTTaxonName": "Morinia",
+    "ot:studyId": "pg_441",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.4.616",
+    "ot:studyPublicationReference": "Collado, Javier, Gonzalo Platas, Gerald F. Bills, \u00c1ngela Basilio, Francisca Vicente, J. Rub\u00e9n Tormo, Pilar Hern\u00e1ndez, M. Teresa D\u00edez, and Fernando Pel\u00e1ez. \"Studies on Morinia: Recognition of Morinia longiappendiculata sp. nov. as a new endophytic fungus, and a new circumscription of Morinia pestalozzioides.\" Mycologia 98, no. 4 (2006): 616-627.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_443": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1532",
+    "ot:focalClade": 359501,
+    "ot:focalCladeOTTTaxonName": "Hypocrea",
+    "ot:studyId": "pg_443",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.3.499",
+    "ot:studyPublicationReference": "Jaklitsch, Walter M., Monika Komon, Christian P. Kubicek, and Irina S. Druzhinina. \"Hypocrea crystalligena sp. nov., a common European species with a white-spored Trichoderma anamorph.\" Mycologia 98, no. 3 (2006): 499-513.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_444": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1542",
+    "ot:focalClade": 109689,
+    "ot:focalCladeOTTTaxonName": "Cryphonectriaceae",
+    "ot:studyId": "pg_444",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.2.239",
+    "ot:studyPublicationReference": "Gryzenhout, M., Myburg H., Wingfield B., & Wingfield M.J. 2006. Cryphonectriaceae (Diaporthales), a new family including Cryphonectria, Endothia, Chrysoporthe and allied genera. Mycologia 98: 239-249.",
+    "ot:studyYear": 2006,
+    "ot:tag": "species not in OTT"
+   }
+  ]
+ },
+ "pg_446": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1644",
+    "ot:focalClade": 380929,
+    "ot:focalCladeOTTTaxonName": "Cercospora",
+    "ot:studyId": "pg_446",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.2.275",
+    "ot:studyPublicationReference": "Groenewald M., Groenewald J., Braun U., & Crous P. 2005. Host range of Cercospora apii and C. beticola, and description of C. apiicola, a novel species from celery. Mycologia, 98: 275-285.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_447": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1544",
+    "ot:focalClade": 668676,
+    "ot:focalCladeOTTTaxonName": "Aurapex",
+    "ot:studyId": "pg_447",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.1.105",
+    "ot:studyPublicationReference": "Gryzenhout M., Myburg H., Rodas C., Wingfield B., & Wingfield M.J. 2006. Aurapex penicillata gen. sp. nov. from native Miconia theaezans and Tibouchina spp. in Colombia. Mycologia, 98: 105-115.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_448": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Karen Cranston",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1387",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "pg_448",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.mycres.2005.11.013",
+    "ot:studyPublicationReference": "Taylor, Andy FS, Alan E. Hills, Giampaolo Simonini, Ernst E. Both, and Ursula Eberhardt. \"Detection of species within the< i> Xerocomus subtomentosus</i> complex in Europe using rDNA\u2013ITS sequences.\" Mycological research 110, no. 3 (2006): 276-287.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_449": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1558",
+    "ot:focalClade": 468069,
+    "ot:focalCladeOTTTaxonName": "Sparassis",
+    "ot:studyId": "pg_449",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.4.584",
+    "ot:studyPublicationReference": "Dai, Yu-Cheng, Zheng Wang, Manfred Binder, and David S. Hibbett. \"Phylogeny and a new species of Sparassis (Polyporales, Basidiomycota): evidence from mitochondrial atp6, nuclear rDNA and rpb2 genes.\" Mycologia 98, no. 4 (2006): 584-592.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_450": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1699",
+    "ot:focalClade": 729017,
+    "ot:focalCladeOTTTaxonName": "Clavariaceae",
+    "ot:studyId": "pg_450",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.98.5.746",
+    "ot:studyPublicationReference": "Dentinger B., & Mclaughlin D. 2006. Reconstructing the Clavariaceae using nuclear large subunit rDNA sequences and a new genus segregated from Clavaria. Mycologia, 98(5): 746-762.",
+    "ot:studyYear": 2006,
+    "ot:tag": "need more curation of tree"
+   }
+  ]
+ },
+ "pg_463": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1831",
+    "ot:focalClade": 741639,
+    "ot:focalCladeOTTTaxonName": "Neotyphodium",
+    "ot:studyId": "pg_463",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.97.4.804",
+    "ot:studyPublicationReference": "Moon, Christina D., Jean-Jacques Guillaumin, Catherine Ravel, Chunjie Li, Kelly D. Craven, and Christopher L. Schardl. \"New Neotyphodium endophyte species from the grass tribes Stipeae and Meliceae.\" Mycologia 99, no. 6 (2007): 895-905",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_470": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1963",
+    "ot:focalClade": 635259,
+    "ot:focalCladeOTTTaxonName": "Lecania",
+    "ot:studyId": "pg_470",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/07-080R",
+    "ot:studyPublicationReference": "Reese N\u00e6sborg R. 2007. Taxonomic revision of the Lecania cyrtella group (Ramalinaceae, lichenized Ascomycota) based on molecular and morphological evidence. Mycologia, 100 (3): 397-416.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_471": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1944",
+    "ot:focalClade": 464790,
+    "ot:focalCladeOTTTaxonName": "Alternaria",
+    "ot:studyId": "pg_471",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/07-186R1",
+    "ot:studyPublicationReference": "Park M., Culler C., & Pryor B. 2007. A re-examination of the phylogenetic relationship between the causal agents of carrot black rot, Alternaria radicina and A. carotiincultae. Mycologia, 100(3): 511-527.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_473": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1945",
+    "ot:focalClade": 4090156,
+    "ot:focalCladeOTTTaxonName": "Salmacisia",
+    "ot:studyId": "pg_473",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.100.1.81",
+    "ot:studyPublicationReference": "Chandra A., & Huff D. 2007. Salmacisia, a new genus of Tilletiales: reclassification of Tilletia buchlo\u00ebana causing induced hermaphroditism in buffalograss. Mycologia, 100(1): 81-93.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_474": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1998",
+    "ot:focalClade": 868675,
+    "ot:focalCladeOTTTaxonName": "Laetiporus",
+    "ot:studyId": "pg_474",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/07-124R2",
+    "ot:studyPublicationReference": "Lindner D., & Banik M. 2008. Molecular phylogeny of Laetiporus and other brown-rot polypore genera in North America. Mycologia, 100(3): 417-430.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_475": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2089",
+    "ot:focalClade": 959450,
+    "ot:focalCladeOTTTaxonName": "Marasmius",
+    "ot:studyId": "pg_475",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/07-009R2",
+    "ot:studyPublicationReference": "Douanla-meli C., & Langer E. 2008. Phylogenetic relationship of Marasmius mbalmayoensis sp. nov. to the the tropical African Marasmius bekolacongoli complex based on nuc-LSU rDNA sequences. Mycologia, 100(3): 445-454.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_477": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2124",
+    "ot:focalClade": 737448,
+    "ot:focalCladeOTTTaxonName": "Agaricus",
+    "ot:studyId": "pg_477",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/08-019",
+    "ot:studyPublicationReference": "Kerrigan R., Callac P., & Parra L. 2008. New and rare taxa in Agaricus section Bivelares (Duploannulati). Mycologia, 100(6): 876-892.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_479": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10007",
+    "ot:focalClade": 239673,
+    "ot:focalCladeOTTTaxonName": "Flammulina",
+    "ot:studyId": "pg_479",
+    "ot:studyPublication": "http://www.fungaldiversity.org/fdp/sfdp/32-4.pdf",
+    "ot:studyPublicationReference": "Ge Z., Yang Z., Zhang P., Matheny P., & Hibbett D. 2008. Flammulina species from China inferred by morphological and molecular data. Fungal Diversity, 32: 59-68.",
+    "ot:studyYear": 2008,
+    "ot:tag": "MP"
+   }
+  ]
+ },
+ "pg_480": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1966",
+    "ot:studyId": "pg_480",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/mycologia.100.1.47",
+    "ot:studyPublicationReference": "Gr\u00fcnig C., Duo A., Sieber T., & Holdenrieder O. 2008. Assignment of species rank to six reproductively isolated cryptic species of the Phialocephala fortinii s.l. - Acephala applanata species complex. Mycologia, 100(1): 47-67.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_481": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10025",
+    "ot:focalClade": 572461,
+    "ot:focalCladeOTTTaxonName": "Neurospora",
+    "ot:studyId": "pg_481",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/08-219",
+    "ot:studyPublicationReference": "Villalta C., Jacobson D., & Taylor J. 2009. Three new phylogenetic and biological Neurospora species: N. hispaniola, N. metzenbergii, and N. perkinsii. Mycologia, 101: 777-789.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_482": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10243",
+    "ot:focalClade": 250591,
+    "ot:focalCladeOTTTaxonName": "Penicillium",
+    "ot:studyId": "pg_482",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/08-149",
+    "ot:studyPublicationReference": "Visagie C., Roets F., & Jacobs K. 2009. A new species of Penicillium, P. ramulosum sp. nov., from the natural environment. Mycologia, 101(6): 888-895.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_483": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S13033",
+    "ot:focalClade": 594104,
+    "ot:focalCladeOTTTaxonName": "Neofusicoccum",
+    "ot:studyId": "pg_483",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/08-193",
+    "ot:studyPublicationReference": "Pavlic D., Slippers B., Coutinho T., & Wingfield M.J. 2009. Molecular and phenotypic characterization of three phylogenetic species discovered within the Neofusicoccum parvum/N. ribis complex. Mycologia, 101(5): 636-647.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_485": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Romina Gazis",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2163",
+    "ot:focalClade": 888947,
+    "ot:focalCladeOTTTaxonName": "Metarhizium",
+    "ot:studyId": "pg_485",
+    "ot:studyPublication": "http://dx.doi.org/10.3852/07-202",
+    "ot:studyPublicationReference": "Bischoff J., Humber R., & Rehner S. 2008. A multilocus phylogeny of the Metarhizium anisopliae lineage. Mycologia, 101(4): 512-530.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_50": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1555",
+    "ot:focalClade": 486206,
+    "ot:focalCladeOTTTaxonName": "Anagallis",
+    "ot:studyId": "pg_50",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/449318",
+    "ot:studyPublicationReference": "Manns U., & Anderberg A. 2005. Molecular phylogeny of Anagallis (Myrsinaceae) based on ITS, trnL-F and ndhF sequence data. International Journal of Plant Sciences, 166: 1019-1028.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_52": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1823",
+    "ot:focalClade": 1006254,
+    "ot:focalCladeOTTTaxonName": "Cucumis",
+    "ot:studyId": "pg_52",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.94.7.1256",
+    "ot:studyPublicationReference": "Ghebretinsae, A. G., Thulin, M., & Barber, J. C. (2007). Relationships of cucumbers and melons unraveled: molecular phylogenetics of Cucumis and related genera (Benincaseae, Cucurbitaceae). American journal of botany, 94(7), 1256-1266.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_53": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S9979",
+    "ot:focalClade": 812770,
+    "ot:focalCladeOTTTaxonName": "Euryops",
+    "ot:studyId": "pg_53",
+    "ot:studyPublication": "http://www.ingentaconnect.com/content/iapt/tax/2010/00000059/00000001/art00007",
+    "ot:studyPublicationReference": "Devos, N., Barker, N. P., Nordenstam, B., & Mucina, L. (2010). A multi-locus phylogeny of Euryops (Asteraceae, Senecioneae) augments support for the\" Cape to Cairo\" hypothesis of floral migrations in Africa. Taxon, 59(1), 57-67.",
+    "ot:studyYear": 2009,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_548": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11224",
+    "ot:focalClade": 560323,
+    "ot:focalCladeOTTTaxonName": "Fabaceae",
+    "ot:studyId": "pg_548",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1100069",
+    "ot:studyPublicationReference": "A. Delgado-Salinas, M. Thulin, R. Pasquet, N. Weeden, M. Lavin. 2011. Vigna (Leguminosae) sensu lato: The names and identities of the American segregate genera. American Journal of Botany 98(10):1694-1715.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_56": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2114",
+    "ot:focalClade": 1095220,
+    "ot:focalCladeOTTTaxonName": "Tsuga",
+    "ot:studyId": "pg_56",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408785679770",
+    "ot:studyPublicationReference": "Havill, N. P., Campbell, C. S., Vining, T. F., LePage, B., Bayer, R. J., & Donoghue, M. J. (2008). Phylogeny and biogeography of Tsuga (Pinaceae) inferred from nuclear ribosomal ITS and chloroplast DNA sequence data. Systematic Botany, 33(3), 478-789.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_562": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12064",
+    "ot:focalClade": 921871,
+    "ot:focalCladeOTTTaxonName": "Poales",
+    "ot:studyId": "pg_562",
+    "ot:studyPublication": "http://dx.doi.org/10.3417/2010023",
+    "ot:studyPublicationReference": "Givnish, T. J., Ames, M. S., McNeal, J. R., McKain, M. R., Steele, P. R., dePamphilis, C. W., Graham, S. W., Pires, J. C., Stevenson, D. W., Zomlefer, W. B., Briggs, B. G., Duvall, M. R., Moore, M. J., Heaney, J. M., Soltis, D. E., Soltis, P. S., Thiele, K., & Leebens-Mack, J. H. 2010. Assembling the tree of the monocotyledons: Plastome sequence phylogeny and evolution of Poales. Ann. Missouri Bot. Gard. 97: 584-616.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_566": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1197",
+    "ot:focalClade": 730911,
+    "ot:focalCladeOTTTaxonName": "Lowiaceae",
+    "ot:studyId": "pg_566",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644053661931",
+    "ot:studyPublicationReference": "Johansen, L. B. (2005). Phylogeny of Orchidantha (Lowiaceae) and the Zingiberales based on six DNA regions. Systematic botany, 30(1), 106-117.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_57": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1933",
+    "ot:focalClade": 563858,
+    "ot:focalCladeOTTTaxonName": "Podalyrieae",
+    "ot:studyId": "pg_57",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408783887500",
+    "ot:studyPublicationReference": "Boatwright J., Savolainen V., Wyk B., Schutte-vlok A., Forest F., & Bank M. 2007. Systematic position of the anomolous genus Cadia and the phylogeny of the tribe Podalyrieae (Fabaceae). Systematic Botany, 33(1), 133-147.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_573": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1322",
+    "ot:focalClade": 881391,
+    "ot:focalCladeOTTTaxonName": "Aponogeton",
+    "ot:studyId": "pg_573",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644054782215",
+    "ot:studyPublicationReference": "Les, D. H., Moody, M. L., & Jacobs, S. W. L. 2005. Phylogeny and systematics of Aponogeton (Aponogetonaceae): The Australian species. Syst. Bot. 30: 503-519.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_576": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Stephen Smith",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12182",
+    "ot:focalClade": 481970,
+    "ot:focalCladeOTTTaxonName": "Alocasia",
+    "ot:studyId": "pg_576",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2011.12.011",
+    "ot:studyPublicationReference": "Nauheimer, L., Boyce, P. C., & Renner, S. S. 2012a. Giant taro and its relatives: Aphylogeny of the large genus Alocasia (Araceae) shedslight on Miocene floristic exchange in the Malesian region.  Mol. Phyl. Evol. 63: 43-52.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_58": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1941",
+    "ot:focalClade": 914794,
+    "ot:focalCladeOTTTaxonName": "Crotalarieae",
+    "ot:studyId": "pg_58",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364408786500271",
+    "ot:studyPublicationReference": "Boatwright J., Roux M., Wink M., Morozova T., & Wyk B. 2008. Phylogenetic Relationships of the Tribe Crotalarieae (Fabaceae) Inferred from DNA Sequences and Morphology. Systematic botany, 33(4), 752-761.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_581": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1931",
+    "ot:focalClade": 740507,
+    "ot:focalCladeOTTTaxonName": "Crocus",
+    "ot:studyId": "pg_581",
+    "ot:studyPublication": "http://www.jstor.org/stable/25066017",
+    "ot:studyPublicationReference": "Petersen, G., Seberg, O., J\u00f8rgensen, T., & Mathew, B. 2008. A phylogeny of the genus Crocus (Iridaceae) based on sequence data from five plastid regions. Taxon 57: 487-499.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_582": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10427",
+    "ot:focalClade": 124526,
+    "ot:focalCladeOTTTaxonName": "Danthonioideae",
+    "ot:studyId": "pg_582",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2008.05.030",
+    "ot:studyPublicationReference": "Pirie, M. D., Humphreys, A. M., Galley, C., Barker, N. P., Verboom, G. A., Orlovich, D., Draffin, S. J., Lloyd, K., Baeza, C. M., Negritto, M., Ruiz, E., Cota-S\u00e1nchez, J. H., Reimer, E., & Linder, H. P. 2008. A novel supermatrix approach improves resolution of phylogenetic relationships in a comprehenesive sample of danthonioid grasses. Molec. Phyl. Evol. 48: 48: 1106-1119.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_588": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S12348",
+    "ot:focalClade": 557124,
+    "ot:focalCladeOTTTaxonName": "Asparagales",
+    "ot:studyId": "pg_588",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1100468",
+    "ot:studyPublicationReference": "Seberg, O., Petersen, G., Davis, J. I., Pires, J. C., Stevenson, D. W., Chase, M. W., Fay, M. F., Devey, D. S., J\u00f8rgensen, T., Sytsma, K. J., & Pillon, Y. 2012. Phylogeny of the Asparagales based on three plastid and two mitochondrial genes. American J. Bot. 99: 875-889.",
+    "ot:studyYear": 2012
+   }
+  ]
+ },
+ "pg_59": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1415",
+    "ot:focalClade": 496578,
+    "ot:focalCladeOTTTaxonName": "Aristolochiaceae",
+    "ot:studyId": "pg_59",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s00606-004-0217-0",
+    "ot:studyPublicationReference": "Neinhuis C., Wanke S., Hilu K., M\u00fcller K., & Borsch T. 2005. Phylogeny of Aristolochiaceae based on parsimony, likelihood, and Bayesian analyses of trnL-trnF sequences. Plant Systematics and Evolution, 250: 7-26.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_594": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S935",
+    "ot:studyId": "pg_594",
+    "ot:studyPublication": "http://dx.doi.org/10.1043/0363-6445-28.2.387",
+    "ot:studyPublicationReference": "Lavin M., Wojciechowski M., Gasson P., Hughes C., & Wheeler E. 2003. Phylogeny of robinioid legumes (Fabaceae) revisited: Coursetia and Gliricidia recircumscribed, and a biogeographical appraisal of the Caribbean endemics. Systematic Botany, 28(2): 387-409.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_595": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10568",
+    "ot:focalClade": 404633,
+    "ot:focalCladeOTTTaxonName": "Senna",
+    "ot:studyId": "pg_595",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1558-5646.2010.01086.x",
+    "ot:studyPublicationReference": "Marazzi B., & Sanderson M.J. 2010. Large-Scale Patterns of Diversification in the Widespread Legume Genus Senna and the Evolutionary Role of Extrafloral Nectaries. Evolution, 64(12): 3570-3592.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_596": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S870",
+    "ot:studyId": "pg_596",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.89.5.854",
+    "ot:studyPublicationReference": "Percy D., & Cronk Q. 2002. Different fates of island brooms: contrasting evolution in Adenocarpus, Genista and Teline (Genisteae, Leguminosae) in the Canary Islands and Madeira. American Journal of Botany, 89: 854-864.",
+    "ot:studyYear": 2002
+   }
+  ]
+ },
+ "pg_597": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1877",
+    "ot:focalClade": 560323,
+    "ot:focalCladeOTTTaxonName": "Fabaceae",
+    "ot:studyId": "pg_597",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407783390700",
+    "ot:studyPublicationReference": "Ribeiro R., Lavin M., Filho J., Filho C., Santos F., & Lovato M. 2007. The genus Machaerium (Leguminosae) is more closely related to Aeschynomene Sect. Ochopodium than to Dalbergia: inferences from combined sequence data. Systematic Botany, 32(4).",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_598": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1689",
+    "ot:focalClade": 508090,
+    "ot:focalCladeOTTTaxonName": "Poaceae",
+    "ot:studyId": "pg_598",
+    "ot:studyPublication": "http://www.jstor.org/stable/20443368",
+    "ot:studyPublicationReference": "Soreng, R. J., Davis, J. I., & Voionomaa, M. A. 2007. A phylogenetic analysis of Poaceae tribe Poeae sensu lato based on morphological characters and sequence data from three plastid-encoded genes: Evidence for reticulation, and a new classification of the tribe. Kew Bull. 62: 425-454.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_599": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1460",
+    "ot:focalClade": 679527,
+    "ot:focalCladeOTTTaxonName": "Costaceae",
+    "ot:studyId": "pg_599",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406775971840",
+    "ot:studyPublicationReference": "Specht, C. D. 2006. Systematics and evolution  the tropical monocot family Costaceae (Zingiberales): A multiple dataset approach. Syst. Bot. 31: 89-106.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_603": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S2377",
+    "ot:focalClade": 595052,
+    "ot:focalCladeOTTTaxonName": "Cymbidieae",
+    "ot:studyId": "pg_603",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.94.11.1860",
+    "ot:studyPublicationReference": "Whitten, W. M., Blanco, M. A., Williams, N. H., Koehler, S., Carnevali, G., Singer, R. B., Endara, L., & Neubig, K. 2007. Molecular phylogenetics of Maxillaria and related genera (Orchidaceae: Cymbidieae) based on combined molecular data sets. American J. Bot. 94: 1860-1889.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_605": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1110",
+    "ot:focalClade": 162021,
+    "ot:focalCladeOTTTaxonName": "Strophostyles",
+    "ot:studyId": "pg_605",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644041744464",
+    "ot:studyPublicationReference": "Riley-Hulting, E. T., Delgado-Salinas, A., & Lavin, M. (2004). Phylogenetic systematics of Strophostyles (Fabaceae): a North American temperate genus within a neotropical diversification. Systematic Botany, 29(3), 627-653.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_606": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:comment": "",
+    "ot:curatorName": "Jonathan A Rees",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1294",
+    "ot:focalCladeOTTTaxonName": "",
+    "ot:studyId": "pg_606",
+    "ot:studyPublication": "http://books.google.com/books?id=vbBaAAAACAAJ",
+    "ot:studyPublicationReference": "Steele K., & Wojciechowski M. 2003. \"Phylogenetic analyses of tribes Trifolieae and Vicieae based on sequences of the plastid gene matK (Papilionoideae: Leguminosae).\" In: Klitgaard B., & Bruneau A., eds. Advances in Legume Systematics, part 10. pp. 355-370. London, Royal Botanic Gardens, Kew.",
+    "ot:studyYear": 2003
+   }
+  ]
+ },
+ "pg_61": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11152",
+    "ot:focalClade": 627035,
+    "ot:focalCladeOTTTaxonName": "Bromeliaceae",
+    "ot:studyId": "pg_61",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000059",
+    "ot:studyPublicationReference": "Givnish, Thomas J., Michael HJ Barfuss, Benjamin Van Ee, Ricarda Riina, Katharina Schulte, Ralf Horres, Philip A. Gonsiska et al. \"Phylogeny, adaptive radiation, and historical biogeography in Bromeliaceae: insights from an eight-locus plastid phylogeny.\" American Journal of Botany 98, no. 5 (2011): 872-895.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_62": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1782",
+    "ot:focalClade": 97782,
+    "ot:focalCladeOTTTaxonName": "Lymania",
+    "ot:studyId": "pg_62",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364407781179707",
+    "ot:studyPublicationReference": "de Oliveira Furtado de Sousa, L., Wendt, T., Brown, G. K., Tuthill, D. E., & Evans, T. M. (2007). Monophyly and phylogenetic relationships in Lymania (Bromeliaceae: Bromelioideae) based on morphology and chloroplast DNA sequences. Systematic Botany, 32(2), 264-270.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_625": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1331",
+    "ot:focalClade": 899147,
+    "ot:focalCladeOTTTaxonName": "Hoheria",
+    "ot:studyId": "pg_625",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/0028825X.2005.9512973",
+    "ot:studyPublicationReference": "Heenan, P. B., Dawson, M. I., Redmond, D. N., & Wagstaff, S. J. (2005). Relationships of the New Zealand mountain ribbonwoods (Hoheria glabrata and H. lyallii: Malvaceae), based on molecular and morphological data. New Zealand Journal of Botany, 43(2), 527-549.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_650": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10284",
+    "ot:focalClade": 655984,
+    "ot:focalCladeOTTTaxonName": "Meliaceae",
+    "ot:studyId": "pg_650",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.0900229",
+    "ot:studyPublicationReference": "Muellner A., Pennington T., Koecke A., & Renner S.S. 2010. Biogeography of Cedrela (Meliaceae, Sapindales) in Central and South America. American Journal of Botany, 97(3): 511-518.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_704": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 584120,
+    "ot:focalCladeOTTTaxonName": "Molluginaceae",
+    "ot:studyId": "pg_704",
+    "ot:studyPublication": "http://dx.doi.org/10.1111/j.1558-5646.2010.01168.x",
+    "ot:studyPublicationReference": "Christin, P.-A., Sage, T. L., Edwards, E. J., gburn, R. M., Khoshravesh, R., & Sage, R. F. 2011. Complex evolutionary transitions and the significance of c(3)-c(4) intermediate forms of photosynthesis in Molluginaceae. Evolution 65: 643-660.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_713": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10963",
+    "ot:focalClade": 23736,
+    "ot:focalCladeOTTTaxonName": "Lamiales",
+    "ot:studyId": "pg_713",
+    "ot:studyPublication": "http://dx.doi.org/10.1186/1471-2148-10-352",
+    "ot:studyPublicationReference": "Sch\u00e4ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch, T., Heubl, G., & M\u00fcller, K. F. (2010). Towards resolving Lamiales relationships: insights from rapidly evolving chloroplast sequences. BMC evolutionary biology, 10(1), 352.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_719": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11079",
+    "ot:focalClade": 694622,
+    "ot:focalCladeOTTTaxonName": "Menyanthaceae",
+    "ot:studyId": "pg_719",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X605092",
+    "ot:studyPublicationReference": "Tippery N., & Les D. 2011. Phylogenetic relationships and morphological evolution in Nymphoides (Menyanthaceae). Systematic Botany, 36: 1101-1113.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_72": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11008",
+    "ot:focalClade": 991891,
+    "ot:focalCladeOTTTaxonName": "Malpighiaceae",
+    "ot:studyId": "pg_72",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.1000146",
+    "ot:studyPublicationReference": "Davis, C. C., & Anderson, W. R. (2010). A complete generic phylogeny of Malpighiaceae inferred from nucleotide sequence data and morphology. American journal of botany, 97(12), 2031-2048.",
+    "ot:studyYear": 2010
+   }
+  ]
+ },
+ "pg_721": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 877745,
+    "ot:focalCladeOTTTaxonName": "Commelinaceae",
+    "ot:studyId": "pg_721",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X569471",
+    "ot:studyPublicationReference": "Burns, J. H., Faden, R. B., & Steppan, S. J. 2011. Phylogenetic studies in the Commelinaceae subfamily Commelinoideae inferred from nuclear ribosomal and chloroplast DNA sequences. Syst. Bot. 36: 268-276.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_723": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 31937,
+    "ot:focalCladeOTTTaxonName": "Triticum",
+    "ot:studyId": "pg_723",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2006.01.023",
+    "ot:studyPublicationReference": "Petersen, G., Seberg, O., Yde, M., & Berthelsen, K. 2006. Phylogenetic relationships of Triticum and Aegilops and evidence for the origin of the A, B, and D genomes of common wheat (Triticum aestivum). Mol. Phyl. Evol. 39: 70-82.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_73": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S10863",
+    "ot:focalClade": 530187,
+    "ot:focalCladeOTTTaxonName": "Passifloraceae",
+    "ot:studyId": "pg_73",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406775971769",
+    "ot:studyPublicationReference": "Hansen A., Gilbert L., Simpson B., Downie S., Cervi A., & Jansen R. 2006. Phylogenetic Relationships and Chromosome Number Evolution in Passiflora. Systematic Botany, 31(1): 138-150.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_75": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1979",
+    "ot:focalClade": 79260,
+    "ot:focalCladeOTTTaxonName": "Apioideae",
+    "ot:studyId": "pg_75",
+    "ot:studyPublication": "http://dx.doi.org/10.2307/2656687",
+    "ot:studyPublicationReference": "Downie, S. R., Katz-Downie, D. S., & Spalik, K. (2000). A phylogeny of Apiaceae tribe Scandiceae: evidence from nuclear ribosomal DNA internal transcribed spacer sequences. American Journal of Botany, 87(1), 76-95.",
+    "ot:studyYear": 2008
+   }
+  ]
+ },
+ "pg_754": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1096",
+    "ot:focalClade": 103998,
+    "ot:focalCladeOTTTaxonName": "Ribes howellii",
+    "ot:studyId": "pg_754",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364404772974239",
+    "ot:studyPublicationReference": "Schultheis, L. M., & Donoghue, M. J. (2004). Molecular phylogeny and biogeography of Ribes (Grossulariaceae), with an emphasis on gooseberries (subg. Grossularia). Systematic botany, 29(1), 77-96.",
+    "ot:studyYear": 2004
+   }
+  ]
+ },
+ "pg_761": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1613",
+    "ot:focalClade": 14968,
+    "ot:focalCladeOTTTaxonName": "Drosera",
+    "ot:studyId": "pg_761",
+    "ot:studyPublication": "http://dx.doi.org/10.1080/1063515060081570",
+    "ot:studyPublicationReference": "Yesson C., & Culham A. 2006. Phyloclimatic Modeling: Combining Phylogenetics and Bioclimatic Modeling. Systematic Biology, 55(5): 785-802.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_77": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1362",
+    "ot:focalClade": 257507,
+    "ot:focalCladeOTTTaxonName": "Anaxagorea",
+    "ot:studyId": "pg_77",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364405775097888",
+    "ot:studyPublicationReference": "Scharaschkin, T., & Doyle, J. A. (2005). Phylogeny and historical biogeography of Anaxagorea (Annonaceae) using morphology and non-coding chloroplast sequence data. Systematic Botany, 712-735.",
+    "ot:studyYear": 2005,
+    "ot:tag": "ingroup added for Fig. 7"
+   }
+  ]
+ },
+ "pg_787": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 673430,
+    "ot:focalCladeOTTTaxonName": "Ephedra",
+    "ot:studyId": "pg_787",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/605116",
+    "ot:studyPublicationReference": "Rydin, C., & Korall, P. (2009). Evolutionary relationships in Ephedra (Gnetales), with implications for seed plant phylogeny. International journal of plant sciences, 170(8), 1031-1043.",
+    "ot:studyYear": 2009
+   }
+  ]
+ },
+ "pg_80": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1370",
+    "ot:focalClade": 66726,
+    "ot:focalCladeOTTTaxonName": "Rhododendron",
+    "ot:studyId": "pg_80",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644054782170",
+    "ot:studyPublicationReference": "Goetsch, L., Eckert, A. J., & Hall, B. D. (2005). The molecular systematics of Rhododendron (Ericaceae): a phylogeny based upon RPB2 gene sequences. Systematic Botany, 30(3), 616-626.",
+    "ot:studyYear": 2005,
+    "ot:tag": "nrDNA"
+   }
+  ]
+ },
+ "pg_81": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1527",
+    "ot:focalClade": 771683,
+    "ot:focalCladeOTTTaxonName": "Pinus",
+    "ot:studyId": "pg_81",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2006.03.009",
+    "ot:studyPublicationReference": "Eckert, A. J., & Hall, B. D. (2006). Phylogeny, historical biogeography, and patterns of diversification for< i> Pinus</i>(Pinaceae): Phylogenetic tests of fossil-based hypotheses. Molecular Phylogenetics and Evolution, 40(1), 166-182.",
+    "ot:studyYear": 2005,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_82": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1581",
+    "ot:focalClade": 590452,
+    "ot:focalCladeOTTTaxonName": "Campanula",
+    "ot:studyId": "pg_82",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406779695924",
+    "ot:studyPublicationReference": "Park, J. M., Kova\u010dic, S., Liber, Z., Eddie, W. M., & Schneeweiss, G. M. (2006). Phylogeny and biogeography of isophyllous species of Campanula (Campanulaceae) in the Mediterranean area. Systematic Botany, 31(4), 862-880.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_88": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1506",
+    "ot:focalClade": 197828,
+    "ot:focalCladeOTTTaxonName": "Erodium",
+    "ot:studyId": "pg_88",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406779695906",
+    "ot:studyPublicationReference": "Fiz, O., Vargas, P., Alarcon, M. L., & Aldasoro, J. J. (2006). Phylogenetic relationships and evolution in Erodium (Geraniaceae) based on trnL-trnF sequences. Systematic Botany, 31(4), 739-763.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_898": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S11418",
+    "ot:focalClade": 383681,
+    "ot:focalCladeOTTTaxonName": "Schefflera",
+    "ot:studyId": "pg_898",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364411X583754",
+    "ot:studyPublicationReference": "Fiaschi, P., & Plunkett, G. M. (2011). Monophyly and phylogenetic relationships of Neotropical Schefflera (Araliaceae) based on plastid and nuclear markers. Systematic Botany, 36(3), 806-817.",
+    "ot:studyYear": 2011
+   }
+  ]
+ },
+ "pg_901": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1328",
+    "ot:focalClade": 959996,
+    "ot:focalCladeOTTTaxonName": "Meryta",
+    "ot:studyId": "pg_901",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/0363644054782279",
+    "ot:studyPublicationReference": "Tronchet, F., Plunkett, G. M., J\u00e9r\u00e9mie, J., & Lowry, P. P. (2005). Monophyly and major clades of Meryta (Araliaceae). Systematic botany, 30(3), 657-670.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_915": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1781",
+    "ot:focalClade": 659705,
+    "ot:focalCladeOTTTaxonName": "Dipsacales",
+    "ot:studyId": "pg_915",
+    "ot:studyPublication": "http://dx.doi.org/10.1086/519460",
+    "ot:studyPublicationReference": "Moore, B. R., & Donoghue, M. J. (2007). Correlates of diversification in the plant clade Dipsacales: geographic movement and evolutionary innovations. the american naturalist, 170(S2), S28-S55.",
+    "ot:studyYear": 2007,
+    "ot:tag": "ingroup added;"
+   }
+  ]
+ },
+ "pg_921": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "Jiabin Deng",
+    "ot:focalClade": 415723,
+    "ot:focalCladeOTTTaxonName": "Oryzeae",
+    "ot:studyId": "pg_921",
+    "ot:studyPublication": "http://dx.doi.org/10.3732/ajb.92.9.1548",
+    "ot:studyPublicationReference": "Guo, Y.-L., & Ge, S. 2005. Molecular phylogeny of Oryzeae (Poaceae) based on DNA sequences from chloroplast, mitochondrial, and nuclear genomes. American J. Bot. 92: 1548-1558.",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_926": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 208036,
+    "ot:focalCladeOTTTaxonName": "Rosaceae",
+    "ot:studyId": "pg_926",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/s00606-007-0539-9",
+    "ot:studyPublicationReference": "Potter, D. [et al. 2007a], Eriksson, T., Evans, R. C., Oh, S., Smedmark, J. E. E., Morgan, D. R., Kerr, M., Robertson, K. R., Arsenault, M., Dickinson, T. A., & Campbell, C. S. 2007. Phylogeny and classification of Rosaceae. Plant Syst. Evol. 266: 5-43.",
+    "ot:studyYear": 2007
+   }
+  ]
+ },
+ "pg_93": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S1483",
+    "ot:focalClade": 168193,
+    "ot:focalCladeOTTTaxonName": "Symplocos",
+    "ot:studyId": "pg_93",
+    "ot:studyPublication": "http://dx.doi.org/10.1600/036364406775971877",
+    "ot:studyPublicationReference": "Fritsch, P. W., Cruz, B. C., Almeda, F., Wang, Y., & Shi, S. (2006). Phylogeny of Symplocos based on DNA sequences of the chloroplast trnC-trnD intergenic region. Systematic botany, 31(1), 181-192.",
+    "ot:studyYear": 2006
+   }
+  ]
+ },
+ "pg_934": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "bryan drew",
+    "ot:focalClade": 511898,
+    "ot:focalCladeOTTTaxonName": "Echinops",
+    "ot:studyId": "pg_934",
+    "ot:studyPublication": "http://dx.doi.org/10.1007/BF02804288",
+    "ot:studyPublicationReference": "Garnatje, T. [et al. 2005], Susanna, A., Garcia-Jacas, N., Vilatersana, R., & Vall\u00e8s, J. 2005. A first approach to the molecular phylogeny of the genus Echinops (Asteraceae): Sectional delimitation and relationships with the genus Acantholepis Less. Folia Geobot. 40: 407-419/",
+    "ot:studyYear": 2005
+   }
+  ]
+ },
+ "pg_99": {
+  "matched_studies": [
+   {
+    "is_deprecated": False,
+    "ot:curatorName": "William Wysocki",
+    "ot:dataDeposit": "http://purl.org/phylo/treebase/phylows/study/TB2:S9970",
+    "ot:studyId": "pg_99",
+    "ot:studyPublication": "http://dx.doi.org/10.1016/j.ympev.2009.01.023",
+    "ot:studyPublicationReference": "Gruenstaeudl M., Urtubey E., Jansen R., Samuel R., Barfuss M., & Stuessy T. 2009. Phylogeny of Barnadesioideae (Asteraceae) inferred from DNA sequence data and morphology. Molecular Phylogenetics and Evolution, 51(3): 572-587.",
+    "ot:studyYear": 2009
+   }
+  ]
+ }
+}
+    study_id = request.args[0]
+    r = d.get(study_id)
+    if r is None:
+        raise HTTP(400, 'Unknown study ID {s} this could be a valid study, but simply one that was not in the synthesis'.format(s=study_id))
+    return r

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -825,6 +825,33 @@ function showObjectProperties( objInfo, options ) {
                             // don't keep sending requests for the same source! we manage this with 'loadStatus'
                             sourceMetadata['loadStatus'] = 'PENDING';
                             ///console.warn('>>>>>>>>>>>>>>> sourceDetails NOT FOUND for sourceID '+ sourceID +', FETCHING NOW...');
+                            $.getJSON(
+                                '/hack/oticache/'+ sourceMetadata.study_id,
+                                function(data) {    // JSONP callback
+                                    // reset this locally, to MAKE SURE we've got the right box
+                                    ///console.warn('<<<<<<<<<<<<<<< BACK FROM FETCH for sourceID '+ sourceID);
+                                    var cbSourceMetadata = argus.treeData.sourceToMetaMap[ sourceID ];
+                                    // ignore this if not requested, or already complete
+                                    if (cbSourceMetadata['loadStatus'] === 'PENDING') {
+                                        if (data.matched_studies && (data.matched_studies.length > 0)) {
+                                            if (data.matched_studies.length > 1) {
+                                                console.log(">>>> EXPECTED to find one matching study for id '"+ (cbSourceMetadata).study_id +"', not multiple:");
+                                                console.log(data);
+                                            }
+                                            var studyInfo = data.matched_studies[0];
+                                            cbSourceMetadata['sourceDetails'] = studyInfo;
+                                            cbSourceMetadata['loadStatus'] = 'COMPLETE';
+                                            // Nudge for a refresh of the properties display?
+                                            showObjectProperties( objInfo );
+                                        } else {
+                                            console.log(">>>> EXPECTED to find a matching study for id '"+ (cbSourceMetadata).study_id +"', not this:");
+                                            console.log(data);
+                                            cbSourceMetadata['loadStatus'] = 'FAILED';
+                                        }
+                                    }
+                                }
+                            );
+/* SKIPPING THIS in favor of mtholder's quick OTI "stand-in" above
                             $.post(
                                 singlePropertySearchForStudies_url, // JSONP fetch URL
                                 {   // POSTed data
@@ -856,6 +883,7 @@ function showObjectProperties( objInfo, options ) {
                                     }
                                 }
                             );
+*/
                         }
                     }
                 });


### PR DESCRIPTION
This was a hot-fix from @mtholder, to relieve the load on oti.
Probably not something we want to keep, but it sure is fast! (Note that
the inline JSON represents supporting studies as of the most recent
synthesis, so this would need to be kept up-to-date.)