### PR TITLE
Support cross-domain request for Nexson conversion

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -202,6 +202,8 @@ def to_nexson():
     N.B. Further documentation is available in curator/README.md
     '''
     _LOG = get_logger(request, 'to_nexson')
+    if request.vars.request_method == 'OPTIONS':
+        raise HTTP(200, T('Preflight approved!'))
     ##pdb.set_trace()
     orig_args = {}
     is_upload = False

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -202,7 +202,7 @@ def to_nexson():
     N.B. Further documentation is available in curator/README.md
     '''
     _LOG = get_logger(request, 'to_nexson')
-    if request.vars.request_method == 'OPTIONS':
+    if request.env.request_method == 'OPTIONS':
         raise HTTP(200, T('Preflight approved!'))
     ##pdb.set_trace()
     orig_args = {}


### PR DESCRIPTION
Initial use case is to provide conversion (from Newick, etc) from the Tree Illustrator prototype.

This code has been running for some time on **devtree**, but was never properly merged to master. I noticed it was missing when conversion calls from Tree Illustrator started failing, and I realized it was because we had recently deployed a different branch.