### PR TITLE
Taxo browser links

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -458,7 +458,6 @@ function getTaxobrowserLink(displayName, ottID) {
                    title="OTT Taxonomy" \
                    target="taxobrowser">{DISPLAY_NAME}</a>';
     return link.replace('{TAXO_BROWSER_URL}', getTaxobrowserURL(ottID))
-        .replace('{OTT_ID}', ottID)
         .replace('{DISPLAY_NAME}', displayName);
 }
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -7,7 +7,7 @@ function fullToCompactReference( fullReference ) {
     if ($.trim(fullReference) !== "") {
         // capture the first valid year in the reference
         var yearMatches = fullReference.match(/(\d{4})/);
-        var compactYear = yearMatches ? yearMatches[0] : "[no year]";  
+        var compactYear = yearMatches ? yearMatches[0] : "[no year]";
         // split on the year to get authors (before), and capture the first surname
         var compactPrimaryAuthor = fullReference.split(compactYear)[0].split(',')[0];
         var compactReference = compactPrimaryAuthor +", "+ compactYear;    // eg, "Smith, 1999";
@@ -30,7 +30,7 @@ function showSuccessMessage(msg) {
 var footerMessageCloseID = null;
 function showFooterMessage(msg, msgType) {
     var $flashArea = $('.flash');  // should be just one
-    
+
     // hide any previous message and clear its timeout
     $flashArea.hide();
     clearTimeout(footerMessageCloseID);
@@ -49,18 +49,18 @@ function showFooterMessage(msg, msgType) {
             $flashArea.removeClass( className );
         }
     });
-    
+
     // add and enable the close widget
     $flashArea.append('<button type="button" id="closeflash" class="close" data-dismiss="alert">&times;</button>');
     $flashArea.find('#closeflash')
         .unbind('click')
         .click( hideFooterMessage );
-        
+
     // some message types should close automatically
     switch( msgType ) {
         case 'info':
         case 'success':
-            footerMessageCloseID = setTimeout( hideFooterMessage, 5000 ); 
+            footerMessageCloseID = setTimeout( hideFooterMessage, 5000 );
             break;
         case 'error':
             // these should stay until user dismisses
@@ -129,7 +129,7 @@ function makeArray( val ) {
 }
 
 function updateClearSearchWidget( searchFieldSelector, observable ) {
-    // Add/remove clear widget based on field's contents (or its 
+    // Add/remove clear widget based on field's contents (or its
     // underlying observable, if provided).
     var $search = $(searchFieldSelector);
     if ($search.length === 0) {
@@ -155,7 +155,7 @@ function updateClearSearchWidget( searchFieldSelector, observable ) {
             $clear = $search.next('.clear-search');
         }
         $clear.unbind('click').click(function() {
-           $(this).prev().val('').trigger('change'); 
+           $(this).prev().val('').trigger('change');
            return false;
         });
     }
@@ -174,8 +174,8 @@ function getPageNumbers( pagedArray ) {
 
 function isVisiblePage( pageNum, pagedArray ) {
     var howManyPages = Math.ceil(pagedArray().length / pagedArray.pageSize);
-    if (howManyPages <= 12) { 
-        return true; 
+    if (howManyPages <= 12) {
+        return true;
     }
     // show first, last, and nearby pages
     if (pageNum < 3) {
@@ -186,7 +186,7 @@ function isVisiblePage( pageNum, pagedArray ) {
     }
     var currentPage = pagedArray.current();
     if (Math.abs(currentPage - pageNum) < 3) {
-        return true; 
+        return true;
     }
     return false;
 }
@@ -216,7 +216,7 @@ function loadMissingFocalCladeNames() {
                         var matchingOttID = data['name'] || '???';
                         console.log( matchingOttID );
                     }
-                    
+
                     // replace another missing name (if any)...
                     loadMissingFocalCladeNames();
                 );
@@ -230,11 +230,11 @@ function loadMissingFocalCladeNames() {
  * Cross-browser (as of 2013) support for a "safety net" when trying to leave a
  * page with unsaved changes. This should also protect against the Back button,
  * swipe gestures in Chrome, etc.
- *  
+ *
  * Call pushPageExitWarning(), popPageExitWarning() to add/remove this
  * protection as needed.
  *
- * Adapted from  
+ * Adapted from
  * http://stackoverflow.com/questions/1119289/how-to-show-the-are-you-sure-you-want-to-navigate-away-from-this-page-when-ch/1119324#1119324
  *
  * UPDATE (August 2015): Now we have use cases with unsaved changes in both
@@ -251,7 +251,7 @@ var expectedPageExitWarningIDs = [
     'UNSAVED_COLLECTION_CHANGES'
 ];
 
-var confirmOnPageExit = function (e) 
+var confirmOnPageExit = function (e)
 {
     // If we haven't been passed the event get the window.event
     e = e || window.event;
@@ -261,7 +261,7 @@ var confirmOnPageExit = function (e)
     var message = messageInfo.text;
 
     // For IE6-8 and Firefox prior to version 4
-    if (e) 
+    if (e)
     {
         e.returnValue = message;
     }
@@ -277,7 +277,7 @@ function pushPageExitWarning( warningID, warningText ) {
         return;
     }
     var matchingWarnings = $.grep(pageExitWarnings, function(msgInfo) {
-        return (msgInfo.id === warningID); 
+        return (msgInfo.id === warningID);
     })
     var alreadyFound = matchingWarnings.length > 0;
     if (!alreadyFound) {
@@ -296,7 +296,7 @@ function popPageExitWarning( warningID ) {
         return;
     }
     pageExitWarnings = $.grep(pageExitWarnings, function(msgInfo) {
-        return (msgInfo.id !== warningID); 
+        return (msgInfo.id !== warningID);
     })
     if (pageExitWarnings.length === 0) {
         // turn it off - remove the function entirely
@@ -310,7 +310,7 @@ function popPageExitWarning( warningID ) {
 function bindHelpPanels() {
     // Enable toggling of help panels anywhere in the page.
     var $helpToggles = $('.help-toggle');
-    
+
     $.each($helpToggles, function(index, toggle) {
         var $toggle = $(toggle);
         var toggleType = $toggle.parent().is('.help-box') ? 'HIDE' : 'SHOW';
@@ -360,7 +360,7 @@ function hideModalScreen() {
  * modals. Since our event-blocking screen sometimes overlaps with other
  * modals, we should suspend some behavior to avoid runaway JS as they fight
  * for input focus. See discussion at:
- *   https://github.com/twbs/bootstrap/issues/4781 
+ *   https://github.com/twbs/bootstrap/issues/4781
  *   http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error
  */
 var activeEnforceFocus = $.fn.modal.Constructor.prototype.enforceFocus;
@@ -422,7 +422,7 @@ function checkForDuplicateStudies( idType, testIdentifier, successCallback ) {
                     matchingStudyIDs.push( obj['ot:studyId'] );
                 });
             } else {
-                var errMsg = 'Sorry, there was an error checking for duplicate studies. <a href="#" onclick="toggleFlashErrorDetails(this); return false;">Show details</a><pre class="error-details" style="display: none;">Missing or malformed "matching_studies" in JSON response:\n\n'+ 
+                var errMsg = 'Sorry, there was an error checking for duplicate studies. <a href="#" onclick="toggleFlashErrorDetails(this); return false;">Show details</a><pre class="error-details" style="display: none;">Missing or malformed "matching_studies" in JSON response:\n\n'+
                     jqXHR.responseText+'</pre>';
                 hideModalScreen();
                 showErrorMessage(errMsg);
@@ -439,6 +439,20 @@ function getViewURLFromStudyID( studyID ) {
         .replace('{STUDY_ID}', studyID);
 }
 
+/*
+Returns a hyperlink to the taxonomy browser for a given OTT taxon
+Note that this function replicated in the webapp, so changes made here
+should also be made in other copy
+*/
+function getTaxobrowserLink(displayName, ottID) {
+    // ASSUMES we will always have the ottid, else check for unique name
+    var url = '<a href="/taxonomy/browse?id={OTT_ID}" \
+                  title="OTT Taxonomy" \
+                  target="taxobrowser">{DISPLAY_NAME}</a>';
+    return  url.replace('{OTT_ID}', ottID)
+        .replace('{DISPLAY_NAME}', displayName);
+}
+
 function slugify(str) {
     // Convert any string into a simplified "slug" suitable for use in URL or query-string
     return str.toLowerCase()
@@ -447,7 +461,7 @@ function slugify(str) {
               .replace(/-+/g, '-');         // collapse dashes
 }
 
-/* 
+/*
  *
  */
 
@@ -458,7 +472,7 @@ var singlePropertySearchForTrees_url;
 
 function fetchAndShowCollection( collectionID, specialHandling ) {
     /* Fetch a known-good collection from the tree-collections API, and open it
-     * in a popup.  This should always get the lastest version from the docstore, 
+     * in a popup.  This should always get the lastest version from the docstore,
      * complete with its commit history and merged edits from other users.
      */
     showModalScreen( "Loading tree collection...", {SHOW_BUSY_BAR:true});
@@ -534,7 +548,7 @@ function showCollectionViewer( collection, options ) {
     // add any missing 'rank' properties
     ensureTreeCollectionRanking( collection );
 
-    // bind just the selected collection to the modal HTML 
+    // bind just the selected collection to the modal HTML
     // NOTE that we must call cleanNode first, to allow "re-binding" with KO.
     var $boundElements = $('#tree-collection-viewer').find('.modal-body, .modal-header');
     // Step carefully to avoid un-binding important modal behavior (close widgets, etc)!
@@ -767,14 +781,14 @@ function addTreeToCollection( collection, inputType ) {
               + 'http://devtree.opentreeoflife.org/curator/study/edit/<strong>pg_2889</strong>'
               + '/?tab=trees&tree=<strong>tree6698</strong>');
             return false;
-        } 
+        }
     }
 
     // check to see if this tree is already in the collection; if so, bail w/ a message
     var alreadyInCollection = false;
     $.each(collection.data.decisions, function(i, decision) {
         if ((decision.treeID === treeID) && (decision.studyID === studyID)) {
-            showErrorMessage("This tree is already in the collection as '<strong>"+ 
+            showErrorMessage("This tree is already in the collection as '<strong>"+
                 decision.name +"</strong>'");
             // TODO: scroll the list to show this tree!? highlight it?
             alreadyInCollection = true;
@@ -793,12 +807,12 @@ function addTreeToCollection( collection, inputType ) {
         // crossdomain: true,
         contentType: "application/json; charset=utf-8",
         url: singlePropertySearchForTrees_url,
-        // data: ('{"property": "ot:studyId", "value": '+ 
+        // data: ('{"property": "ot:studyId", "value": '+
         //    JSON.stringify(studyID) +', "exact": true, "verbose": true }'),
         data: JSON.stringify({
-            property: "oti_tree_id", 
-            value: (String(studyID) +'_'+ String(treeID)), 
-            exact: true, 
+            property: "oti_tree_id",
+            value: (String(studyID) +'_'+ String(treeID)),
+            exact: true,
             verbose: true }),
         processData: false,
         complete: function( jqXHR, textStatus ) {
@@ -871,7 +885,7 @@ function addTreeToCollection( collection, inputType ) {
                         return;
                 }
             } else {
-                var errMsg = 'Sorry, there was an error checking for matching trees. <a href="#" onclick="toggleFlashErrorDetails(this); return false;">Show details</a><pre class="error-details" style="display: none;">Missing or malformed "matching_studies" in JSON response:\n\n'+ 
+                var errMsg = 'Sorry, there was an error checking for matching trees. <a href="#" onclick="toggleFlashErrorDetails(this); return false;">Show details</a><pre class="error-details" style="display: none;">Missing or malformed "matching_studies" in JSON response:\n\n'+
                     jqXHR.responseText+'</pre>';
                 hideModalScreen();
                 showErrorMessage(errMsg);
@@ -911,7 +925,7 @@ function moveInTreeCollection( tree, collection, newPosition ) {
             newPosition = Math.min(decisionList.length, oldPosition + 1);
             break;
 
-        default:  
+        default:
             // stated rank should be an integer or int-as-string
             if (isNaN(Number(tree['rank'])) || ($.trim(tree['rank']) == '')) {
                 // don't move if it's not a valid rank!
@@ -944,13 +958,13 @@ function moveInTreeCollection( tree, collection, newPosition ) {
                 newPosition = decisionList.length - 1;
             } else {
                 // displace the first matching tree
-                nextTree = sameRankOrHigher[0]; 
+                nextTree = sameRankOrHigher[0];
                 newPosition = decisionList.indexOf( nextTree );
             }
             break;
     }
 
-    // just grab the moving item and move (or append) it 
+    // just grab the moving item and move (or append) it
     var grabbedItem = decisionList.splice( oldPosition, 1 )[0];
     decisionList.splice(newPosition, 0, grabbedItem);
 
@@ -996,7 +1010,7 @@ function showCollectionMoveUI( decision, itsElement, collection ) {
                      .unbind('click').click(function() {
                         // sort all trees by rank-as-number, in ascending order
                         var decisionList = collection.data.decisions;
-                        decisionList.sort(function(a,b) { 
+                        decisionList.sort(function(a,b) {
                             // N.B. This works even if there's no such property.
                             var aStatedRank = Number(a['rank']);
                             var bStatedRank = Number(b['rank']);
@@ -1202,7 +1216,7 @@ function copyCollection( collection ) {
         // from this point, it's treated like a new collection
     } else {
         if (confirm('Copying a tree collection requires login via Github. OK to proceed?')) {
-            loginAndReturn(); 
+            loginAndReturn();
         }
     }
 }
@@ -1214,7 +1228,7 @@ function editCollection( collection, editorOptions ) {
         if ('data' in collection && 'url' in collection.data) {
             currentlyEditingCollectionID = getCollectionIDFromURL( collection.data.url );
             showCollectionViewer( collection, editorOptions );  // to refresh the UI
-            pushPageExitWarning('UNSAVED_COLLECTION_CHANGES', 
+            pushPageExitWarning('UNSAVED_COLLECTION_CHANGES',
                                 "WARNING: This page contains unsaved changes.");
             return;
         }
@@ -1222,7 +1236,7 @@ function editCollection( collection, editorOptions ) {
         console.warn(collection);
     } else {
         if (confirm('Editing a tree collection requires login via Github. OK to proceed?')) {
-            loginAndReturn(); 
+            loginAndReturn();
         }
     }
 }
@@ -1289,8 +1303,8 @@ function promptForSaveCollectionComments( collection ) {
         $('#save-collection-comments-submit')
             .unbind('click')
             .click(function() {
-                $('#save-collection-comments-popup').modal('hide'); 
-                saveTreeCollection( collection ); 
+                $('#save-collection-comments-popup').modal('hide');
+                saveTreeCollection( collection );
                 clearPendingCollectionChanges();
             });
         $('#save-collection-comments-cancel')
@@ -1319,8 +1333,8 @@ function promptForDeleteCollectionComments( collection ) {
             $('#delete-collection-comments-submit')
                 .unbind('click')
                 .click(function() {
-                    $('#delete-collection-comments-popup').modal('hide'); 
-                    deleteTreeCollection( collection ); 
+                    $('#delete-collection-comments-popup').modal('hide');
+                    deleteTreeCollection( collection );
                     clearPendingCollectionChanges();
                 });
             $('#delete-collection-comments-cancel')
@@ -1337,8 +1351,8 @@ function promptForDeleteCollectionComments( collection ) {
             $('#delete-collection-comments-submit')
                 .unbind('click')
                 .click(function() {
-                    $('#delete-collection-comments-popup').modal('hide'); 
-                    deleteTreeCollection( collection ); 
+                    $('#delete-collection-comments-popup').modal('hide');
+                    deleteTreeCollection( collection );
                     clearPendingCollectionChanges();
                 });
         }
@@ -1361,8 +1375,8 @@ function saveTreeCollection( collection ) {
         createOrUpdate = 'CREATE';
     }
 
-    showModalScreen( 
-        (createOrUpdate === 'UPDATE') ? "Saving tree collection..." : "Adding tree collection...", 
+    showModalScreen(
+        (createOrUpdate === 'UPDATE') ? "Saving tree collection..." : "Adding tree collection...",
         {SHOW_BUSY_BAR:true}
     );
 
@@ -1423,7 +1437,7 @@ function saveTreeCollection( collection ) {
     } else {
         commitMessage = $.trim(firstLine) +"\n\n"+ $.trim(moreLines);
     }
-    
+
     // add non-JSON values to the query string
     var qsVars = $.param({
         author_name: userDisplayName,
@@ -1537,7 +1551,7 @@ function deleteTreeCollection( collection ) {
         // crossdomain: true,
         contentType: "application/json; charset=utf-8",
         url: removeURL, // modified API call, see above
-        data: {},   // sadly not recognized for DELETE, using query-string instead 
+        data: {},   // sadly not recognized for DELETE, using query-string instead
         complete: function( jqXHR, textStatus ) {
             // report errors or malformed data, if any
             if (textStatus !== 'success') {
@@ -1602,20 +1616,20 @@ function getCollectionTreeCount(collection) {
 function getCollectionCreatorLink(collection) {
     //return '<a href="#" onclick="filterCollectionsByCurator(\''+ collection.creator.name +'\'); return false;"'+'>'+ collection.creator.name +'</a'+'>';
     // link to the creator's profile page
-    return '<a href="/curator/profile/'+ collection.creator.login +'" target="_blank">'+ 
+    return '<a href="/curator/profile/'+ collection.creator.login +'" target="_blank">'+
                 collection.creator.name +'</a'+'>';
 }
 function getCollectionCuratorRole(collection) {
     // return 'Owner' | 'Collaborator' | 'None'
     var userIsTheCreator = false;
     var userIsAContributor = false;
-    if (('creator' in collection) && ('login' in collection.creator)) { 
+    if (('creator' in collection) && ('login' in collection.creator)) {
         // compare to logged-in userid provide in the main page
         if (collection.creator.login === curatorLogin) {
             return 'Owner';
         }
     }
-    if (('contributors' in collection) && $.isArray(collection.contributors)) { 
+    if (('contributors' in collection) && $.isArray(collection.contributors)) {
         // compare to logged-in userid provide in the main page
         $.each(collection.contributors, function(i, c) {
             if (c.login === curatorLogin) {
@@ -1623,10 +1637,10 @@ function getCollectionCuratorRole(collection) {
             }
         });
     }
-    return 'None'; 
+    return 'None';
 }
 function getCollectionLastModification(collection) {
-    // nicely formatted for display, with details on mouseover 
+    // nicely formatted for display, with details on mouseover
     return '<span title="'+ collection.lastModified.display_date +'">'+ collection.lastModified.relative_date +'</a'+'>';
 }
 
@@ -1654,4 +1668,3 @@ function removeFromArray( doomedValue, theArray ) {
         theArray.splice( index, 1 );
     }
 }
-

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -446,6 +446,14 @@ should also be made in other copy
 */
 function getTaxobrowserLink(displayName, ottID) {
     // ASSUMES we will always have the ottid, else check for unique name
+    if (!ottID) {
+        // show just the name (static text, possibly an empty string)
+        return displayName;
+    }
+    if (!displayName) {
+        // empty or missing name? show the raw ID
+        displayName = 'OTT: {OTT_ID}'.replace('OTT_ID',ottID)
+    }
     var url = '<a href="/taxonomy/browse?id={OTT_ID}" \
                   title="OTT Taxonomy" \
                   target="taxobrowser">{DISPLAY_NAME}</a>';

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -454,11 +454,20 @@ function getTaxobrowserLink(displayName, ottID) {
         // empty or missing name? show the raw ID
         displayName = 'OTT: {OTT_ID}'.replace('OTT_ID',ottID)
     }
-    var url = '<a href="/taxonomy/browse?id={OTT_ID}" \
-                  title="OTT Taxonomy" \
-                  target="taxobrowser">{DISPLAY_NAME}</a>';
-    return  url.replace('{OTT_ID}', ottID)
+    var link = '<a href="{TAXO_BROWSER_URL}" \
+                   title="OTT Taxonomy" \
+                   target="taxobrowser">{DISPLAY_NAME}</a>';
+    return link.replace('{TAXO_BROWSER_URL}', getTaxobrowserURL(ottID))
+        .replace('{OTT_ID}', ottID)
         .replace('{DISPLAY_NAME}', displayName);
+}
+
+function getTaxobrowserURL(ottID) {
+    if (!ottID) {
+        return null;
+    }
+    var url = '/taxonomy/browse?id={OTT_ID}';
+    return url.replace('{OTT_ID}', ottID);
 }
 
 function slugify(str) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2421,7 +2421,7 @@ function getInGroupCladeDescriptionForTree( tree ) {
             nodeName = $.trim(otu['^ot:ottTaxonName']) || 'Unlabeled OTU';
         }
     }
-
+    // TODO: return link to taxo-browser?
     return nodeName;
 }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1371,7 +1371,7 @@ function loadSelectedStudy() {
             viewModel.ticklers.STUDY_HAS_CHANGED.subscribe( function() {
                 if (viewOrEdit == 'EDIT') {
                     enableSaveButton();
-                    pushPageExitWarning('UNSAVED_STUDY_CHANGES',  
+                    pushPageExitWarning('UNSAVED_STUDY_CHANGES',
                                         "WARNING: This study has unsaved changes! To preserve your work, you should save this study before leaving or reloading the page.");
                 }
                 updateQualityDisplay();
@@ -3270,7 +3270,7 @@ function showTreeViewer( tree, options ) {
             setTimeout(function() {
                 if (viewModel.allCollections && viewModel.allCollections.length) {
                     nudgeTickler('COLLECTIONS_LIST');
-                } else { 
+                } else {
                     loadCollectionList('INIT');
                 }
             }, 10);
@@ -3299,12 +3299,12 @@ function showTreeViewer( tree, options ) {
                     break;
                 case 'tree-collections':
                     $('#tree-phylogram-options').hide();
-                    /* alternate loading of collections list when 
+                    /* alternate loading of collections list when
                      * Tree > Collections subtab is chosen.
                      *
                     if (viewModel.allCollections && viewModel.allCollections.length) {
                         loadCollectionList('REFRESH');
-                    } else { 
+                    } else {
                         loadCollectionList('INIT');
                     }
                      */
@@ -4900,6 +4900,10 @@ function getAttrsForMappingOption( optionData ) {
         // keep default label with matching score
         attrs.class += ' badge-success';
     }
+    // each should also link to the taxonomy browser
+    attrs.href = getTaxobrowserURL(optionData['ottId']);
+    attrs.target = '_blank';
+    attrs.title += ' (click for more information)'
     return attrs;
 }
 function matchScoreToOpacity(score) {
@@ -6101,7 +6105,7 @@ function moveOrMergeLocalMessage(msg, parentElement, nexml) {
                 throw "expected (old) '@sourceForTree' not found!";
             }
 
-            // look for matching file information in the main nexml 
+            // look for matching file information in the main nexml
             var nexmlFilesMessage = getSupportingFiles(nexml);
             if (!nexmlFilesMessage) {
                 throw 'nexml supporting-files info not found!';
@@ -7559,7 +7563,7 @@ function loadCollectionList(option) {
                 showErrorMessage('Sorry, there is a problem with the tree-collection data.');
                 return;
             }
-            
+
             viewModel.allCollections = data;
 
             // enable sorting and filtering for lists in the editor
@@ -7609,8 +7613,8 @@ function loadCollectionList(option) {
                 // map old array to new and return it
                 var currentStudyID = $('#current-study-id').val();
                 var currentTreeID = $('#current-tree-id').val();
-                var filteredList = ko.utils.arrayFilter( 
-                    viewModel.allCollections, 
+                var filteredList = ko.utils.arrayFilter(
+                    viewModel.allCollections,
                     function(collection) {
                         // this basic filter just checks for matching tree+study ids
                         var foundCurrentTree = false;
@@ -7654,7 +7658,7 @@ function loadCollectionList(option) {
                         if (!wholeSlugMatchPattern.test(id) && !wholeSlugMatchPattern.test(ownerSlug) && !wholeSlugMatchPattern.test(titleSlug) && !matchPattern.test(name) && !matchPattern.test(description) && !matchPattern.test(creator) && !matchPattern.test(contributors)) {
                             return false;
                         }
-                        
+
                         // check for preset filters
                         switch (filter) {
                             case 'All tree collections':
@@ -7664,7 +7668,7 @@ function loadCollectionList(option) {
                             case 'Collections I own':
                                 // show only matching collections
                                 var userIsTheCreator = false;
-                                if (('creator' in collection) && ('login' in collection.creator)) { 
+                                if (('creator' in collection) && ('login' in collection.creator)) {
                                     // compare to logged-in userid provide in the main page
                                     if (collection.creator.login === userLogin) {
                                         userIsTheCreator = true;
@@ -7675,13 +7679,13 @@ function loadCollectionList(option) {
                             case 'Collections I participate in':
                                 var userIsTheCreator = false;
                                 var userIsAContributor = false;
-                                if (('creator' in collection) && ('login' in collection.creator)) { 
+                                if (('creator' in collection) && ('login' in collection.creator)) {
                                     // compare to logged-in userid provide in the main page
                                     if (collection.creator.login === userLogin) {
                                         userIsTheCreator = true;
                                     }
                                 }
-                                if (('contributors' in collection) && $.isArray(collection.contributors)) { 
+                                if (('contributors' in collection) && $.isArray(collection.contributors)) {
                                     // compare to logged-in userid provide in the main page
                                     $.each(collection.contributors, function(i, c) {
                                         if (c.login === userLogin) {
@@ -7704,7 +7708,7 @@ function loadCollectionList(option) {
                     }
 */
                 );  // END of list filtering
-                        
+
                 // apply selected sort order
                 switch(order) {
                     /* REMINDER: in sort functions, results are as follows:
@@ -7713,7 +7717,7 @@ function loadCollectionList(option) {
                      *   1 = b comes before a
                      */
                     case 'Most recently modified':
-                        filteredList.sort(function(a,b) { 
+                        filteredList.sort(function(a,b) {
                             var aMod = a.lastModified.ISO_date;
                             var bMod = b.lastModified.ISO_date;
                             if (aMod === bMod) return 0;
@@ -7722,7 +7726,7 @@ function loadCollectionList(option) {
                         break;
 
                     case 'Most recently modified (reversed)':
-                        filteredList.sort(function(a,b) { 
+                        filteredList.sort(function(a,b) {
                             var aMod = a.lastModified.ISO_date;
                             var bMod = b.lastModified.ISO_date;
                             if (aMod === bMod) return 0;
@@ -7731,7 +7735,7 @@ function loadCollectionList(option) {
                         break;
 
                     case 'By owner/name':
-                        filteredList.sort(function(a,b) { 
+                        filteredList.sort(function(a,b) {
                             // first element is the ID with user-name/collection-name
                             if (a.id === b.id) return 0;
                             return (a.id < b.id) ? -1 : 1;
@@ -7739,7 +7743,7 @@ function loadCollectionList(option) {
                         break;
 
                     case 'By owner/name (reversed)':
-                        filteredList.sort(function(a,b) { 
+                        filteredList.sort(function(a,b) {
                             // first element is the ID with user-name/collection-name
                             if (a.id === b.id) return 0;
                             return (a.id > b.id) ? -1 : 1;
@@ -7747,7 +7751,7 @@ function loadCollectionList(option) {
                         break;
 
                     // TODO: add a filter for 'Has un-merged changes'?
-                    
+
                     default:
                         console.warn("Unexpected order for collection list: ["+ order +"]");
                         return null;
@@ -7764,7 +7768,7 @@ function loadCollectionList(option) {
 
 function getAssociatedCollectionsCount() {
     // used mainly to supply a display string in the Tree > Collections indicator
-    if (viewModel.filteredCollections) { 
+    if (viewModel.filteredCollections) {
         return ( viewModel.filteredCollections()().length ).toString();
     }
     // an empty space will collapse (hide) the indicator if we're not ready
@@ -7781,7 +7785,7 @@ function addTreeToExistingCollection(clicked) {
         $collectionPrompt.find('input').eq(0).focus();
     } else {
         if (confirm('This requires login via Github. OK to proceed?')) {
-            loginAndReturn(); 
+            loginAndReturn();
         }
     }
 }
@@ -7995,7 +7999,7 @@ function addCurrentTreeToCollection( collection ) {
         collection.decisions.push(treeEntry);
     }
     addPendingCollectionChange( 'ADD', currentStudyID, currentTreeID );
-    
+
     // to refresh the list
     //showCollectionViewer( collection, {SCROLL_TO_BOTTOM: true} );
     editCollection( collection, {SCROLL_TO_BOTTOM: true} );
@@ -8003,12 +8007,12 @@ function addCurrentTreeToCollection( collection ) {
 
 function addTreeToNewCollection() {
     if (userIsLoggedIn()) {
-        var c = createNewTreeCollection(); 
+        var c = createNewTreeCollection();
         addCurrentTreeToCollection(c);
         showCollectionViewer( c, {SCROLL_TO_BOTTOM: true} );
     } else {
         if (confirm('This requires login via Github. OK to proceed?')) {
-            loginAndReturn(); 
+            loginAndReturn();
         }
     }
 }

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1249,7 +1249,7 @@ body {
                             </div>
                             <a class="btn btn-mini"
                                                   style="padding: 0px 4px;"
-                                                  data-bind="click: approveProposedOTUMappingOption">
+                                                  data-bind="click: approveProposedOTULabel">
                                 <i class="icon-ok"></i></a>&nbsp;<a data-bind="text: proposedMapping(otu)[0].name,
                                                css: viewModel.ticklers.OTU_MAPPING_HINTS,
                                                attr: getAttrsForMappingOption(proposedMapping(otu)[0])"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1243,18 +1243,17 @@ body {
                           <!-- ko if: proposedMapping(otu) && (proposedMapping(otu).length === 1) -->
                            {{ # show mapped label }}
                             <div class="btn-group pull-right">
-                                <button class="btn btn-mini" data-bind="click: approveProposedOTULabel, css: viewModel.ticklers.OTU_MAPPING_HINTS">
-                                    <i class="icon-ok"></i>
-                                </button>
                                 <button class="btn btn-mini" data-bind="click: rejectProposedOTULabel, css: viewModel.ticklers.OTU_MAPPING_HINTS">
                                     <i class="icon-remove"></i>
                                 </button>
                             </div>
-                            <a data-bind="text: proposedMapping(otu)[0].name,
+                            <a class="btn btn-mini"
+                                                  style="padding: 0px 4px;"
+                                                  data-bind="click: approveProposedOTUMappingOption">
+                                <i class="icon-ok"></i></a>&nbsp;<a data-bind="text: proposedMapping(otu)[0].name,
                                                css: viewModel.ticklers.OTU_MAPPING_HINTS,
                                                attr: getAttrsForMappingOption(proposedMapping(otu)[0])"
                                     href="#"
-                                    onclick="return false;"
                                 >PROPOSED LABEL</a>
                           <!-- /ko -->
                           <!-- ko if: proposedMapping(otu) && (proposedMapping(otu).length > 1) -->
@@ -1268,10 +1267,13 @@ body {
                             <ul class="mapping-options"
                                 data-bind="foreach: makeArray(proposedMapping(otu)),
                                            css: viewModel.ticklers.OTU_MAPPING_HINTS">
-                                <li><a data-bind="text: $data.originalMatch.unique_name,
-                                                  click: approveProposedOTUMappingOption,
+                                <li><a class="btn btn-mini"
+                                                      style="padding: 0px 4px;"
+                                                      data-bind="click: approveProposedOTUMappingOption">
+                                <i class="icon-ok"></i></a>&nbsp;<a data-bind="text: $data.originalMatch.unique_name,
                                                   attr: getAttrsForMappingOption($data)"
-                                       href="#"></a></li>
+                                       href="#"></a>
+                                </li>
                             </ul>
                           <!-- /ko -->
                           <!-- ko if: viewModel.ticklers.OTU_MAPPING_HINTS() && $.trim(otu['^ot:ottTaxonName']) -->
@@ -1280,12 +1282,12 @@ body {
                                     <i class="icon-remove"></i>
                                 </button>
                             </div>
-                            <strong data-bind="text: $.trim(otu['^ot:ottTaxonName']),
+                            <strong data-bind="html: getTaxobrowserLink(otu['^ot:ottTaxonName'], otu['^ot:ottId']),
                                                css: viewModel.ticklers.OTU_MAPPING_HINTS",
                                 >MAPPED LABEL</strong>
                           <!-- /ko -->
                       {{ else: }}
-                            <strong data-bind="text: $.trim(otu['^ot:ottTaxonName'])">MAPPED LABEL</strong>
+                            <strong data-bind="html: getTaxobrowserLink(otu['^ot:ottTaxonName'], otu['^ot:ottId'])">MAPPED LABEL</strong>
                       {{ pass }}
                          <!-- /ko -->
                         </td>
@@ -1994,7 +1996,7 @@ body {
         </p>
         <ul class="mapping-options" style="padding-left: 20px;">
             <li>
-                <div class="key-note">most possible matches are green</div>
+                <div class="key-note">possible matches are green</div>
                 <a class="badge badge-success"
                    style="opacity: 1.0;"
                    title="100% match of original label"
@@ -2025,7 +2027,7 @@ body {
                 >Psathyrella</a>
             </li>
             <li>
-                <div class="key-note">taxon-name homonyms are amber</div>
+                <div class="key-note">homonyms are amber</div>
                 <a class="badge badge-warning"
                    style="opacity: 1;"
                    title="Taxon-name homonym"
@@ -2034,13 +2036,19 @@ body {
             </li>
         </ul>
         <p>
-            Roll over each match to learn more about it. Click a match to
-            map this OTU to this taxon. If none of these options is a good
-            match, click
+            Click <button
+            class="btn btn-mini row-controls-ghosted"
+            type="button" onclick="return true;"><i class="icon-ok"></i>
+            </button> to
+            map the OTU to this taxon. Click
             <button class="btn btn-mini row-controls-ghosted"
                     type="button" onclick="return false;"><i class="icon-remove"></i>
             </button>
-            to clear the list and modify the original label used for mapping.
+            to reject all mappings; then try modifying the original label and re-mapping.
+        </p>
+        <p>
+          Roll over each match to learn more about it. Click a name to
+          open the taxonomy browser for that taxon.
         </p>
     </div>
     <div class="modal-footer">
@@ -2658,4 +2666,7 @@ body {
       </div>
       <a class="btn" style="margin-left: 25px;" onclick="$('#tree-viewer').modal('hide'); return false;">Close</a>
     </div>
-</div>
+</div
+ml
+
+>

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -953,7 +953,9 @@ function showObjectProperties( objInfo, options ) {
                                 break;
 
                             case 'OTT':
-                                displayVal = '<a href="/taxonomy/browse?id=' + sourceInfo.taxSourceId + '" ' + 'title="OTT Taxonomy" target="_blank">OTT: ' + sourceInfo.taxSourceId + '</a>';
+                                //displayVal = '<a href="/taxonomy/browse?id=' + sourceInfo.taxSourceId + '" ' + 'title="OTT Taxonomy" target="_blank">OTT: ' + sourceInfo.taxSourceId + '</a>';
+                                displayName = 'OTT: ' + sourceInfo.taxSourceId
+                                displayVal = getTaxobrowserLink(displayName, sourceInfo.taxSourceId)
                                 break;
 
                             default:

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -94,9 +94,13 @@ function updateTreeView( State ) {
                     var errMsg;
                     if (jqXHR.responseText.indexOf('TaxonNotFoundException') !== -1) {
                         // the requested OTT taxon is not found in the target tree
-                        errMsg = '<span style="font-weight: bold; color: #777;">This taxon is in our taxonomy but not in our tree'
-                                +' synthesis database. This can happen for a variety of reasons, but the most probable is that it'
-                                +' is flagged as <em>incertae sedis</em>.'
+                        var taxobrowserlink = getTaxobrowserLink('taxonomy browser',ottolID)
+                        errMsg = '<span style="font-weight: bold; color: #777;">This taxon is in our taxonomy'
+                                +' but not in our tree synthesis database. This can happen for a variety of reasons,'
+                                +' but the most probable is that is has a taxon flag (e.g. <em>incertae sedis</em>) that'
+                                +' causes it to be pruned from the synthetic tree. See the '
+                                +taxobrowserlink
+                                +' for more information about this taxon.'
                                 +'<br/><br/>If you think this is an error, please'
                                 +' <a href="https://github.com/OpenTreeOfLife/feedback/issues" target="_blank">create an issue in our bug tracker</a>.';
                         // TODO: Explain in more detail: Why wasn't this used?

--- a/webapp/static/js/webapp-helpers.js
+++ b/webapp/static/js/webapp-helpers.js
@@ -1,0 +1,40 @@
+/*
+ * Utilities common to multiple pages in the OpenTree webapp.
+ * There are also helper functions in webapp/views/layout.html, which
+ * should eventually be moved over here.
+ */
+
+ /*
+ * Returns a hyperlink to the taxonomy browser for a given OTT taxon
+ * Note that this function replicated curator/static/js/curation-helpers.js,
+ * so changes made here should also be made in other copy
+ */
+ function getTaxobrowserLink(displayName, ottID) {
+     // ASSUMES we will always have the ottid, else check for unique name
+     if (!ottID) {
+         // show just the name (static text, possibly an empty string)
+         return displayName;
+     }
+     if (!displayName) {
+         // empty or missing name? show the raw ID
+         displayName = 'OTT: {OTT_ID}'.replace('OTT_ID',ottID)
+     }
+     var link = '<a href="{TAXO_BROWSER_URL}" \
+                    title="OTT Taxonomy" \
+                    target="taxobrowser">{DISPLAY_NAME}</a>';
+     return link.replace('{TAXO_BROWSER_URL}', getTaxobrowserURL(ottID))
+         .replace('{DISPLAY_NAME}', displayName);
+ }
+
+ /*
+ * Returns a bare URL to the taxonomy browser for a given OTT taxon
+ * Note that this function replicated curator/static/js/curation-helpers.js,
+ * so changes made here should also be made in other copy
+ */
+ function getTaxobrowserURL(ottID) {
+     if (!ottID) {
+         return null;
+     }
+     var url = '/taxonomy/browse?id={OTT_ID}';
+     return url.replace('{OTT_ID}', ottID);
+ }

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
-{{ 
+{{
 from applications.opentree.modules.opentreewebapputil import get_user_display_name, get_conf, get_domain_banner_text, get_domain_banner_hovertext, get_currently_deployed_opentree_branch
 }}
+
+<script src="{{=URL('static','js/webapp-helpers.js')}}"></script>
+
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -17,8 +20,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     </style>
 
     <script type="text/javascript">
-        /*    
-        @licstart  The following is the entire license notice for the JavaScript code in this page. 
+        /*
+        @licstart  The following is the entire license notice for the JavaScript code in this page.
 
         Copyright (c) 2013, Jonathan Rees
         Copyright (c) 2013, Mark Holder
@@ -64,7 +67,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     {{response.files.append(URL('static','plugin_layouts/superfish.js'))}}
     <!-- css for comments -->
     {{response.files.append(URL('static','plugin_localcomments/css/localcomments.css'))}}
-    
+
     <!-- js dependencies for argus -->
     {{if globals().get('treemachine_domain',False):}}  <!-- TODO: add a proper test here, to omit while in /opentree/appadmin -->
     <script type="text/javascript">
@@ -109,7 +112,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
 
     <!-- js improved date parsing & formatting -->
     {{response.files.append(URL('static','js/moment.min.js'))}}
-    
+
     <!-- support for web2py AJAX (incl. link to static/js/jquery.js) -->
     {{include 'web2py_ajax.html'}}
 
@@ -206,7 +209,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
             // is this unchanged from last time? no need to search again..
             if ((searchText == showingResultsForSearchText) && (searchContextName == showingResultsForSearchContextName)) {
                 ///console.log("Search text and context UNCHANGED!");
-                return false; 
+                return false;
             }
 
             // stash these to use for later comparison (to avoid redundant searches)
@@ -218,12 +221,12 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
             $('#search-results').html('<li class="disabled"><a><span class="text-warning">Search in progress...</span></a></li>');
             $('#search-results').dropdown('toggle');
             if (typeof snapViewerFrameToMainTitle === 'function') snapViewerFrameToMainTitle();
-            
+
             $.ajax({
                 url: doTNRSForAutocomplete_url,  // NOTE that actual server-side method name might be quite different!
                 type: 'POST',
                 dataType: 'json',
-                data: JSON.stringify({ 
+                data: JSON.stringify({
                     "queryString": searchText,
                     "contextName": searchContextName
                 }),  // data (asterisk required for completion suggestions)
@@ -279,7 +282,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                                 visibleResults++;
                             }
                         }
-                        
+
                         $('#search-results a')
                             .click(function(e) {
                                 // suppress normal dropdown logic and jump to link normally (TODO: Why is this needed?)
@@ -289,7 +292,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                                 var $link = $(this);
                                 //// WAS constructed literal ('/opentree/'+ "ottol" +'@'+ itsNodeID +'/'+ itsName)
                                 var safeURL = historyStateToURL({
-                                    nodeID: $link.attr('href'), 
+                                    nodeID: $link.attr('href'),
                                     domSource: 'ottol',
                                     nodeName: makeSafeForWeb2pyURL($link.text()),
                                     viewer: 'argus'
@@ -334,7 +337,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         });
 
     </script>
-    
+
     {{
     # using sidebars need to know what sidebar you want to use
     left_sidebar_enabled = globals().get('left_sidebar_enabled',False)
@@ -351,7 +354,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     -->
                                    <link rel="shortcut icon" href="/favicon.ico">
   </head>
-  
+
 <body>
 {{ if get_domain_banner_text(request): }}
   <div class="ribbon-banner" title="{{= get_domain_banner_hovertext(request) }}">{{= get_domain_banner_text(request) }}</div>
@@ -418,8 +421,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                     {{ except: }}
                             <option selected="selected">ERROR loading context values</option>
                        {{ pass }}
-                <!-- 
-                NOTE that the displayed OPTION values (confirmed as current via AJAX) are accepted 
+                <!--
+                NOTE that the displayed OPTION values (confirmed as current via AJAX) are accepted
                 by the server, ie, there's no distinction between visible and occult values.
                 -->
                 </select>
@@ -442,9 +445,9 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         <div class="span3 left-sidebar">
             <div class="header">
               <div class="headerlogo">
-                {{=A(IMG(_src=URL('static','images/logo.png'), 
+                {{=A(IMG(_src=URL('static','images/logo.png'),
                         _alt="Open Tree of Life logo",
-                        _width="144", 
+                        _width="144",
                         _height="74",
                         _valign="middle"),
                     _href="http://opentreeoflife.org/")}}
@@ -472,7 +475,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         </div>
         {{pass}}
     </section>
-    
+
 </div><!-- /.container -->
 
 <!-- Footer ================================================== -->
@@ -492,7 +495,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
             <a href="http://www.web2py.com/" target="_blank" >web2py</a>
         </div>
         <div id="server-details" style="display: none; clear: both; margin: 4px 0; background-color: #f5f5f5; padding: 6px 8px; border-radius: 8px;">
-            Configuration for the <strong>{{= request.application }}</strong> web2py app: 
+            Configuration for the <strong>{{= request.application }}</strong> web2py app:
             <dl>
                <dt id="deployed-branch">deployed branch of opentree webapps:</dt>
                    <dd><strong style="color: #888;">{{= get_currently_deployed_opentree_branch(request) }}


### PR DESCRIPTION
Links from taxon names in the OTU mapping tab to the the OTT taxonomy browser. Includes both mapped names (when viewing / editing) and proposed names (when editing). 

Also many whitespace changes (ah, Atom...). Might want to use [no whitespace diff](https://github.com/OpenTreeOfLife/opentree/pull/861/files?w=0) to view. 