### PR TITLE
Fix for clumsy per-tree cache of conflicting OTUs

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7758,17 +7758,18 @@ function getConflictingNodesInTree( tree ) {
 
     if (!isPreferredTree(tree)) {
         // ignoring these for now...
+        ///console.log('<<<<< getConflictingNodesInTree (treeid='+ tree['@id'] +'...) IGNORING non-preferred tree!');
         return conflictingNodes;
     }
 
     // Pull from cached information, if any (else populate the cache)
     if (tree.taxonMappingInfo) {
-        ///console.log('!!!!! using cached taxon-mapping info');
+        ///console.log('!!!!! getConflictingNodesInTree (treeid='+ tree['@id'] +'...) using cached taxon-mapping info');
         return tree.taxonMappingInfo;
     }
-    ///console.log('..... building fresh taxon-mapping info');
+    ///console.log('..... getConflictingNodesInTree (treeid='+ tree['@id'] +'...) building fresh taxon-mapping info');
 
-    var taxonMappings = tree.taxonMappingInfo = { };
+    var taxonMappings = { };
     $.each(tree.node, function( i, node ) {
         if ('@otu' in node) {
             var otuID = node['@otu'];
@@ -7789,7 +7790,7 @@ function getConflictingNodesInTree( tree ) {
             }
         }
     });
-
+    ///console.log('..... found '+ Object.keys(taxonMappings).length  +' total mapped taxa');
     // Gather all mappings that have multiple appearances, but mark them to
     // distinguish monophyletic (incl. siblings-only) sets from more
     // interesting conflicts.
@@ -7810,10 +7811,13 @@ function getConflictingNodesInTree( tree ) {
             } else {
                 ///console.log('>>>> checking for monophyly... NO');
             }
+            conflictingNodes[ taxonID ] = itsMappings;
         }
-        conflictingNodes[ taxonID ] = itsMappings;
     }
-
+    ///console.log('..... found '+ Object.keys(conflictingNodes).length  +' conflicting nodes');
+    
+    // cache the result for next time
+    tree.taxonMappingInfo = conflictingNodes;
     return conflictingNodes;
 }
 function tipsAreMonophyletic(tipIDs, tree) {


### PR DESCRIPTION
I was caching *all* OTU mapping info, instead of conflicting mappings only (as intended). This resulted in lots of false positives in the tree view, i.e. nodes marked as conflicting that were not.

This latest version (IMO) demonstrates that we don't need to revert a prior merge in #936.