### PR TITLE
Resolve monophyletic conflicting OTU mappings

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2635,8 +2635,8 @@ function normalizeTree( tree ) {
 
     removeDuplicateTags( tree );
 
-    // pre-select first node among conflicting siblings
-    resolveSiblingOnlyConflictsInTree(tree);
+    // pre-select first node among monophyletic sets
+    resolveMonophyleticConflictsInTree(tree);
 }
 
 function getAllTreeIDs() {
@@ -3205,7 +3205,7 @@ var studyScoringRules = {
                 var startTime = new Date();
                 $.each(getPreferredTrees(), function(i, tree) {
                     // disregard sibling-only conflicts (will be resolved on the server)
-                    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_SIBLINGS_ONLY: false} );
+                    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
                     if ( !($.isEmptyObject(conflictData)) ) {
                         conflictingNodesFound = true;
                         return false;
@@ -3598,10 +3598,10 @@ function showTreeViewer( tree, options ) {
     var highlightNodeID = options.HIGHLIGHT_NODE_ID || null;
 
     if (tree) {
-        // Clean up sibling-only conflicts before annoying the user. (We do
+        // Clean up mononphyletic conflicts before annoying the user. (We do
         // this here since OTU mapping or other changes may have introduced new
         // conflicts, and we don't want to waste the curator's time with them.)
-        resolveSiblingOnlyConflictsInTree(tree);
+        resolveMonophyleticConflictsInTree(tree);
     }
 
     if (!tree) {
@@ -3952,7 +3952,7 @@ function showOTUInContext() {
 
 function showConflictingNodesInTreeViewer(tree) {
     // If there are no conflicts, fall back to simple tree view
-    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_SIBLINGS_ONLY: false} );
+    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
     if (!isPreferredTree(tree) || $.isEmptyObject(conflictData)) {
         showTreeWithHistory(tree);
         return;
@@ -7649,8 +7649,8 @@ function validateAndTestDOI() {
 }
 
 function unresolvedConflictsFoundInTree( tree ) {
-    // N.B. This checks for UNRESOLVED and INTERESTING (non-sibling) conflicts
-    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_SIBLINGS_ONLY: false} );
+    // N.B. This checks for UNRESOLVED and INTERESTING (non-monophyletic) conflicts
+    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
     return $.isEmptyObject(conflictData) ? false : true;
 }
 function isConflictingNode( tree, node ) {
@@ -7671,9 +7671,11 @@ function isConflictingNode( tree, node ) {
 function getUnresolvedConflictsInTree( tree, options ) {
     // Filter from full conflict data to include just those node-sets that
     // have't been resolved, ie, curator has not chosen an exemplar.
-    var includeSiblingOnlyConflicts = options && ('INCLUDE_SIBLINGS_ONLY' in options) ? options.INCLUDE_SIBLINGS_ONLY : false;
+    var includeMonophyleticConflicts = options && ('INCLUDE_MONOPHYLETIC' in options) ? options.INCLUDE_MONOPHYLETIC : false;
     var unresolvedConflicts = {};
+var startTime = new Date();
     var allConflicts = getConflictingNodesInTree( tree );
+console.log(">>>>>> total elapsed to gather conflicting nodes: "+ (new Date() - startTime) +" ms");
     for (var taxonID in allConflicts) {
         var allNodesAlreadyMarked = true; // we can disprove this from any node
         var itsMappings = allConflicts[taxonID];
@@ -7684,10 +7686,10 @@ function getUnresolvedConflictsInTree( tree, options ) {
             }
         });
         if (!(allNodesAlreadyMarked)) {
-            if (includeSiblingOnlyConflicts) {
+            if (includeMonophyleticConflicts) {
                 unresolvedConflicts[ taxonID ] = itsMappings;
-            } else if (!(itsMappings.siblingsOnly)) {
-                // ignore conflicts just between siblings
+            } else if (!(itsMappings.monophyletic)) {
+                // ignore sets that constitute a clade
                 unresolvedConflicts[ taxonID ] = itsMappings;
             }
         }
@@ -7696,8 +7698,8 @@ function getUnresolvedConflictsInTree( tree, options ) {
 }
 function getConflictingNodesInTree( tree ) {
     // Return sets of nodes that ultimately map to a single OT taxon (via
-    // multiple OTUs) and are not siblings. A curator should choose the
-    // 'exemplar' node to avoid problems in synthesis.
+    // multiple OTUs) and are not monophyletic (incl. siblings). A curator
+    // should choose the 'exemplar' node to avoid problems in synthesis.
     var conflictingNodes = { };
     // N.B. OTUs should be unique within a tree. We're looking for OTUs that
     // are mapped to the same OTT taxon id.
@@ -7730,51 +7732,117 @@ function getConflictingNodesInTree( tree ) {
     });
 
     // Gather all mappings that have multiple appearances, but mark them to
-    // distinguish siblings-only from more interesting conflicts.
-    // N.B. Siblings will be reconciled on the server in any case, but this
-    // will help us to show consistent UI when siblings are obviously in conflict.
-    // TODO: Mark monophyletic sets (incl. siblings-only)?
+    // distinguish monophyletic (incl. siblings-only) sets from more
+    // interesting conflicts.
+    // N.B. These trivial conflicts will be reconciled on the server in any
+    // case, but this we we can show consistent UI and save curator effort.
     for (taxonID in taxonMappings) {
+        ///console.log('>>>> taxonID '+ taxonID +'...');
         // is there more than one node for this taxon?
         var itsMappings = taxonMappings[taxonID];
-        var foundSiblingConflicts = false;
-        var foundInterestingConflicts = false;  // interesting == not just siblings
+        itsMappings.monophyletic = false;
         if (itsMappings.length > 1) {
-            // are all of the nodes siblings? use fast edge lookup!
-            var matchParent = null;
-            $.each(itsMappings, function(i, item) {
-                var upwardEdge = getTreeEdgesByID(tree, item.nodeID, 'TARGET')[0];
-                // N.B. Due to NexSON constraints, assume exactly one upward edge!
-                var itsParentID = upwardEdge['@source'];
-                if (!matchParent) {
-                    matchParent = itsParentID;
-                } else {
-                    if (itsParentID === matchParent) {
-                        foundSiblingConflicts = true;
-                    } else {
-                        foundInterestingConflicts = true;
-                        return false;  // no need to check remaining mappings
-                    }
-                }
+            var conflictingNodeIDs = $.map(itsMappings, function(m) {
+                return m.nodeID;
             });
-        }
-        if (foundInterestingConflicts) {
-            itsMappings['siblingsOnly'] = false;
-            if (false) {
-                // TODO: look more closely to determine (and mark) monophyletic sets
-                itsMappings['monophyletic'] = true;
+            if (tipsAreMonophyletic(conflictingNodeIDs, tree)) {
+                itsMappings.monophyletic = true;
+                ///console.log('>>>> checking for monophyly... YES');
             } else {
-                itsMappings['monophyletic'] = false;
+                ///console.log('>>>> checking for monophyly... NO');
             }
-            conflictingNodes[ taxonID ] = itsMappings;
-        } else if (foundSiblingConflicts) {
-            itsMappings['siblingsOnly'] = true;
-            itsMappings['monophyletic'] = false;
-            conflictingNodes[ taxonID ] = itsMappings;
         }
+        conflictingNodes[ taxonID ] = itsMappings;
     }
 
     return conflictingNodes;
+}
+function tipsAreMonophyletic(tipIDs, tree) {
+    ///return false;
+    // general fast check for monophyly in a specified tree
+    if (tipIDs.length < 2) {
+        return true;
+    }
+    /* Find the least-inclusive common ancestor for all the specified tips,
+     * then recurse to see if all these tips (and only these tips) are found in
+     * its clade.
+     */
+    var licaID = getCommonAncestorNodeID(tipIDs, tree);
+    var licaTipIDs = getAllMemberTipIDs(licaID, tree);
+    // For monophyly, this list of IDs must *exactly* match our initial tip-ID list.
+    if (licaTipIDs.length !== tipIDs.length) return false;
+    var differenceFound = false;
+    $.grep(licaTipIDs, function(el) {
+        if ($.inArray(el, tipIDs) == -1) {
+            differenceFound = true;
+            return false;  // stops checking ids
+        }
+    });
+    return (!differenceFound);
+}
+function getAllMemberTipIDs(cladeTopNodeID, tree, memberTipIDsSoFar) {
+    // recurse through subclades to gather all tip IDs under the given node
+    if (!memberTipIDsSoFar) { memberTipIDsSoFar = [ ] };  // used for recursion
+    var sourceLookup = getFastLookup('EDGES_BY_SOURCE_ID');
+    var childEdges = sourceLookup[ cladeTopNodeID ];
+    if (childEdges) {
+        $.each(childEdges, function(i, edge) {
+            var testChildID = edge['@target'];
+            getAllMemberTipIDs(testChildID, tree, memberTipIDsSoFar);
+        });
+    } else {
+        // this is a tip!
+        memberTipIDsSoFar.push( cladeTopNodeID );
+    }
+    return memberTipIDsSoFar;
+}
+function getCommonAncestorNodeID(tipIDs, tree) {
+    // Find and return the least-inclusive common ancestor (its ID) for the tip/leaf IDs provided
+    var foundLICA = null;
+    var ancestorsByTipID = {};
+    $.each(tipIDs, function(i, tipID) {
+        ancestorsByTipID[ tipID ] = getAncestorNodeIDs(tipID, tree);
+    });
+    ///console.log('>>> ancestorsByTipID:');
+    ///console.log(ancestorsByTipID);
+    var firstTipID = tipIDs[0];
+    var firstTipAncestorIDs = ancestorsByTipID[ firstTipID ];
+    // One of these is our LICA... but which? Test against the other tips!
+    delete ancestorsByTipID[ firstTipID ];
+    $.each(firstTipAncestorIDs, function(i, testAncestorID) {
+        // the first one that exists in every list is the LICA
+        var notFound = false;
+        for (var testTipID in ancestorsByTipID) {
+            var itsAncestorIDs = ancestorsByTipID[ testTipID ];
+            if ($.inArray(testAncestorID, itsAncestorIDs) === -1) {
+                // this was not found in another tip's ancestors! try the next
+                return true;
+            }
+        }
+        foundLICA = testAncestorID;
+        return false; // stop searching!
+    });
+    ///console.log('>>> foundLICA:');
+    ///console.log(foundLICA);
+    return foundLICA;
+}
+function getAncestorNodeIDs(nodeID, tree) {
+    var ancestorIDs = [ ];
+    var testNodeID = nodeID;
+    while (testNodeID) {
+        var parentID = getParentNodeID(testNodeID, tree)
+        if (parentID) {
+            ancestorIDs.push( parentID );
+        }
+        testNodeID = parentID;
+    }
+    ///console.log('>>>> ancestor nodes for '+ nodeID +': '+ ancestorIDs);
+    return ancestorIDs;
+}
+function getParentNodeID(nodeID, tree) {
+    var upwardEdge = getTreeEdgesByID(tree, nodeID, 'TARGET')[0];
+    // N.B. Due to NexSON constraints, assume exactly one upward edge!
+    return upwardEdge ? upwardEdge['@source'] : null;
 }
 function markTaxonExemplar( treeID, chosenNodeID, options ) {
     // find all conflicting nodes and set flag for each
@@ -7846,14 +7914,14 @@ function clearTaxonExemplar( treeID, chosenNodeID, options ) {
         drawTree(treeID);
     }
 }
-function resolveSiblingOnlyConflictsInTree(tree) {
-    // Find and resolve all simple conflicts between sibling nodes (select the
-    // first as exemplar).
-    // TODO: change to resolveMonophyleticConflictsInTree()
-    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_SIBLINGS_ONLY: true} );
+function resolveMonophyleticConflictsInTree(tree) {
+    // Find and resolve all simple conflicts between sibling nodes, and any
+    // others where the conflicting nodes constitute a clade. In all cases, our
+    // choice is arbitrary; we simply select the first node found as the exemplar.
+    var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_MONOPHYLETIC: true} );
     for (var taxonID in conflictData) {
         var conflictInfo = conflictData[taxonID];
-        if (conflictInfo.siblingsOnly) {
+        if (conflictInfo.monophyletic) {
             var firstConflictingNodeID = conflictInfo[0].nodeID;
             markTaxonExemplar( tree['@id'], firstConflictingNodeID, {REDRAW_TREE: false});
         }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7733,6 +7733,7 @@ function getConflictingNodesInTree( tree ) {
     // distinguish siblings-only from more interesting conflicts.
     // N.B. Siblings will be reconciled on the server in any case, but this
     // will help us to show consistent UI when siblings are obviously in conflict.
+    // TODO: Mark monophyletic sets (incl. siblings-only)?
     for (taxonID in taxonMappings) {
         // is there more than one node for this taxon?
         var itsMappings = taxonMappings[taxonID];
@@ -7759,9 +7760,16 @@ function getConflictingNodesInTree( tree ) {
         }
         if (foundInterestingConflicts) {
             itsMappings['siblingsOnly'] = false;
+            if (false) {
+                // TODO: look more closely to determine (and mark) monophyletic sets
+                itsMappings['monophyletic'] = true;
+            } else {
+                itsMappings['monophyletic'] = false;
+            }
             conflictingNodes[ taxonID ] = itsMappings;
         } else if (foundSiblingConflicts) {
             itsMappings['siblingsOnly'] = true;
+            itsMappings['monophyletic'] = false;
             conflictingNodes[ taxonID ] = itsMappings;
         }
     }
@@ -7841,6 +7849,7 @@ function clearTaxonExemplar( treeID, chosenNodeID, options ) {
 function resolveSiblingOnlyConflictsInTree(tree) {
     // Find and resolve all simple conflicts between sibling nodes (select the
     // first as exemplar).
+    // TODO: change to resolveMonophyleticConflictsInTree()
     var conflictData = getUnresolvedConflictsInTree( tree, {INCLUDE_SIBLINGS_ONLY: true} );
     for (var taxonID in conflictData) {
         var conflictInfo = conflictData[taxonID];


### PR DESCRIPTION
~~**WORK IN PROGRESS**.~~ This feature is working now, but larger trees would benefit from a per-tree cache. (See commit messages for more details.) Addresses https://github.com/OpenTreeOfLife/feedback/issues/232

The current code is on **devtree** for review. As a demonstration, the example tree [provided in issue #232](https://github.com/OpenTreeOfLife/feedback/issues/232#issuecomment-186691172) has eight monophyletic sets of conflicting OTU mappings (e.g. _Gelasinospora tetrasperma_) that are detected and resolved automatically, i.e. an arbitrary node is chosen as the exemplar.

_**UPDATE:** For best performance, this now includes a per-tree cache of taxon-mapping info. This is flushed whenever we re-root a tree, mark/clear an exemplar node, or change any taxon mapping._