### PR TITLE
Force failed mappings below other unmapped OTUs.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1178,10 +1178,19 @@ function loadSelectedStudy() {
                             var aMapStatus = $.trim(a['^ot:ottTaxonName']) !== '';
                             var bMapStatus = $.trim(b['^ot:ottTaxonName']) !== '';
                             if (aMapStatus === bMapStatus) {
-                                if (!aMapStatus) { // not yet mapped
-                                    // Try to retain their prior precedence in
-                                    // the list (avoid items jumping around)
-                                    return (a.priorPosition < b.priorPosition) ? -1:1;
+                                if (!aMapStatus) { // both OTUs are currently un-mapped
+                                    // Force failed mappings to the bottom of the list
+                                    var aFailedMapping = (failedMappingOTUs.indexOf(a['@id']) !== -1);
+                                    var bFailedMapping = (failedMappingOTUs.indexOf(b['@id']) !== -1);
+                                    if (aFailedMapping === bFailedMapping) {
+                                        // Try to retain their prior precedence in
+                                        // the list (avoid items jumping around)
+                                        return (a.priorPosition < b.priorPosition) ? -1:1;
+                                    } 
+                                    if (aFailedMapping) {
+                                        return 1;   // force a (failed) below b
+                                    } 
+                                    return -1;   // force b (failed) below a
                                 } else {
                                     return 0;
                                 }


### PR DESCRIPTION
This should make it less frustrating for curators, as described in #809.
N.B. that this effect will not persist across sessions; clearing
(resetting) these mapping results will restore the "failed" OTUs to
their position among the other unmapped taxa.