### PR TITLE
Add supporting URL to phylo-feedback

### DIFF
--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -326,7 +326,6 @@ def index():
                     child_comments = resp.json()
                 except:
                     child_comments = resp.json
-                print("found {0} child comments".format(len(child_comments)))
             except:
                 # WE need logging in the web app!
                 try:
@@ -432,14 +431,12 @@ def index():
         # delete the specified comment or close an issue...
         try:
             if issue_or_comment == 'issue':
-                print("CLOSING ISSUE: ")
-                print(comment_id)
+                print("CLOSING ISSUE {0}".format(comment_id))
                 close_issue(comment_id)
                 clear_local_comments()
                 return 'closed'
             else:
-                print("DELETING COMMENT: ")
-                print(comment_id)
+                print("DELETING COMMENT {0}".format(comment_id))
                 delete_comment(comment_id)
                 clear_local_comments()
                 return 'deleted'
@@ -532,8 +529,6 @@ def index():
         return node(new_msg)                
 
     # retrieve related comments, based on the chosen filter
-    print("retrieving local comments using this filter:")
-    print(filter)
     if filter == 'skip_comments':
         # sometimes we just want the markup/UI (eg, an empty page that's quickly updated by JS)
         comments = [ ]
@@ -553,7 +548,7 @@ def index():
     for comment in comments:
         #thread[comment.thread_parent_id] = thread.get(comment.thread_parent_id,[])+[comment]
         threads.append(comment)
-    pprint('{0} threads loaded'.format(len(threads)))
+
     return DIV(script,
                DIV(FORM(# anonymous users should see be encouraged to login or add a name-or-email to their comments
                         '' if auth.user_id else A(T('Login'),_href=URL(r=request,c='default',f='user',args=['login']),_class='login-logout reply'),
@@ -651,8 +646,8 @@ def add_or_update_comment(msg_data, comment_id=None, parent_issue_id=None ):
     if comment_id:
         # edit an existing comment
         url = '{0}/repos/OpenTreeOfLife/feedback/issues/comments/{1}'.format(GH_BASE_URL, comment_id)
-        print('URL for editing an existing comment:')
-        print(url)
+        #print('URL for editing an existing comment:')
+        #print(url)
         resp = requests.patch( url, 
             headers=GH_POST_HEADERS,
             data=json.dumps(msg_data)
@@ -660,8 +655,8 @@ def add_or_update_comment(msg_data, comment_id=None, parent_issue_id=None ):
     else:
         # create a new comment
         url = '{0}/repos/OpenTreeOfLife/feedback/issues/{1}/comments'.format(GH_BASE_URL, parent_issue_id)
-        print('URL for adding a new comment:')
-        print(url)
+        #print('URL for adding a new comment:')
+        #print(url)
         resp = requests.post( url, 
             headers=GH_POST_HEADERS,
             data=json.dumps(msg_data)
@@ -677,8 +672,8 @@ def add_or_update_comment(msg_data, comment_id=None, parent_issue_id=None ):
 def close_issue(issue_id):
     # close a thread (issue) on GitHub
     url = '{0}/repos/OpenTreeOfLife/feedback/issues/{1}'.format(GH_BASE_URL, issue_id)
-    print('URL for closing an existing issue:')
-    print(url)
+    #print('URL for closing an existing issue:')
+    #print(url)
     resp = requests.patch( url, 
         headers=GH_POST_HEADERS,
         data=json.dumps({"state":"closed"})
@@ -694,8 +689,8 @@ def close_issue(issue_id):
 def delete_comment(comment_id):
     # delete a comment on GitHub
     url = '{0}/repos/OpenTreeOfLife/feedback/issues/comments/{1}'.format(GH_BASE_URL, comment_id)
-    print('URL for deleting an existing comment:')
-    print(url)
+    #print('URL for deleting an existing comment:')
+    #print(url)
     resp = requests.delete( url, 
         headers=GH_GET_HEADERS
     )
@@ -744,7 +739,7 @@ def get_local_comments(location={}):
         search_text = '{0}"{1} | {2} " '.format( search_text, k, v )
     search_text = urllib.quote_plus(search_text.encode('utf-8'), safe='~')
     #print search_text
-    print('>> calling GitHub API for local issues...')
+    #print('>> calling GitHub API for local issues...')
     url = '{0}/search/issues?q={1}repo:OpenTreeOfLife%2Ffeedback+state:open&sort=created&order=desc'
     ##TODO: search only within body?
     ## url = '{0}/search/issues?q={1}repo:OpenTreeOfLife%2Ffeedback+in:body+state:open&sort=created&order=asc'

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -93,17 +93,22 @@ function capture_form() {
             return false;
         }
         var $fbTypeField = $form.find('select[name="feedback_type"]'); 
+        var $fbScopeField = $form.find('select[name="intended_scope"]'); 
         if ($fbTypeField.is(':visible')) {
             if ($.trim($fbTypeField.val()) === '') {
                 alert("Please choose a feedback type for this topic.");
                 return false;
-            } else if ($.trim($fbTypeField.val()) === 'Error in phylogeny'){
+            } 
+            /* TODO: Should the supporting-reference URL be required? 
+                     Decide this based on the phylo-error "scope"? i.e., `$fbScopeField.val()`
+            else if ($.trim($fbTypeField.val()) === 'Error in phylogeny'){
                 var $referenceURLField = $form.find('input[name="reference_url"]'); 
                 if ($.trim($referenceURLField.val()) === '') {
                     alert("Please provide a supporting reference (URL).");
                     return false;
                 }
             }
+            */
         }
         var $titleField = $form.find('input[name="issue_title"]'); 
         if ($titleField.is(':visible') && ($.trim($titleField.val()) === '')) {
@@ -390,12 +395,13 @@ def index():
         # NOTE the funky constructor required to use this below
 
         try:   # TODO: if not comment.deleted:
+            # N.B. some missing information (e.g. supporting URL) will appear here as a string like "None"
             markup = LI(
                     DIV(##T('posted by %(first_name)s %(last_name)s',comment.created_by),
                     # not sure why this doesn't work... db.auth record is not a mapping!?
                     ('title' in comment) and DIV( comment['title'], A(T('on GitHub'), _href=comment['html_url'], _target='_blank'), _class='topic-title') or '',
                     DIV( XML(markdown(get_visible_comment_body(comment['body'] or ''), extras={'link-patterns':None}, link_patterns=[(link_regex, link_replace)]).encode('utf-8'), sanitize=False),_class=(issue_node and 'body issue-body' or 'body comment-body')),
-                    DIV( A(T('Supporting reference (opens in a new window)'), _href=metadata.get('Supporting reference'), _target='_blank'), _class='body issue-supporting-reference' ) if metadata.get('Supporting reference') else '',
+                    DIV( A(T('Supporting reference (opens in a new window)'), _href=metadata.get('Supporting reference'), _target='_blank'), _class='body issue-supporting-reference' ) if (metadata.get('Supporting reference') != u'None') else '',
                     DIV(
                         A(T(author_display_name), _href=author_link, _target='_blank'),
                         # SPAN(' [local expertise]',_class='badge') if comment.claimed_expertise else '',

--- a/webapp/models/plugin_localcomments.py
+++ b/webapp/models/plugin_localcomments.py
@@ -29,6 +29,8 @@ db.define_table('plugin_localcomments_comment',
                 Field('body','text'),
                 Field('deleted','boolean',default=False,readable=False,writable=False),
                 Field('feedback_type','text'),
+                # Require a reference URL for reporting errors in phylogeny
+                Field('reference_url',length=2000), # max safe length for URLs (across browsers)
                 Field('claimed_expertise','boolean',default=False,readable=False,writable=False),
                 Field('votes','integer',default=0,readable=False,writable=False),
                 Field('created_by',db.auth_user,default=auth.user_id,readable=False,writable=False),  # OR 'reference auth_user'

--- a/webapp/static/plugin_localcomments/css/localcomments.css
+++ b/webapp/static/plugin_localcomments/css/localcomments.css
@@ -39,6 +39,9 @@ div.plugin_localcomments .byline .controls {
     font-size: 110%;
     padding: 4px 8px 0;
 }
+.plugin_localcomments .issue-supporting-reference {
+    padding-bottom: 12px;
+}
 .plugin_localcomments ul .issue {
     margin-bottom: 4px;
 }
@@ -93,7 +96,8 @@ div.plugin_localcomments .byline .controls {
     width: 38%;
     vertical-align: baseline;
 }
-.plugin_localcomments div.reply #issue_title {
+.plugin_localcomments div.reply #issue_title,
+.plugin_localcomments div.reply #reference_url {
     display: block;
     width: 98%;
 }


### PR DESCRIPTION
**STILL IN PROGRESS**. This addresses #744; see that issue's comments for more detail and ongoing discussion. The work so far is available for review on **devtree**:

  - Added a non-required 'supporting reference URL' field for phylogenetic feedback
  - Removed lots of diagnostic chatter in web2py logs
  - Finished smarter cache-clearing for local comments (incl. when adding a new issue)