### PR TITLE
Hide exemplar actions in read-only tree-view.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4008,7 +4008,7 @@ function showDuplicateNodesInTreeViewer(tree) {
     });
     showTreeViewer(null, {
         HIGHLIGHT_PLAYLIST: duplicatePlaylist,
-        HIGHLIGHT_PROMPT: ("Showing all tips mapped to '<strong>MAPPED_TAXON</strong>'. Choose an exemplar."),
+        HIGHLIGHT_PROMPT: ("Showing all tips mapped to '<strong>MAPPED_TAXON</strong>'." + (viewOrEdit === 'EDIT' ? " Choose an exemplar." : "")),
         HIGHLIGHT_POSITION: 0
     });
     // TODO: Modify prompt text as we move through duplicate taxa?
@@ -6248,7 +6248,8 @@ function showNodeOptionsMenu( tree, node, nodePageOffset, importantNodeIDs ) {
     var nodeInfoBox = nodeMenu.find('.node-information');
     var labelInfo = getTreeNodeLabel(tree, node, importantNodeIDs);
     nodeInfoBox.append('<span class="node-name">'+ labelInfo.label +'</span>');
-    if (isDuplicateNode( tree, node )) {
+
+    if ((viewOrEdit === 'EDIT') && isDuplicateNode( tree, node )) {
         if (node['^ot:isTaxonExemplar'] === true) {
             nodeMenu.append('<li><a href="#" onclick="hideNodeOptionsMenu(); clearTaxonExemplar( \''+ tree['@id'] +'\', \''+ nodeID +'\' ); return false;">Clear exemplar for mapped taxon</a></li>');
         } else {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -3258,7 +3258,7 @@ var studyScoringRules = {
             },
             weight: 0.2,
             successMessage: "No duplicate tips with conflicting placement found in preferred trees.",
-            failureMessage: "Duplicate taxa found: designate an 'exemplar' for each set of tips mapped to the same taxon.",
+            failureMessage: "Duplicate tips found with conflicting mapping (no exemplar chosen).",
             suggestedAction: "Designate an exemplar for each set of tips mapped to the same taxon."
         },
         {
@@ -3282,7 +3282,7 @@ var studyScoringRules = {
             },
             weight: 0.2,
             successMessage: "No undefined internal node labels found.",
-            failureMessage: "Undefined internal node labels: assign a label type.",
+            failureMessage: "Internal node labels found with no label type assigned.",
             suggestedAction: "Assign a type to undefined internal node labels."
         },
         {


### PR DESCRIPTION
Fixes #934. Note that this also includes modifications to the declarative `failureMessage` strings (see commit https://github.com/OpenTreeOfLife/opentree/commit/706814ae785994ed44fc208d168f6ade9b19e584 for details).