### PR TITLE
Shift-select multiple OTUs in mapping tool

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1242,6 +1242,9 @@ function loadSelectedStudy() {
                     }
                 });
 
+                // clear any stale last-selected OTU (it's likely moved)
+                lastClickedTogglePosition = null;
+                
                 viewModel._filteredOTUs( filteredList );
                 viewModel._filteredOTUs.goToPage(1);
                 return viewModel._filteredOTUs;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4918,20 +4918,36 @@ var bogusEditedLabelCounter = ko.observable(1);  // this just nudges the label-e
 // keep track of the last (de)selected list item (its position)
 var lastClickedTogglePosition = null;
 function toggleMappingForOTU(otu, evt) {
-    var $toggle = $(evt.target);
-    if ($toggle.is(':checked')) {
-        otu['selectedForAction'] = true;
+    var $toggle, newState;
+    // allow triggering this from anywhere in the row
+    if ($(evt.target).is(':checkbox')) {
+        $toggle = $(evt.target);
+        // N.B. user's click (or the caller) has already set its state!
+        newState = $toggle.is(':checked');
     } else {
-        otu['selectedForAction'] = false;
+        $toggle = $(evt.target).closest('tr').find('input.map-toggle');
+        // clicking elsewhere should toggle checkbox state!
+        newState = !($toggle.is(':checked'));
+        forceToggleCheckbox($toggle, newState);
     }
-    // determine the position (nth checkbox) of this OTU in the visible list
-    var $visibleToggles = $toggle.closest('table').find('.map-toggle');
-    var newListPosition = $.inArray(evt.target, $visibleToggles);
-    if (evt.shiftKey && typeof(lastClickedTogglePosition) === 'number') {
-        forceMappingForRangeOfOTUs( otu['selectedForAction'], lastClickedTogglePosition, newListPosition );
+    // add (or remove) highlight color that works with hover-color
+    if (newState) {
+        $toggle.closest('tr').addClass('warning');
+    } else {
+        $toggle.closest('tr').removeClass('warning');
     }
-    // in any case, make this the new range-starter
-    lastClickedTogglePosition = newListPosition;
+    // if this is the original click event; check for a range!
+    if (typeof(evt.shiftKey) !== 'undefined') {
+        // determine the position (nth checkbox) of this OTU in the visible list
+        var $visibleToggles = $toggle.closest('table').find('input.map-toggle');
+        var newListPosition = $.inArray( $toggle[0], $visibleToggles);
+        if (evt.shiftKey && typeof(lastClickedTogglePosition) === 'number') {
+            forceMappingForRangeOfOTUs( otu['selectedForAction'], lastClickedTogglePosition, newListPosition );
+        }
+        // in any case, make this the new range-starter
+        lastClickedTogglePosition = newListPosition;
+    }
+    evt.stopPropagation();
     return true;  // update the checkbox
 }
 function forceMappingForRangeOfOTUs( newState, posA, posB ) {
@@ -4944,41 +4960,38 @@ function forceMappingForRangeOfOTUs( newState, posA, posB ) {
         $togglesInRange = $allMappingToggles.slice(posB, posA+1);
     }
     $togglesInRange.each(function() {
-        var $cb = $(this);
-        if (newState === true) {
-            if ($cb.is(':checked') == false) {
-                $cb.prop('checked', true);
-                $cb.triggerHandler('click');
-            }
-        } else {
-            if ($cb.is(':checked') == true) {
-                $cb.prop('checked', false);
-                $cb.triggerHandler('click');
-            }
-        }
+        forceToggleCheckbox(this, newState);
     });
 }
 
-function toggleAllMappingCheckboxes(cb) {
-    var $bigToggle = $(cb);
-    var $allMappingToggles = $('input.map-toggle');
-    if ($bigToggle.is(':checked')) {
-        $allMappingToggles.each(function() {
-            var $cb = $(this);
+function forceToggleCheckbox(cb, newState) {
+    var $cb = $(cb);
+    switch(newState) {
+        case (true):
             if ($cb.is(':checked') == false) {
                 $cb.prop('checked', true);
                 $cb.triggerHandler('click');
             }
-        });
-    } else {
-        $allMappingToggles.each(function() {
-            var $cb = $(this);
+            break;
+        case (false):
             if ($cb.is(':checked')) {
                 $cb.prop('checked', false);
                 $cb.triggerHandler('click');
             }
-        });
+            break;
+        default:
+            console.error("forceToggleCheckbox() invalid newState <"+ typeof(newState) +">:");
+            console.error(newState);
+            return;
     }
+}
+function toggleAllMappingCheckboxes(cb) {
+    var $bigToggle = $(cb);
+    var $allMappingToggles = $('input.map-toggle');
+    var newState = $bigToggle.is(':checked');
+    $allMappingToggles.each(function() {
+        forceToggleCheckbox(this, newState);
+    });
     return true;
 }
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1171,16 +1171,21 @@ body {
                     </tr>
                   </thead>
                   <tbody data-bind="foreach: { data: viewModel.filteredOTUs().pagedItems(), as: 'otu' }">
-                    <tr data-bind="if: true">
+                    <tr data-bind="if: true,
+                                   css: viewModel.ticklers.OTU_MAPPING_HINTS() +' '+ (otu['selectedForAction'] ? 'warning' : '')">
                       {{ if viewOrEdit == 'EDIT': }}
-                         <td style="text-align: left;">
+                         <td style="text-align: left;"
+                             onmousedown="return false;"
+                             data-bind="click: toggleMappingForOTU">
                              <input type="checkbox" class="map-toggle"
                                     data-bind="checked: $data['selectedForAction'],
                                                click: toggleMappingForOTU,
                                                css: viewModel.ticklers.OTU_MAPPING_HINTS" />
                          </td>
                       {{ pass }}
-                        <td data-bind="text: otu['^ot:originalLabel']">&nbsp;</td>
+                        <td onmousedown="return false;"
+                            data-bind="text: otu['^ot:originalLabel'],
+                                       click: toggleMappingForOTU">&nbsp;</td>
                         <td>
                             <button class="btn btn-mini row-controls-ghosted" title="Show this OTU in all trees"
                                      data-bind="click: showOTUInContext, css: viewModel.ticklers.OTU_MAPPING_HINTS">


### PR DESCRIPTION
This fixes issue #737, following the simple interaction model used in Gmail (see [comments in that issue](https://github.com/OpenTreeOfLife/opentree/issues/737#issuecomment-173621771) for details). I've also added more visible highlighting of the selected OTUs, as shown here:

<img width="794" alt="screen shot 2016-01-21 at 6 26 06 pm" src="https://cloud.githubusercontent.com/assets/446375/12497935/0b727782-c06d-11e5-92ea-4f8e50671f1b.png">

(The slightly darker row *Capparis leprieurii* is the one under the mouse, which would be pale gray if not selected for mapping.)

This is working now on **devtree**. Comments welcome!