### PR TITLE
Suppress unsaved-data warning when viewing a study

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1369,8 +1369,10 @@ function loadSelectedStudy() {
 
             // Any further changes (*after* tree normalization) should prompt for a save before leaving
             viewModel.ticklers.STUDY_HAS_CHANGED.subscribe( function() {
-                enableSaveButton();
-                pushPageExitWarning( "WARNING: This study has unsaved changes! To preserve your work, you should save this study before leaving or reloading the page." );
+                if (viewOrEdit == 'EDIT') {
+                    enableSaveButton();
+                    pushPageExitWarning( "WARNING: This study has unsaved changes! To preserve your work, you should save this study before leaving or reloading the page." );
+                }
                 updateQualityDisplay();
             });
 


### PR DESCRIPTION
This warning sometimes appears when someone is viewing (read-only) a
study in the curation app. It's caused by reflexive cleanup of Nexson
when its data is loaded into the app, but of course the viewer can't
actually save these changes. Fixes #824.