### PR TITLE
More careful auto-approval of OTU mappings

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -5128,11 +5128,22 @@ function approveAllVisibleMappings() {
             itsMappingInfo;
         if ($.isArray(approvedMapping)) {
             if (approvedMapping.length === 1) {
-                // apply the first (only) value
+                // test the first (only) value for possible approval
+                var onlyMapping = approvedMapping[0];
+                if (onlyMapping.originalMatch.is_synonym) {
+                    return;  // synonyms require manual review
+                }
+                if (onlyMapping.originalMatch.matched_name !== onlyMapping.originalMatch.unique_name) {
+                    return;  // taxon-name homonyms require manual review
+                }
+                if (onlyMapping.originalMatch.score < 1.0) {
+                    return;  // non-exact matches require manual review
+                }
+                // still here? then this mapping looks good enough for auto-approval
                 delete proposedOTUMappings()[ OTUid ];
                 mapOTUToTaxon( OTUid, approvedMapping[0], {POSTPONE_UI_CHANGES: true} );
             } else {
-                // do nothing if there are multiple possibilities
+                return; // multiple possibilities require manual review
             }
         } else {
             // apply the inner value of an observable (accessor) function

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1615,7 +1615,7 @@ function updateMappingStatus() {
                         +' <button class="btn btn-mini disabled"><i class="icon-ok"></i></button>'
                         +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
                         +'</span>'
-                        +' buttons to accept or reject each suggested mapping, or'
+                        +' buttons to accept or reject each suggested mapping,'
                         +' or the buttons below to accept or reject the suggestions for all visible OTUs.<'+'/p>';
                 showBatchApprove = true;
                 showBatchReject = true;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1615,8 +1615,8 @@ function updateMappingStatus() {
                         +' <button class="btn btn-mini disabled"><i class="icon-ok"></i></button>'
                         +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
                         +'</span>'
-                        +' buttons to approve or reject each suggested mapping, or'
-                        +' or the buttons below to approve or reject the suggestions for all visible OTUs.<'+'/p>';
+                        +' buttons to accept or reject each suggested mapping, or'
+                        +' or the buttons below to accept or reject the suggestions for all visible OTUs.<'+'/p>';
                 showBatchApprove = true;
                 showBatchReject = true;
                 needsAttention = true;
@@ -1628,7 +1628,7 @@ function updateMappingStatus() {
                     // we can add more by including 'All trees'
                     detailsHTML = '<p'+'><strong>Congrtulations!</strong> '
                             +'Mapping is suspended because all OTUs in this '
-                            +'study\'s preferred trees have approved labels already. To continue, '
+                            +'study\'s preferred trees have accepted labels already. To continue, '
                             +'reject some mapped labels with the '
                             +'<span class="btn-group" style="margin: -2px 0;">'
                             +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
@@ -1640,7 +1640,7 @@ function updateMappingStatus() {
                 } else {
                     // we're truly done with mapping (in all trees)
                     detailsHTML = '<p'+'><strong>Congrtulations!</strong> '
-                            +'Mapping is suspended because all OTUs in this study have approved '
+                            +'Mapping is suspended because all OTUs in this study have accepted '
                             +'labels already.. To continue, use the '
                             +'<span class="btn-group" style="margin: -2px 0;">'
                             +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
@@ -1654,7 +1654,7 @@ function updateMappingStatus() {
 
                 /* TODO: replace this stuff with if/else block above
                  */
-                detailsHTML = '<p'+'>Mapping is suspended because all selected OTUs have approved '
+                detailsHTML = '<p'+'>Mapping is suspended because all selected OTUs have accepted '
                         +' labels already. To continue, select additional OTUs to map, or use the '
                         +'<span class="btn-group" style="margin: -2px 0;">'
                         +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1252,7 +1252,8 @@ body {
                                     <i class="icon-remove"></i>
                                 </button>
                             </div>
-                            <a class="btn btn-mini"
+                            <span style="white-space: nowrap;">
+                                <a class="btn btn-mini"
                                                   style="padding: 0px 4px;"
                                                   data-bind="click: approveProposedOTULabel">
                                 <i class="icon-ok"></i></a>&nbsp;<a data-bind="text: proposedMapping(otu)[0].name,
@@ -1260,6 +1261,7 @@ body {
                                                attr: getAttrsForMappingOption(proposedMapping(otu)[0])"
                                     href="#"
                                 >PROPOSED LABEL</a>
+                            </span>
                           <!-- /ko -->
                           <!-- ko if: proposedMapping(otu) && (proposedMapping(otu).length > 1) -->
                            {{ # show available choices for mapping this OTU }}
@@ -1272,7 +1274,7 @@ body {
                             <ul class="mapping-options"
                                 data-bind="foreach: makeArray(proposedMapping(otu)),
                                            css: viewModel.ticklers.OTU_MAPPING_HINTS">
-                                <li><a class="btn btn-mini"
+                                <li style="white-space: nowrap;"><a class="btn btn-mini"
                                                       style="padding: 0px 4px;"
                                                       data-bind="click: approveProposedOTUMappingOption">
                                 <i class="icon-ok"></i></a>&nbsp;<a data-bind="text: $data.originalMatch.unique_name,
@@ -1409,11 +1411,11 @@ body {
                 <div class="mapping-batch-operations" style="display: none;">
                     <button id="batch-approve" class="btn btn-small pull-left"
                             onclick="approveAllVisibleMappings(); return false;">
-                        <i class="icon-ok"></i> <strong>Approve all</strong> and continue
+                        <i class="icon-ok"></i> <strong>Auto-approve</strong> (continue)
                     </button>
                     <button id="batch-reject" class="btn btn-small pull-right"
                             onclick="rejectAllVisibleMappings(); return false;">
-                        <i class="icon-remove"></i> <strong>Reject all</strong> and pause
+                        <i class="icon-remove"></i> <strong>Reject all</strong> (pause)
                     </button>
                 </div>
             </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1411,11 +1411,11 @@ body {
                 <div class="mapping-batch-operations" style="display: none;">
                     <button id="batch-approve" class="btn btn-small pull-left"
                             onclick="approveAllVisibleMappings(); return false;">
-                        <i class="icon-ok"></i> <strong>Auto-approve</strong> (continue)
+                        <i class="icon-ok"></i> Accept exact matches
                     </button>
                     <button id="batch-reject" class="btn btn-small pull-right"
                             onclick="rejectAllVisibleMappings(); return false;">
-                        <i class="icon-remove"></i> <strong>Reject all</strong> (pause)
+                        <i class="icon-remove"></i> Reject all and pause
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
We now skip auto-approval for OTUs with one suggestion, if
  - it's a synonym
  - it's a taxon-name homonym
  - its matching score is less than perfect

I've also tweaked the auto-approval button text so it doesn't
over-promise, and added CSS to prevent line-wrapping for mapping
suggestions (so approval buttons stay alongside the suggested name).
Fixes #730. Addresses #719 and #769.