### PR TITLE
Change the tree-upload form validation.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4163,7 +4163,10 @@ function updateNewTreeUploadForm() {
         readyToSubmit = false;
     }
 
-    var chosenFile = $.trim( $('#treeupload').val() );
+    //var chosenFile = $.trim( $('#treeupload').val() );
+    // NO, this is routinely cleared by the upload widget; the file-name
+    // display (white on blue) alongside, is actually a safer test.
+    var chosenFile = $.trim( $('#upload-tree-info').text() );
     var pastedText = $.trim( $('#new-tree-text').val() );
     // either of these is acceptable
     if (pastedText === '' && chosenFile === '') {


### PR DESCRIPTION
This was using the value of the input[type=file] widget as part of form
validation; as it turns out, the upload widget clears this after each
file is added, so it's not a reliable test. Instead, we'll actually use
the filename preview, since this is maintained by the widget. (In each
test, we're looking for a non-empty field value *or* element text.)
Fixes #542.