### PR TITLE
Reconstruct full GitHub URL for collections

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -706,7 +706,7 @@ $(window).resize( function () {
 });
 
 // Use a known-good URL fragment to extract a collection ID from its API URL
-var collectionURLSplitterAPI = '/v2/collection/';
+var collectionURLSplitterAPI = '/collection/';
 // Fall back to raw-data URL in some cases
 var collectionURLSplitterRaw = '/collections/';
 
@@ -719,6 +719,22 @@ function getCollectionIDFromURL(url) {
         fromRawData = fromRawData.split('.json')[0];
     }
     return fromAPI || fromRawData;
+}
+
+function getFullGitHubURLForCollection(collection) {
+    /* Munge the downloadable `external_url` to get a link to full blob+history on GitHub, for example
+     *   https://raw.githubusercontent.com/OpenTreeOfLife/collections-0/master/collections-by-owner/jimallman/newtest-2.json
+     * ...becomes this:
+     *   https://github.com/OpenTreeOfLife/collections-0/blob/master/collections-by-owner/jimallman/newtest-2.json
+     * More specifically, we just need to change this early path:
+     *   https://raw.githubusercontent.com/OpenTreeOfLife/collections-#/
+     * ... to this:
+     *   https://github.com/OpenTreeOfLife/collections-#/blob/
+     */
+    if (collection.external_url) {
+        return collection.external_url.replace( /.*collections-(\d*)\// , "https://github.com/OpenTreeOfLife/collections-$1/blob/");
+    }
+    return '';
 }
 
 function updateNewCollTreeUI() {

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -554,7 +554,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
             <span id="collection-id-display"
                   data-bind="text: getCollectionIDFromURL($data.data.url)">&nbsp;</span>
            <!-- ko if: ('external_url' in $data) -->
-            <a data-bind="attr: { href: $data['external_url'] }" target="_blank">(on GitHub)</a>
+            <a data-bind="attr: { href: getFullGitHubURLForCollection($data) }" target="_blank">(on GitHub)</a>
            <!-- /ko -->
         </p>
       </div>


### PR DESCRIPTION
We can safely convert between a download URL on GitHub (currently provided as the collection's `external_url`) and a "full" URL to the collection blob and its history. Addresses #871.

**N.B.** that we might instead choose to [redefine all "public" or "external" URLs](https://github.com/OpenTreeOfLife/peyotl/blob/a91833404b6e84ac33ebbc176296bdf9a2c698fc/peyotl/git_storage/sharded_doc_store.py#L34-L39) in peyotl's documents, if we'd **always** prefer to show the richer GitHub view. Or we might distinguish between the two, if we can agree on suitable property names, perhaps `doc.download_url` (looks like [this](https://raw.githubusercontent.com/OpenTreeOfLife/collections-0/master/collections-by-owner/jimallman/new-test-ad.json)) versus `doc.history_url` (looks like [this](https://github.com/OpenTreeOfLife/collections-0/blob/master/collections-by-owner/jimallman/new-test-ad.json)).