### PR TITLE
fix v2 and v3 numbers

### DIFF
--- a/webapp/static/statistics/synthesis.json
+++ b/webapp/static/statistics/synthesis.json
@@ -8,13 +8,13 @@
         "total_OTU_count": null, 
         "tip_count": null
     },
-    "2014-09-20T00Z": {
+    "2014-09-14T00Z": {
         "version": "v2",
-        "===": "Using initial stats gathered on 2015-01-16T23Z, which should be accurate here. Release date is based on .tgz file modification date.",
-        "OTT_version": "ott2.8",
-        "tree_count": 429, 
-        "total_OTU_count": 60933, 
-        "tip_count": null
+        "===": "tree_count and tip_count from graph/about service",
+        "OTT_version": "ott2.8draft5",
+        "tree_count": 484, 
+        "total_OTU_count": null, 
+        "tip_count": 2339516
     },
     "2015-05-06T00Z": {
         "version": "v3",

--- a/webapp/static/statistics/synthesis.json
+++ b/webapp/static/statistics/synthesis.json
@@ -20,7 +20,8 @@
         "version": "v3",
         "OTT_version": "ott2.8draft5",
         "tree_count": 478, 
-        "total_OTU_count": 63393, 
+        "===": "revised downward from 63393 by JAR 2016-01-29",
+        "total_OTU_count": 41580,
         "tip_count": 2339460
     },
     "2015-10-24T00Z": {


### PR DESCRIPTION
I don't know where those v2 numbers came from, but they are wrong. I have checked the DB and the values are now correct. Unfortunately, no value for `total_OTU_count` was ever computed (again, no idea where the previous value of 60933 came from).