### PR TITLE
Allow re-rooting on an edge from the current root.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -6416,7 +6416,7 @@ function showEdgeOptionsMenu( tree, edge, nodePageOffset, importantNodeIDs ) {
         nodeInfoBox.append('<div>Edge length: '+ edge.target.length +'</div>');
     }
 
-    var availableForRooting = (edge.source['@id'] !== importantNodeIDs.treeRoot) && (edge.target['@id'] !== importantNodeIDs.treeRoot);
+    var availableForRooting = (edge.source['@id'] !== getAdHocRootID(tree)) && (edge.target['@id'] !== getAdHocRootID(tree));
     if (availableForRooting && (viewOrEdit === 'EDIT')) {
         nodeMenu.append('<li><a href="#" onclick="hideNodeOptionsMenu(); setTreeRoot( \''+ tree['@id'] +'\', [\''+ edge.source['@id'] +'\', \''+ edge.target['@id'] +'\'] ); return false;">Re-root from this edge</a></li>');
     }


### PR DESCRIPTION
This allows cleanup of trees that have [a polytomy directly from the root node](https://devtree.opentreeoflife.org/curator/study/edit/tt_101?tab=trees&tree=Tr57863). It now blocks re-rooting only if the chosen edge is adjacent to an *existing* ad-hoc root, since this would be a no-op. Fixes #919.