### PR TITLE
Shorten timeouts to preserve sockets

### DIFF
--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import urllib2
+import socket
 from opentreewebapputil import (get_opentree_services_method_urls, 
                                 fetch_current_TNRS_context_names)
 
@@ -153,8 +154,13 @@ def phylopic_proxy():
     phylopic_url = 'http://phylopic.org/%s' % phylopic_url
     try:
         req = urllib2.Request(url=phylopic_url) 
-        resp = urllib2.urlopen(req).read()
+        resp = urllib2.urlopen(req, timeout=10).read()
+        # N.B. timeout value is in seconds!
         return resp
-    except:
-        raise HTTP(503, 'The attempt to fetch an image from phylopic failed')
+    except urllib2.URLError, e:
+        # this includes possible timeout from urllib2
+        raise HTTP(503, 'The attempt to fetch an image from phylopic failed (probable timeout)')
+    except socket.timeout, e:
+        # report underlying socket timeouts!
+        raise HTTP(504, 'The attempt to fetch an image from phylopic timed out')
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -345,7 +345,8 @@ def index():
         child_comments = [ ]
         if comment.get('comments') and comment.get('comments') > 0:
             get_children_url = comment['comments_url']
-            resp = requests.get( get_children_url, headers=GH_GET_HEADERS)
+            resp = requests.get( get_children_url, headers=GH_GET_HEADERS, timeout=10)
+            # N.B. Timeout is in seconds, and watches for *any* new data within that time (vs. whole response)
             try:
                 resp.raise_for_status()
                 try:
@@ -763,7 +764,8 @@ def get_local_comments(location={}):
     ##TODO: search only within body?
     ## url = '{0}/search/issues?q={1}repo:OpenTreeOfLife%2Ffeedback+in:body+state:open&sort=created&order=asc'
     url = url.format(GH_BASE_URL, search_text)
-    resp = requests.get(url, headers=GH_GET_HEADERS)
+    resp = requests.get(url, headers=GH_GET_HEADERS, timeout=10)  
+    # N.B. Timeout is in seconds, and watches for *any* new data within that time (vs. whole response)
     ##print(url)
     ##print(resp)
     try:


### PR DESCRIPTION
Addresses issue #942 (web-app server fails if upstream services are slow to respond). We're setting 10-second timeouts on the most likely culprits, PhyloPic and the GitHub issues API, which is used for the "local comments" (feedback) tool in the synthetic-tree viewer. 

_Note that once fetched, these comments are cached on our server, so this condition might not appear until someone adds/deletes/changes a comment, clearing the cache entry for a taxon._

This is running now on **devtree**.