### PR TITLE
Disable UI for branch lengths info if not found.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1554,15 +1554,16 @@ function toggleBranchLengthsInViewer(cb) {
 var usingRadialTreeLayout = false;
 function toggleRadialTreeLayoutInViewer(cb) {
     // checkbox enables/disables radial tree layout in tree-view popup
+    // fetch tree ID from popup's widgets
+    var currentTreeID = $('#tree-tags').attr('treeid');
+    var currentTree = getTreeByID(currentTreeID);
     usingRadialTreeLayout = $(cb).is(':checked');
     // disable/enable the branch-lengths checkbox
-    if (usingRadialTreeLayout) {
+    if (usingRadialTreeLayout || !(branchLengthsFoundInTree(currentTree))) {
         $('#branch-length-toggle').attr('disabled', 'disabled');
     } else {
         $('#branch-length-toggle').removeAttr('disabled');
     }
-    // fetch tree ID from popup's widgets
-    var currentTreeID = $('#tree-tags').attr('treeid');
     if (currentTreeID) {
         drawTree(currentTreeID)
     } else {
@@ -3140,7 +3141,7 @@ function showTreeViewer( tree, options ) {
 
     // bind just the selected tree to the modal HTML
     // NOTE that we must call cleanNode first, to allow "re-binding" with KO.
-    var $boundElements = $('#tree-viewer').find('.modal-body, .modal-header h3, .nav-tabs .badge');
+    var $boundElements = $('#tree-viewer').find('.modal-body, .modal-header h3, .nav-tabs .badge, .modal-footer');
     // Step carefully to avoid un-binding important modal behavior (close widgets, etc)!
     $.each($boundElements, function(i, el) {
         ko.cleanNode(el);

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2302,6 +2302,7 @@ body {
               <br/>
                -->
 
+            <div style="margin-top: 6px;" data-bind="visible: viewModel.ticklers.TREES() && branchLengthsFoundInTree( $data )">
                 <label>Branch length mode: </label>
                 <select data-bind="options: branchLengthModeDescriptions,
                     optionsValue: function(item) {
@@ -2315,22 +2316,29 @@ body {
                     css: viewModel.ticklers.TREES
                     ">TYPE</select>
 
-            <span data-bind="visible: viewModel.ticklers.TREES() && $data['^ot:branchLengthMode'] === 'ot:time'" >
-                <label style="margin-left: 10px;">Time unit: </label>
-                <select data-bind="options: ['Myr'],
-                    value: $data['^ot:branchLengthTimeUnit'],
-                    event: { keyup: nudge.TREES, change: nudge.TREES },
-                    css: viewModel.ticklers.TREES
-                    ">TYPE</select>
-            </span>
+                <span data-bind="visible: viewModel.ticklers.TREES() && $data['^ot:branchLengthMode'] === 'ot:time'" >
+                    <label style="margin-left: 10px;">Time unit: </label>
+                    <select data-bind="options: ['Myr'],
+                        value: $data['^ot:branchLengthTimeUnit'],
+                        event: { keyup: nudge.TREES, change: nudge.TREES },
+                        css: viewModel.ticklers.TREES
+                        ">TYPE</select>
+                </span>
 
-            <span data-bind="visible: viewModel.ticklers.TREES() && $data['^ot:branchLengthMode'] === 'ot:other'" >
-                <input type="text" data-bind="value: $data['^ot:branchLengthDescription'],
-                    valueUpdate: ['afterkeydown', 'input'],
-                    event: { keyup: nudge.TREES, change: nudge.TREES },
-                    css: viewModel.ticklers.TREES
-                " placeholder="Describe here"></input>
-            </span>
+                <span data-bind="visible: viewModel.ticklers.TREES() && $data['^ot:branchLengthMode'] === 'ot:other'" >
+                    <input type="text" data-bind="value: $data['^ot:branchLengthDescription'],
+                        valueUpdate: ['afterkeydown', 'input'],
+                        event: { keyup: nudge.TREES, change: nudge.TREES },
+                        css: viewModel.ticklers.TREES
+                    " placeholder="Describe here"></input>
+                </span>
+            </div>
+
+           <!-- NOTE that a virtual element with 'ko if: ...' didn't work here! -->
+            <div style="margin-top: 6px;" data-bind="visible: viewModel.ticklers.TREES() && !branchLengthsFoundInTree( $data )">
+                <label>Branch length mode: </label>
+                <strong data-bind="css: viewModel.ticklers.TREES(), text: getBranchLengthModeDescriptionForTree($data)"></strong>
+            </div>
 
            <!-- NOTE that a virtual element with 'ko if: ...' didn't work here! -->
             <div data-bind="visible: viewModel.ticklers.TREES() && ambiguousLabelsFoundInTree( $data )"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2633,6 +2633,7 @@ body {
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
           <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle">
               <input type="checkbox" id="branch-length-toggle"
+                     data-bind="enable: branchLengthsFoundInTree($data)"
                      onclick="toggleBranchLengthsInViewer(this); return true;" />
               Cladogram (hide branch lengths)
           </label>


### PR DESCRIPTION
We now use a single, central test for branch-length information. If no branch lengths are found in the current tree, we disable the UI for setting this information (as we've already done for ambiguous internal
labels). Fixes #738 and #747.

I've also disabled the tree viewer's **Cladogram (hide branch lengths)** checkbox if the current tree has no branch-length information. These changes are working now on **devtree**.