### PR TITLE
Tree conflict viz (ongoing improvements)

### DIFF
--- a/curator/private/config.example
+++ b/curator/private/config.example
@@ -62,7 +62,7 @@ findAllStudies_url = {oti_domain}/findAllStudies
 singlePropertySearchForStudies_url = {oti_domain}/singlePropertySearchForStudies
 singlePropertySearchForTrees_url = {oti_domain}/singlePropertySearchForTrees
 findAllTreeCollections_url = {opentree_api_domain}/../../v2/collections/find_collections
-treeConflictStatus_url = {conflict_api_domain}/conflict-status?tree1={TREE1_ID}&tree2={TREE2_ID}
+treeConflictStatus_url = {conflict_api_domain}/conflict-status?tree1={TREE1_ID}&tree2={TREE2_ID}&use_cache={USE_CACHE}
 
 # Open Tree API - RESTful URLs for managing studies in remote storage (note HTTP verbs for each)
 #

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1787,7 +1787,7 @@ function displayConflictSummary(conflictInfo) {
     }
 }
 
-function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback) {
+function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCachedResponse) {
     // Expects inputTreeID from the current study (concatenate these!)
     // Expects referenceTreeID of 'taxonomy' or 'synth'
     if (typeof(inputTreeID) !== 'string') {
@@ -1795,6 +1795,9 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback) {
     }
     if (typeof(referenceTreeID) !== 'string') {
         referenceTreeID = $('#reference-select').val();
+    }
+    if (typeof(useCachedResponse) !== 'boolean') {
+        useCachedResponse = false;  // when in doubt, get fresh conflict information
     }
     if (!inputTreeID || !referenceTreeID) {
         hideModalScreen()
@@ -1817,9 +1820,10 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback) {
             return;
     }
     var conflictURL = treeConflictStatus_url
-        .replace('&amp;', '&')  // restore naked ampersand for query-string args
+        .replace(/&amp;/g, '&')  // restore all naked ampersands (for query-string args)
         .replace('{TREE1_ID}', fullInputTreeID)
         .replace('{TREE2_ID}', referenceTreeID)
+        .replace('{USE_CACHE}', String(useCachedResponse))
     // call this URL and try to show a summary report
     $.ajax({
         global: false,  // suppress web2py's aggressive error handling
@@ -1886,7 +1890,8 @@ function fetchAndShowTreeConflictSummary(inputTreeID, referenceTreeID) {
         referenceTreeID,
         function(conflictInfo) {
             displayConflictSummary(conflictInfo);
-        }
+        },
+        false  // don't reuse a cached response
     );
 }
 function fetchAndShowTreeConflictDetails(inputTreeID, referenceTreeID, options) {
@@ -1912,7 +1917,8 @@ function fetchAndShowTreeConflictDetails(inputTreeID, referenceTreeID, options) 
             if (options.SHOW_SPINNER) {
                 hideModalScreen();
             }
-        }
+        },
+        false  // don't reuse a cached response
     );
 }
 function showTreeConflictDetailsFromPopup(tree) {


### PR DESCRIPTION
**WORK IN PROGRESS**. I've revived this feature branch for ongoing tweaks to conflict reporting and visualization. As a first step, I've added explicit control (from JS) for whether to re-use cached responses (for a given set of trees) from the conflict service [as discussed on Gitter](https://gitter.im/OpenTreeOfLife/public?at=56c63afd833e58f50fb0082a). 