### PR TITLE
add 'tree' prefix to id placeholder

### DIFF
--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -850,7 +850,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                 <label>and tree ID</label>
                 <input type="text" name="tree-id"
                     class="input-small" style="margin-bottom: 2px;"
-                    placeholder="456"
+                    placeholder="tree456"
                     data-bind="value: '', 
                                valueUpdate: ['afterkeydown', 'input'], 
                                event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }


### PR DESCRIPTION
Not tested yet... don't see what can go wrong, but if someone insists I'll try it out before going to production