### PR TITLE
Bundle Markdown source as a named argument.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7340,7 +7340,7 @@ function showStudyCommentPreview() {
         crossdomain: true,
         type: 'POST',
         url: render_markdown_url,
-        data: viewModel.nexml['^ot:comment'],
+        data: {'src': viewModel.nexml['^ot:comment']},
         success: function( data, textstatus, jqxhr ) {
             $('#comment-preview').show();
         },


### PR DESCRIPTION
This (along with corresponding tweak to `phylesystem-api`) fixes #814. Both PRs are working now on **devtree**, so we should be able to preview any reasonable Markdown.