### PR TITLE
Warn user no email

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1334,7 +1334,14 @@ function promptForSaveCollectionComments( collection ) {
         $('#save-collection-comment-first-line').val(firstLine);
         $('#save-collection-comment-more-lines').val(moreLines);
 
-        $('#save-collection-comments-popup').modal('show');
+        if (userEmail != 'ANONYMOUS') {
+          // console.log('email: '+ userEmail);
+          $('#save-collection-comments-popup').modal('show');
+        }
+        else {
+          $('#save-collection-comments-popup-no-email').modal('show');
+        }
+
         // buttons there do the remaining work
         $('#save-collection-comments-submit')
             .unbind('click')

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2225,7 +2225,14 @@ function validateFormData() {
 
 function promptForSaveComments() {
     // show a modal popup to gather comments (or cancel)
-    $('#save-comments-popup').modal('show');
+    // check for valid user email address and show modal with warning if none
+    if (userEmail != 'ANONYMOUS') {
+      console.log('email: '+ userEmail);
+      $('#save-comments-popup').modal('show');
+    }
+    else {
+      $('#save-comments-popup-no-email').modal('show');
+    }
     // buttons there do the remaining work
 }
 

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -941,9 +941,9 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
     </div>
     <p>
-        <div class="help-box"><strong>Warning</strong>: You have not provided a public email
-          address in your GitHub profile. Without a public email, you can
-          still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+        <div class="help-box"><strong>Warning</strong>: You have not provided a
+          public email address in your GitHub profile. You can still edit data, but this activity will not be shown on your GitHub or OpenTree profiles (and cannot be
+          linked back at a later date). See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
         </div>
     </p>
     <div class="modal-footer">

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -899,6 +899,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
   </div><!-- end of #tree-collection-viewer.modal- -->
 
 <!-- hidden template for gathering comments when saving a tree collection -->
+<!-- this version for cases where we have valid email addy for curator -->
 <div class="modal hide fade modal-save-comments" id="save-collection-comments-popup" style="display: none;">
     <div class="modal-header">
       <a data-dismiss="modal" class="close">×</a>
@@ -914,6 +915,37 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
     </div>
+    <div class="modal-footer">
+      <button id="save-collection-comments-submit"
+              class="btn btn-info pull-right" style="margin-left: 20px;"
+              onclick="return false;">Save Collection</button>
+      <a id="save-collection-comments-cancel" data-dismiss="modal" class="btn" >Cancel</a>
+    </div>
+</div>
+
+<!-- hidden template for gathering comments when saving a tree collection -->
+<!-- this version includes warning for curators without public email addys -->
+<div class="modal hide fade modal-save-comments" id="save-collection-comments-popup-no-email" style="display: none;">
+    <div class="modal-header">
+      <a data-dismiss="modal" class="close">×</a>
+      <h3 id='dialog-heading'>
+         Add a comment for these changes
+      </h3>
+    </div>
+    <div class="modal-body">
+        <p>
+            Add a brief description of the work you've done.
+            This will appear in this collection's history on GitHub.
+        </p>
+        <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
+        <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+    </div>
+    <p>
+        <div class="help-box"><strong>Warning</strong>: You have not provided a public email
+          address in your GitHub profile. Without a public email, you can
+          still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+        </div>
+    </p>
     <div class="modal-footer">
       <button id="save-collection-comments-submit"
               class="btn btn-info pull-right" style="margin-left: 20px;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2089,6 +2089,7 @@ body {
 </div>
 
 <!-- hidden template for gathering comments when saving the study -->
+<!-- this version when we have user email -->
 <div class="modal hide fade modal-save-comments" id="save-comments-popup" style="display: none;">
     <div class="modal-header">
       <a data-dismiss="modal" class="close">×</a>
@@ -2103,6 +2104,36 @@ body {
         </p>
         <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-info pull-right" style="margin-left: 20px;"
+              onclick="$('#save-comments-popup').modal('hide'); saveFormDataToStudyJSON(); return false;">Save Study</button>
+      <a data-dismiss="modal" class="btn" >Cancel</a>
+    </div>
+</div>
+
+<!-- hidden template for gathering comments when saving the study -->
+<!-- this version when we don't have user email and want to show warning -->
+<div class="modal hide fade modal-save-comments" id="save-comments-popup-no-email" style="display: none;">
+    <div class="modal-header">
+      <a data-dismiss="modal" class="close">×</a>
+      <h3 id='dialog-heading'>
+         Add a comment for these changes
+      </h3>
+    </div>
+    <div class="modal-body">
+        <p>
+            Add a brief description of the work you've done.
+            This will appear in the History tab.
+        </p>
+        <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
+        <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+          <p>
+              <div class="help-box"><strong>Warning</strong>: You have not provided a public email
+                address in your GitHub profile. Without a public email, you can
+                still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+              </div>
+          </p>
     </div>
     <div class="modal-footer">
       <button class="btn btn-info pull-right" style="margin-left: 20px;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2130,8 +2130,8 @@ body {
         <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
           <p>
               <div class="help-box"><strong>Warning</strong>: You have not provided a public email
-                address in your GitHub profile. Without a public email, you can
-                still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+                address in your GitHub profile. You can still edit data, but this activity will not be shown on your GitHub or OpenTree profiles (and cannot be
+                linked back at a later date). See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
               </div>
           </p>
     </div>


### PR DESCRIPTION
This addresses part of #920 , providing a warning message on the commit popup when saving studies or collections and when a user does not have a public email address on GitHub. Deployed on devtree, but a PITA to test (you need to make your email address private on GitHub, re-load devtree (maybe clearing cache?), log out and log in again, make a change to a collection or study and save). You can confirm the status of your email address on your opentree profile page - public GitHub email = no email listed on profile page. For anyone not thrilled about going through all of that hassle, this is what the new popup looks like when you don't have a public email address:

<img width="551" alt="screen shot 2016-04-20 at 11 05 56 am" src="https://cloud.githubusercontent.com/assets/312034/14680329/ec2a903e-06ea-11e6-849d-16f8960f80f1.png">

