### PR TITLE
Collections in curator profile

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -208,7 +208,8 @@ def _get_opentree_activity( userid=None, username=None ):
         'added_studies':[], 
         'curated_studies': [], 
         'curated_studies_in_synthesis': [], 
-        'collections':[]
+        'added_collections':[],
+        'curated_collections':[]
     }
     method_dict = get_opentree_services_method_urls(request)
 
@@ -287,7 +288,6 @@ def _get_opentree_activity( userid=None, username=None ):
             if contributing_study_info.has_key( study['ot:studyId'] ):
                 activity['curated_studies_in_synthesis'].append(study)
 
-    # TODO: fetch collections once we have a home for them
     # Use oti to gather collections curated and created by this user.
     fetch_url = method_dict['findAllTreeCollections_url']
     if fetch_url.startswith('//'):
@@ -296,11 +296,13 @@ def _get_opentree_activity( userid=None, username=None ):
     all_collections = requests.get(url=fetch_url).json()
     for collection in all_collections:
         # gather all participants and check against their GitHub userids
+        if userid == collection.get('creator', {}).get('login', None):
+            activity_found = True
+            activity['added_collections'].append(collection)
         contributor_ids = [c.get('login', None) for c in collection.get('contributors', [ ])]
-        contributor_ids.append(collection.get('creator', {}).get('login', None))
         if userid in contributor_ids:
             activity_found = True
-            activity['collections'].append(collection)
+            activity['curated_collections'].append(collection)
 
     if activity_found:
         try:

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -288,6 +288,19 @@ def _get_opentree_activity( userid=None, username=None ):
                 activity['curated_studies_in_synthesis'].append(study)
 
     # TODO: fetch collections once we have a home for them
+    # Use oti to gather collections curated and created by this user.
+    fetch_url = method_dict['findAllTreeCollections_url']
+    if fetch_url.startswith('//'):
+        # Prepend scheme to a scheme-relative URL
+        fetch_url = "https:%s" % fetch_url
+    all_collections = requests.get(url=fetch_url).json()
+    for collection in all_collections:
+        # gather all participants and check against their GitHub userids
+        contributor_ids = [c.get('login', None) for c in collection.get('contributors', [ ])]
+        contributor_ids.append(collection.get('creator', {}).get('login', None))
+        if userid in contributor_ids:
+            activity_found = True
+            activity['collections'].append(collection)
 
     if activity_found:
         try:

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1675,15 +1675,17 @@ function getCollectionCuratorRole(collection) {
             return 'Owner';
         }
     }
+    var roleFound = 'None';
     if (('contributors' in collection) && $.isArray(collection.contributors)) {
         // compare to logged-in userid provide in the main page
         $.each(collection.contributors, function(i, c) {
             if (c.login === curatorLogin) {
-                return 'Contributor';
+                roleFound = 'Contributor';
+                return false;
             }
         });
     }
-    return 'None';
+    return roleFound;
 }
 function getCollectionLastModification(collection) {
     // nicely formatted for display, with details on mouseover

--- a/curator/static/js/curator-profile.js
+++ b/curator/static/js/curator-profile.js
@@ -48,6 +48,7 @@ var History = window.History; // Note: capital H refers to History.js!
 // these variables should already be defined in the main HTML page
 var findAllTreeCollections_url;
 var curatorLogin; // userid for the *profiled* curator (NOT the current user)
+var activeUserFound; // is the specified user an active OpenTree participant?
 var isCurrentUserProfile; // does this profile belong to the current user?
 
 // working space for parsed JSON objects (incl. sub-objects)
@@ -121,7 +122,7 @@ function updateListFiltersWithHistory() {
 
 $(document).ready(function() {
     bindHelpPanels();
-    if (isCurrentUserProfile) {
+    if (activeUserFound) {
         loadCollectionList();
     }
     

--- a/curator/views/default/collections.html
+++ b/curator/views/default/collections.html
@@ -30,13 +30,6 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
     var isLoggedIn = {{= isLoggedIn and 'true' or 'false' }};
     {{ # TODO: Define needed URLs for collections API, others }}
 
-    var findAllTreeCollections_url = "{{=findAllTreeCollections_url}}"; 
-    var singlePropertySearchForTrees_url = "{{=singlePropertySearchForTrees_url}}"; 
-    var API_create_collection_POST_url = "{{=API_create_collection_POST_url}}"; 
-    var API_load_collection_GET_url = "{{=API_load_collection_GET_url}}"; 
-    var API_update_collection_PUT_url = "{{=API_update_collection_PUT_url}}";
-    var API_remove_collection_DELETE_url = "{{=API_remove_collection_DELETE_url}}"; 
-
     // If inbound URL specifies tab, tree, or filter settings, record them here
     var initialState = {{= XML( dict(request.vars) ) }};
     // set any required defaults (for clean/simple history behavior)

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -212,6 +212,24 @@ elif active_user_found:
         </div>
     </div>
 
+    <div class="control-group">
+        <label class="control-label">Studies</label>
+        <div class="controls">
+            <p class="static-form-value">
+                <span class="interesting-value" style="font-weight: normal;">
+                    Reliable counts are coming soon, pending
+                    <a href="https://github.com/OpenTreeOfLife/oti/issues/35" target="_blank">
+                        needed fixes to oti</a>.
+                </span>
+            </p>
+            <p>
+                For now, you can 
+                <a target="_blank" href="/curator/?match={{= user_info.get('name', user_info.get('login')) }}">
+                   see this curator's studies
+                </a> in the curation dashboard.
+            </p>
+        </div>
+    </div>
 {{# TODO: Restore these stats once OTI has been fixed, see https://github.com/OpenTreeOfLife/oti/issues/35 }}
 {{ if False: }}
     <div class="control-group">

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -15,7 +15,7 @@ left_sidebar_enabled,right_sidebar_enabled=False,False
 
 response.title = "User profile"
 if active_user_found:
-subtitle_markup = """%s<span style="font-weight: normal; font-size: 0.7em;">
+    subtitle_markup = """%s<span style="font-weight: normal; font-size: 0.7em;">
                         (<a href="%s" target="_blank"
                            title="Open GitHub profile in a new window"
                            >%s <span style="color: #333;">on GitHub</span></a>)</span>""" % (
@@ -83,9 +83,9 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             initialState[prop] = filterDefaults[prop];
         }
     }
-    var curatorLogin = '{{= user_info.get('login')}}';
+    var curatorLogin = '{{= user_info and user_info.get('login') or ''}}';
+    var activeUserFound = {{= active_user_found and 'true' or 'false' }};
     var isCurrentUserProfile = {{= is_current_user_profile and 'true' or 'false' }};
-
 </script>
 <script src="{{=URL('static','js/curator-profile.js')}}"></script>
 <style type="text/css">
@@ -222,14 +222,17 @@ elif active_user_found:
                         needed fixes to oti</a>.
                 </span>
             </p>
+            {{ if user_info: }}
             <p>
                 For now, you can 
                 <a target="_blank" href="/curator/?match={{= user_info.get('name', user_info.get('login')) }}">
                    see this curator's studies
                 </a> in the curation dashboard.
             </p>
+            {{ pass }}
         </div>
     </div>
+
 {{# TODO: Restore these stats once OTI has been fixed, see https://github.com/OpenTreeOfLife/oti/issues/35 }}
 {{ if False: }}
     <div class="control-group">

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -259,6 +259,19 @@ elif active_user_found:
 {{ pass }}
 
     <div class="control-group">
+        <label class="control-label">Tree collections</label>
+        <div class="controls">
+            <p class="static-form-value">
+                {{= len( opentree_activity.get('added_collections', []) ) }}
+                <span style="font-weight: normal;">added</span>, 
+                {{= len( opentree_activity.get('curated_collections', []) ) }}
+                <span style="font-weight: normal;">curated (details below)</span> 
+            </p>
+            <!--  TODO: add markers for top 5%, etc. -->
+        </div>
+    </div>
+
+    <div class="control-group">
         <label class="control-label">Feedback</label>
         <div class="controls">
             <p class="static-form-value">

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -210,9 +210,7 @@ elif active_user_found:
         <div class="controls">
             <p class="static-form-value">
                 <span class="interesting-value" style="font-weight: normal;">
-                    Reliable counts are coming soon, pending
-                    <a href="https://github.com/OpenTreeOfLife/oti/issues/35" target="_blank">
-                        needed fixes to oti</a>.
+                    Reliable counts are coming soon.
                 </span>
             </p>
             {{ if user_info: }}
@@ -276,10 +274,16 @@ elif active_user_found:
         <label class="control-label">Tree collections</label>
         <div class="controls">
             <p class="static-form-value">
-                {{= len( opentree_activity.get('added_collections', []) ) }}
+                {{ how_many_added = len( opentree_activity.get('added_collections', []) )
+                   how_many_curated = len( opentree_activity.get('curated_collections', []) )
+                }}
+                {{= how_many_added }}
                 <span style="font-weight: normal;">added</span>, 
-                {{= len( opentree_activity.get('curated_collections', []) ) }}
-                <span style="font-weight: normal;">curated (details below)</span> 
+                {{= how_many_curated }}
+                <span style="font-weight: normal;">curated</span>
+                {{ if (how_many_added + how_many_curated) > 0: }}
+                    <span style="font-weight: normal;"> (details below)</span>
+                {{ pass }}
             </p>
             <!--  TODO: add markers for top 5%, etc. -->
         </div>

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -57,13 +57,6 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
 {{extend 'layout.html'}}
 <script src="{{=URL('static','js/curation-helpers.js')}}"></script>
 <script type='text/javascript'>
-    var findAllTreeCollections_url = "{{=findAllTreeCollections_url}}";
-    var singlePropertySearchForTrees_url = "{{=singlePropertySearchForTrees_url}}";
-    var API_create_collection_POST_url = "{{=API_create_collection_POST_url}}";
-    var API_load_collection_GET_url = "{{=API_load_collection_GET_url}}";
-    var API_update_collection_PUT_url = "{{=API_update_collection_PUT_url}}";
-    var API_remove_collection_DELETE_url = "{{=API_remove_collection_DELETE_url}}";
-
     // If inbound URL specifies tab, tree, or filter settings, record them here
     var initialState = {{= XML( dict(request.vars) ) }};
     // set any required defaults (for clean/simple history behavior)

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -86,6 +86,15 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
     <script type='text/javascript'>
         var applicationName = '{{=request.application}}';
         var phylesystem_config_url = '{{=phylesystem_config_url or "URL_NOT_SPECIFIED"}}';
+
+        /* N.B. These methods are needed to manage tree collections from any page. */
+        var findAllTreeCollections_url = "{{=findAllTreeCollections_url}}";
+        var singlePropertySearchForTrees_url = "{{=singlePropertySearchForTrees_url}}";
+        var API_create_collection_POST_url = "{{=API_create_collection_POST_url}}";
+        var API_load_collection_GET_url = "{{=API_load_collection_GET_url}}";
+        var API_update_collection_PUT_url = "{{=API_update_collection_PUT_url}}";
+        var API_remove_collection_DELETE_url = "{{=API_remove_collection_DELETE_url}}";
+
     </script>
 
     {{#------  require CSS and JS files for this page (read info in base.css) ------}}
@@ -347,16 +356,15 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                         <li><a href="/curator/study/create">Import from TreeBASE</a></li><!-- just an alias, to encourage imports -->
                     </ul>
                 </li>
-                <li class="Xweb2py-menu-first"><a href="/curator/collections">Tree collections</a></li>
-                <!--
                 <li class="dropdown">
                     <a href="/curator#TODO" class="dropdown-toggle" data-toggle="dropdown">Tree collections  <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/curator/profile">Manage my collections</a></li>
+                        <li><a href="/curator/profile#collections">Manage my collections</a></li>
                         <li><a href="/curator/collections">Browse all collections</a></li>
-                        <li><a href="/curator#TODO">Add new collection</a></li>
+                        <li><a href="#" onclick="createNewTreeCollection(); return false;">Add new collection</a></li>
                     </ul>
                 </li>
+                <!--
                 <li class="dropdown">
                     <a href="/curator/stree" class="dropdown-toggle" data-toggle="dropdown">Source Trees  <b class="caret"></b></a>
                     <ul class="dropdown-menu">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1983,13 +1983,6 @@ body {
     var getDraftTreeSubtreeForNodes_url = "{{=getDraftTreeSubtreeForNodes_url}}";
     var singlePropertySearchForStudies_url = "{{=singlePropertySearchForStudies_url}}";
     var treeConflictStatus_url = "{{=treeConflictStatus_url}}";
-
-    var findAllTreeCollections_url = "{{=findAllTreeCollections_url}}";
-    var singlePropertySearchForTrees_url = "{{=singlePropertySearchForTrees_url}}";
-    var API_create_collection_POST_url = "{{=API_create_collection_POST_url}}";
-    var API_load_collection_GET_url = "{{=API_load_collection_GET_url}}";
-    var API_update_collection_PUT_url = "{{=API_update_collection_PUT_url}}";
-    var API_remove_collection_DELETE_url = "{{=API_remove_collection_DELETE_url}}";
 </script>
 <script src="{{=URL('static','js/study-editor.js')}}"></script>
 


### PR DESCRIPTION
This addresses a number of related bugs re: collections and the curator profile page:

- Adding or editing a tree collection is now recognized as OpenTree activity, so a user who has only done these things will have a proper curator profile page.

- The "their tree collections" list will appear for any valid OpenTree user.

- Fixed a server-side bug (500 error) when we show the "no such user in GitHub" page.

- We show tree-collection stats for an active curator, in a compact format.

- We show an explanation for missing study stats, pending [OTI fixes described elsewhere](https://github.com/OpenTreeOfLife/oti/issues/35).

- We restore the 'Tree collections' menu (in the app's main menubar) and enable 'Add new collection' from any page in the curation app.