### PR TITLE
Indicate empty description for tree in collection.

### DIFF
--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -801,7 +801,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                             <!-- /ko -->
                             <!-- ko if: !userIsEditingCollection($parent) -->
                               <a data-bind="html: name,
-                                            attr: { href: getTreeViewURL($data), title: comments }"
+                                            attr: { href: getTreeViewURL($data), title: comments || '(no description provided)' }"
                                  href="#" target="_blank"><!--NAME--></a>
                             <!-- /ko -->
                           </td>


### PR DESCRIPTION
I believe this fixes #851, but comments welcome. Available for review on **devtree**.