### PR TITLE
Capture initial OTU mapping context in Nexson

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7455,7 +7455,10 @@ function inferSearchContextFromAvailableOTUs() {
             ///console.log(">> inferredContext: "+ inferredContext);
             if (inferredContext) {
                 // update BOTH search-context drop-down menus to show this result
-                $('select[name=taxon-search-context], select[name=mapping-search-context]').val(inferredContext);
+                $('select[name=taxon-search-context]').val(inferredContext);
+                // tweak the model's OTU mapping, then refresh the UI
+                getOTUMappingHints().data.searchContext.$ = inferredContext;
+                updateMappingHints();
             } else {
                 showErrorMessage('Sorry, no search context was inferred.');
             }

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1434,6 +1434,7 @@ body {
                     <select class="input-block-level" style="margin-bottom: 8px;" name="mapping-search-context"
                             data-bind="value: getOTUMappingHints().data.searchContext.$,
                               valueUpdate: ['afterkeydown', 'input'],
+                              css: viewModel.ticklers.OTU_MAPPING_HINTS,
                               event: { keyup: updateMappingHints, change: updateMappingHints }
                               ">
                     {{ # generate our contextNames list based on newly fetched names


### PR DESCRIPTION
This was updated in the UI, but not in the underlying Nexson model; as a
result, TNRS calls would use the wrong search context until/unless the
curator changed the context. Fixes https://github.com/OpenTreeOfLife/taxomachine/issues/120