### PR TITLE
Manage very large server responses in footer.

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -835,3 +835,8 @@ tr.after-shims th {
     left: 8px;
     pointer-events: none;
 }
+.alert pre.error-details {
+    /* manage very large server responses in footer */
+    overflow: scroll;
+    max-height: 400px;
+}


### PR DESCRIPTION
This will contain very long error messages (e.g., nexson validation
responses) in the footer, so that they scroll rather than filling the
window. Most importantly, this preserves the close widget so the user
can return to the main page. This is working now on **devtree**.

Here's an example (forced by duplicating output in the browser's dev tools):
<img width="723" alt="screen shot 2015-10-09 at 3 17 41 pm" src="https://cloud.githubusercontent.com/assets/446375/10403379/1bf9bc9e-6e99-11e5-9f8f-91fe823e075b.png">
