### PR TITLE
Warn user no email

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1334,7 +1334,14 @@ function promptForSaveCollectionComments( collection ) {
         $('#save-collection-comment-first-line').val(firstLine);
         $('#save-collection-comment-more-lines').val(moreLines);
 
-        $('#save-collection-comments-popup').modal('show');
+        if (userEmail != 'ANONYMOUS') {
+          // console.log('email: '+ userEmail);
+          $('#save-collection-comments-popup').modal('show');
+        }
+        else {
+          $('#save-collection-comments-popup-no-email').modal('show');
+        }
+
         // buttons there do the remaining work
         $('#save-collection-comments-submit')
             .unbind('click')

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1334,21 +1334,21 @@ function promptForSaveCollectionComments( collection ) {
         $('#save-collection-comment-first-line').val(firstLine);
         $('#save-collection-comment-more-lines').val(moreLines);
 
-        // include a warning message if the user has no public email
-        // var warningNoEmailMsg = ""
-        // if (userEmail != 'ANONYMOUS') {
-        //   // console.log('email: '+ userEmail);
-        // }
-        // else {
-        //   warningNoEmailMsg = '<strong>Warning</strong>: You have not provided a '+
-        //     'public email address in your GitHub profile. You can still edit data'+
-        //     'but this activity will not be shown on your GitHub or OpenTree profiles '+
-        //     '(and cannot be linked back at a later date). See '+
-        //     '<a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>'+
-        //     'the help page</a> for details.'
-        // }
-        //
-        // $('#save-collection-comment-warning-msg').val(warningNoEmailMsg);
+        //include a warning message if the user has no public email
+        var warningNoEmailMsg = ""
+        if (userEmail != 'ANONYMOUS') {
+          // console.log('email: '+ userEmail);
+        }
+        else {
+          warningNoEmailMsg = '<strong>Warning</strong>: You have not provided a '+
+            'public email address in your GitHub profile. You can still edit data'+
+            'but this activity will not be shown on your GitHub or OpenTree profiles '+
+            '(and cannot be linked back at a later date). See '+
+            '<a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>'+
+            'the help page</a> for details.'
+        }
+
+        $('#save-collection-comment-noemail-warning').val(warningNoEmailMsg);
 
         $('#save-collection-comments-popup').modal('show');
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -706,7 +706,7 @@ $(window).resize( function () {
 });
 
 // Use a known-good URL fragment to extract a collection ID from its API URL
-var collectionURLSplitterAPI = '/v2/collection/';
+var collectionURLSplitterAPI = '/collection/';
 // Fall back to raw-data URL in some cases
 var collectionURLSplitterRaw = '/collections/';
 
@@ -1335,20 +1335,13 @@ function promptForSaveCollectionComments( collection ) {
         $('#save-collection-comment-more-lines').val(moreLines);
 
         //include a warning message if the user has no public email
-        var warningNoEmailMsg = ""
-        if (userEmail != 'ANONYMOUS') {
+        if (userEmail == 'ANONYMOUS') {
+          $('#save-collection-noemail-warning').show();
           // console.log('email: '+ userEmail);
         }
         else {
-          warningNoEmailMsg = '<strong>Warning</strong>: You have not provided a '+
-            'public email address in your GitHub profile. You can still edit data'+
-            'but this activity will not be shown on your GitHub or OpenTree profiles '+
-            '(and cannot be linked back at a later date). See '+
-            '<a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>'+
-            'the help page</a> for details.'
+          $('#save-collection-noemail-warning').hide();
         }
-
-        $('#save-collection-comment-noemail-warning').val(warningNoEmailMsg);
 
         $('#save-collection-comments-popup').modal('show');
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1334,13 +1334,23 @@ function promptForSaveCollectionComments( collection ) {
         $('#save-collection-comment-first-line').val(firstLine);
         $('#save-collection-comment-more-lines').val(moreLines);
 
-        if (userEmail != 'ANONYMOUS') {
-          // console.log('email: '+ userEmail);
-          $('#save-collection-comments-popup').modal('show');
-        }
-        else {
-          $('#save-collection-comments-popup-no-email').modal('show');
-        }
+        // include a warning message if the user has no public email
+        // var warningNoEmailMsg = ""
+        // if (userEmail != 'ANONYMOUS') {
+        //   // console.log('email: '+ userEmail);
+        // }
+        // else {
+        //   warningNoEmailMsg = '<strong>Warning</strong>: You have not provided a '+
+        //     'public email address in your GitHub profile. You can still edit data'+
+        //     'but this activity will not be shown on your GitHub or OpenTree profiles '+
+        //     '(and cannot be linked back at a later date). See '+
+        //     '<a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>'+
+        //     'the help page</a> for details.'
+        // }
+        //
+        // $('#save-collection-comment-warning-msg').val(warningNoEmailMsg);
+
+        $('#save-collection-comments-popup').modal('show');
 
         // buttons there do the remaining work
         $('#save-collection-comments-submit')

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2224,16 +2224,26 @@ function validateFormData() {
 }
 
 function promptForSaveComments() {
-    // show a modal popup to gather comments (or cancel)
-    // check for valid user email address and show modal with warning if none
-    if (userEmail != 'ANONYMOUS') {
-      console.log('email: '+ userEmail);
-      $('#save-comments-popup').modal('show');
-    }
-    else {
-      $('#save-comments-popup-no-email').modal('show');
-    }
-    // buttons there do the remaining work
+  // show a modal popup to gather comments (or cancel)
+
+  //include a warning message if the user has no public email
+  var warningNoEmailMsg = ""
+  if (userEmail != 'ANONYMOUS') {
+    // console.log('email: '+ userEmail);
+  }
+  else {
+    warningNoEmailMsg = '<strong>Warning</strong>: You have not provided a '+
+      'public email address in your GitHub profile. You can still edit data'+
+      'but this activity will not be shown on your GitHub or OpenTree profiles '+
+      '(and cannot be linked back at a later date). See '+
+      '<a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>'+
+      'the help page</a> for details.'
+  }
+
+  $('#save-comment-noemail-warning').val(warningNoEmailMsg);
+
+  $('#save-comments-popup').modal('show');
+  // buttons there do the remaining work
 }
 
 function promptForDeleteComments() {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2225,7 +2225,14 @@ function validateFormData() {
 
 function promptForSaveComments() {
     // show a modal popup to gather comments (or cancel)
-    $('#save-comments-popup').modal('show');
+    // check for valid user email address and show modal with warning if none
+    if (userEmail != 'ANONYMOUS') {
+      console.log('email: '+ userEmail);
+      $('#save-comments-popup').modal('show');
+    }
+    else {
+      $('#save-comments-popup-no-email').modal('show');
+    }
     // buttons there do the remaining work
 }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2225,22 +2225,15 @@ function validateFormData() {
 
 function promptForSaveComments() {
   // show a modal popup to gather comments (or cancel)
+  // console.log('email: '+ userEmail);
 
   //include a warning message if the user has no public email
-  var warningNoEmailMsg = ""
-  if (userEmail != 'ANONYMOUS') {
-    // console.log('email: '+ userEmail);
+  if (userEmail == 'ANONYMOUS') {
+    $('#save-study-noemail-warning').show();
   }
   else {
-    warningNoEmailMsg = '<strong>Warning</strong>: You have not provided a '+
-      'public email address in your GitHub profile. You can still edit data'+
-      'but this activity will not be shown on your GitHub or OpenTree profiles '+
-      '(and cannot be linked back at a later date). See '+
-      '<a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>'+
-      'the help page</a> for details.'
+    $('#save-study-noemail-warning').hide();
   }
-
-  $('#save-comment-noemail-warning').val(warningNoEmailMsg);
 
   $('#save-comments-popup').modal('show');
   // buttons there do the remaining work

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -941,9 +941,9 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
     </div>
     <p>
-        <div class="help-box"><strong>Warning</strong>: You have not provided a public email
-          address in your GitHub profile. Without a public email, you can
-          still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+        <div class="help-box"><strong>Warning</strong>: You have not provided a
+          public email address in your GitHub profile. You can still edit data, but this activity will not be shown on your GitHub or OpenTree profiles (and cannot be
+          linked back at a later date). See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
         </div>
     </p>
     <div class="modal-footer">

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -914,38 +914,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         </p>
         <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+        <!--<p id="save-collection-comment-warning-msg" class="help-box"></p>-->
     </div>
-    <div class="modal-footer">
-      <button id="save-collection-comments-submit"
-              class="btn btn-info pull-right" style="margin-left: 20px;"
-              onclick="return false;">Save Collection</button>
-      <a id="save-collection-comments-cancel" data-dismiss="modal" class="btn" >Cancel</a>
-    </div>
-</div>
-
-<!-- hidden template for gathering comments when saving a tree collection -->
-<!-- this version includes warning for curators without public email addys -->
-<div class="modal hide fade modal-save-comments" id="save-collection-comments-popup-no-email" style="display: none;">
-    <div class="modal-header">
-      <a data-dismiss="modal" class="close">×</a>
-      <h3 id='dialog-heading'>
-         Add a comment for these changes
-      </h3>
-    </div>
-    <div class="modal-body">
-        <p>
-            Add a brief description of the work you've done.
-            This will appear in this collection's history on GitHub.
-        </p>
-        <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
-        <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
-    </div>
-    <p>
-        <div class="help-box"><strong>Warning</strong>: You have not provided a
-          public email address in your GitHub profile. You can still edit data, but this activity will not be shown on your GitHub or OpenTree profiles (and cannot be
-          linked back at a later date). See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
-        </div>
-    </p>
     <div class="modal-footer">
       <button id="save-collection-comments-submit"
               class="btn btn-info pull-right" style="margin-left: 20px;"
@@ -977,7 +947,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       <a id="delete-collection-comments-cancel" data-dismiss="modal" class="btn" >Cancel</a>
     </div>
 </div>
-
 
 {{ if ('maintenance_info' in locals()) and maintenance_info.get('maintenance_notice', None):
    # N.b. Check to make sure it's in the view-dict, or error pages etc. will fail }}

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -914,7 +914,14 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         </p>
         <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
-        <p id="save-collection-comment-noemail-warning" class="help-box"></p>
+        <p id="save-collection-noemail-warning" class="help-box">
+          <strong>Warning</strong>: You have not provided a public email address
+            in your GitHub profile. You can still edit data but this activity
+            will not be shown on your GitHub or OpenTree profiles (and cannot be
+            linked back at a later date). See
+            <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub target="_blank">
+            the help page</a> for details.
+        </p>
     </div>
     <div class="modal-footer">
       <button id="save-collection-comments-submit"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -918,7 +918,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
             in your GitHub profile. You can still edit data but this activity
             will not be shown on your GitHub or OpenTree profiles (and cannot be
             linked back at a later date). See
-            <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub target="_blank">
+            <a href="https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub" target="_blank">
             the help page</a> for details.
         </p>
     </div>

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -914,7 +914,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         </p>
         <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
-        <!--<p id="save-collection-comment-warning-msg" class="help-box"></p>-->
+        <p id="save-collection-comment-noemail-warning" class="help-box"></p>
     </div>
     <div class="modal-footer">
       <button id="save-collection-comments-submit"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -899,6 +899,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
   </div><!-- end of #tree-collection-viewer.modal- -->
 
 <!-- hidden template for gathering comments when saving a tree collection -->
+<!-- this version for cases where we have valid email addy for curator -->
 <div class="modal hide fade modal-save-comments" id="save-collection-comments-popup" style="display: none;">
     <div class="modal-header">
       <a data-dismiss="modal" class="close">×</a>
@@ -914,6 +915,37 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
         <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
     </div>
+    <div class="modal-footer">
+      <button id="save-collection-comments-submit"
+              class="btn btn-info pull-right" style="margin-left: 20px;"
+              onclick="return false;">Save Collection</button>
+      <a id="save-collection-comments-cancel" data-dismiss="modal" class="btn" >Cancel</a>
+    </div>
+</div>
+
+<!-- hidden template for gathering comments when saving a tree collection -->
+<!-- this version includes warning for curators without public email addys -->
+<div class="modal hide fade modal-save-comments" id="save-collection-comments-popup-no-email" style="display: none;">
+    <div class="modal-header">
+      <a data-dismiss="modal" class="close">×</a>
+      <h3 id='dialog-heading'>
+         Add a comment for these changes
+      </h3>
+    </div>
+    <div class="modal-body">
+        <p>
+            Add a brief description of the work you've done.
+            This will appear in this collection's history on GitHub.
+        </p>
+        <input type="text" id="save-collection-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
+        <textarea id="save-collection-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+    </div>
+    <p>
+        <div class="help-box"><strong>Warning</strong>: You have not provided a public email
+          address in your GitHub profile. Without a public email, you can
+          still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+        </div>
+    </p>
     <div class="modal-footer">
       <button id="save-collection-comments-submit"
               class="btn btn-info pull-right" style="margin-left: 20px;"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -899,7 +899,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
   </div><!-- end of #tree-collection-viewer.modal- -->
 
 <!-- hidden template for gathering comments when saving a tree collection -->
-<!-- this version for cases where we have valid email addy for curator -->
 <div class="modal hide fade modal-save-comments" id="save-collection-comments-popup" style="display: none;">
     <div class="modal-header">
       <a data-dismiss="modal" class="close">×</a>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2104,37 +2104,8 @@ body {
         </p>
         <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
-    </div>
-    <div class="modal-footer">
-      <button class="btn btn-info pull-right" style="margin-left: 20px;"
-              onclick="$('#save-comments-popup').modal('hide'); saveFormDataToStudyJSON(); return false;">Save Study</button>
-      <a data-dismiss="modal" class="btn" >Cancel</a>
-    </div>
-</div>
-
-<!-- hidden template for gathering comments when saving the study -->
-<!-- this version when we don't have user email and want to show warning -->
-<div class="modal hide fade modal-save-comments" id="save-comments-popup-no-email" style="display: none;">
-    <div class="modal-header">
-      <a data-dismiss="modal" class="close">×</a>
-      <h3 id='dialog-heading'>
-         Add a comment for these changes
-      </h3>
-    </div>
-    <div class="modal-body">
-        <p>
-            Add a brief description of the work you've done.
-            This will appear in the History tab.
-        </p>
-        <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
-        <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
-          <p>
-              <div class="help-box"><strong>Warning</strong>: You have not provided a public email
-                address in your GitHub profile. You can still edit data, but this activity will not be shown on your GitHub or OpenTree profiles (and cannot be
-                linked back at a later date). See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
-              </div>
-          </p>
-    </div>
+        <p id="save-comment-noemail-warning" class="help-box"></p>
+  </div>
     <div class="modal-footer">
       <button class="btn btn-info pull-right" style="margin-left: 20px;"
               onclick="$('#save-comments-popup').modal('hide'); saveFormDataToStudyJSON(); return false;">Save Study</button>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2089,7 +2089,6 @@ body {
 </div>
 
 <!-- hidden template for gathering comments when saving the study -->
-<!-- this version when we have user email -->
 <div class="modal hide fade modal-save-comments" id="save-comments-popup" style="display: none;">
     <div class="modal-header">
       <a data-dismiss="modal" class="close">×</a>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2104,7 +2104,14 @@ body {
         </p>
         <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
-        <p id="save-comment-noemail-warning" class="help-box"></p>
+        <p id="save-study-noemail-warning" class="help-box">
+          <strong>Warning</strong>: You have not provided a public email address
+            in your GitHub profile. You can still edit data but this activity
+            will not be shown on your GitHub or OpenTree profiles (and cannot be
+            linked back at a later date). See
+            <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub target="_blank">
+            the help page</a> for details.
+        </p>
   </div>
     <div class="modal-footer">
       <button class="btn btn-info pull-right" style="margin-left: 20px;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2089,6 +2089,7 @@ body {
 </div>
 
 <!-- hidden template for gathering comments when saving the study -->
+<!-- this version when we have user email -->
 <div class="modal hide fade modal-save-comments" id="save-comments-popup" style="display: none;">
     <div class="modal-header">
       <a data-dismiss="modal" class="close">×</a>
@@ -2103,6 +2104,36 @@ body {
         </p>
         <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
         <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-info pull-right" style="margin-left: 20px;"
+              onclick="$('#save-comments-popup').modal('hide'); saveFormDataToStudyJSON(); return false;">Save Study</button>
+      <a data-dismiss="modal" class="btn" >Cancel</a>
+    </div>
+</div>
+
+<!-- hidden template for gathering comments when saving the study -->
+<!-- this version when we don't have user email and want to show warning -->
+<div class="modal hide fade modal-save-comments" id="save-comments-popup-no-email" style="display: none;">
+    <div class="modal-header">
+      <a data-dismiss="modal" class="close">×</a>
+      <h3 id='dialog-heading'>
+         Add a comment for these changes
+      </h3>
+    </div>
+    <div class="modal-body">
+        <p>
+            Add a brief description of the work you've done.
+            This will appear in the History tab.
+        </p>
+        <input type="text" id="save-comment-first-line" class="input-block-level" maxlength="50" placeholder="Add a one-line summary (50 chars max)"/>
+        <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+          <p>
+              <div class="help-box"><strong>Warning</strong>: You have not provided a public email
+                address in your GitHub profile. Without a public email, you can
+                still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+              </div>
+          </p>
     </div>
     <div class="modal-footer">
       <button class="btn btn-info pull-right" style="margin-left: 20px;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2108,7 +2108,7 @@ body {
             in your GitHub profile. You can still edit data but this activity
             will not be shown on your GitHub or OpenTree profiles (and cannot be
             linked back at a later date). See
-            <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub target="_blank">
+            <a href="https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub" target="_blank">
             the help page</a> for details.
         </p>
   </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2130,8 +2130,8 @@ body {
         <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
           <p>
               <div class="help-box"><strong>Warning</strong>: You have not provided a public email
-                address in your GitHub profile. Without a public email, you can
-                still curate studies, but that activity will not be shown on your               GitHub or OpenTree profiles. See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
+                address in your GitHub profile. You can still edit data, but this activity will not be shown on your GitHub or OpenTree profiles (and cannot be
+                linked back at a later date). See <a href=https://github.com/OpenTreeOfLife/opentree/wiki/OpenTree-user-accounts-and-GitHub>the help page</a> for details.
               </div>
           </p>
     </div>


### PR DESCRIPTION
OK, I think I finally have this working. Live on dev. To test:

* with public email, save study and / or collection. There shouldn't be any warnings on the comment popup
* go to your github profile and set the Public email field to 'Do not show my email address'. Save your profile changes
* on devtree, log out and log back in again. Refresh the page just to be sure, too
* save a study or a collection. You should get a warning message on the comment popup.

Sample commits:

* study [with](https://github.com/OpenTreeOfLife/phylesystem-0/commit/dd7b6929328698cb5cd9249c8bc6fc04be6c49ef) and [without](https://github.com/OpenTreeOfLife/phylesystem-0/commit/8db9ef65aa246a5c3e0369051f03f07deaaecd66) public email
* collection [with](https://github.com/OpenTreeOfLife/collections-0/commit/51d6795c1d70aee26944679343e60bd590599031) and [without](https://github.com/OpenTreeOfLife/collections-0/commit/5466884804091d04c3fe7ace001b5e4796491530) public email