### PR TITLE
Misc collection fixes (direct and history URLs)

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1224,6 +1224,13 @@ addPendingCollectionChange( 'REORDER' );
 compressPendingCollectionChanges();
 */
 
+function shareCollection( collection ) {
+    // provide a direct URL to the collection (to copy/paste or email)
+    var collectionID = getCollectionIDFromURL( collection.data.url );
+    var directURL = window.location.protocol +'//'+ window.location.hostname +'/curator/collections/'+ collectionID;
+    window.prompt("This URL will open the current collection automatically (no login required).", directURL);
+}
+
 function copyCollection( collection ) {
     // create a user-owned copy (or login if user is anonymous)
     if (userIsLoggedIn()) {

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -706,7 +706,7 @@ $(window).resize( function () {
 });
 
 // Use a known-good URL fragment to extract a collection ID from its API URL
-var collectionURLSplitterAPI = '/v2/collection/';
+var collectionURLSplitterAPI = '/collection/';
 // Fall back to raw-data URL in some cases
 var collectionURLSplitterRaw = '/collections/';
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1224,11 +1224,25 @@ addPendingCollectionChange( 'REORDER' );
 compressPendingCollectionChanges();
 */
 
-function shareCollection( collection ) {
+function getCollectionDirectURL( collection ) {
     // provide a direct URL to the collection (to copy/paste or email)
     var collectionID = getCollectionIDFromURL( collection.data.url );
     var directURL = window.location.protocol +'//'+ window.location.hostname +'/curator/collections/'+ collectionID;
+    return directURL;
+}
+function shareCollection( collection ) {
+    var directURL = getCollectionDirectURL(collection);
     window.prompt("This URL will open the current collection automatically (no login required).", directURL);
+}
+
+function getCollectionHistoryURL( collection ) {
+    // provide a URL to the collection on GitHub (for full history)
+    // ASSUMES that its 'external_url' property points to the JSON file on 'raw.githubusercontent.com'
+    // ASSUMES that collection is currently on branch 'master'
+    var historyURL = collection.external_url
+                        .replace('raw.githubusercontent.com', 'github.com')
+                        .replace('master','commits/master');
+    return historyURL;
 }
 
 function copyCollection( collection ) {

--- a/curator/static/js/tree-collection-dashboard.js
+++ b/curator/static/js/tree-collection-dashboard.js
@@ -129,6 +129,40 @@ $(document).ready(function() {
         initialState.nudge = new Date().getTime();
         History.replaceState(initialState, window.document.title, window.location.href);
     }
+
+    /* Extract collection ID from URL, which could look like any of these patterns:
+     *   /curator/collections/jimallman/newtest-3
+     *   /curator/collections/jimallman/newtest-3#foo
+     *   /curator/collections/jimallman/newtest-3/
+     *   /curator/collections/jimallman/newtest-3/#foo
+     *   /curator/collections/jimallman/newtest-3?match=micro
+     *   /curator/collections/jimallman/newtest-3?match=micro#foo
+     *   /curator/collections/jimallman/newtest-3/?match=micro
+     *   /curator/collections/jimallman/newtest-3/?match=micro#foo
+     * N.B. So far, hashes don't seem to matter much here.
+     */
+    var trailingPath = window.location.pathname.split('/collections/')[1];
+    // strip final slash, if any
+    trailingPath = trailingPath.split(/\/$/)[0];
+    // check for a valid collection ID, in the form '{user-id}/{collection-id}'
+    var collectionID = null;
+    if (trailingPath) {
+        var trailingPathParts = trailingPath.split('/');
+        if ((trailingPathParts.length === 2) && trailingPathParts[0] && trailingPathParts[1]) {
+            // it looks like this is a proper collection ID
+            collectionID = trailingPath;
+            ///console.warn("Found this collection ID ["+ collectionID +"]");
+        } else {
+            ///console.warn("Trailing path, but it's not a proper collection ID! ["+ trailingPath +"]");
+        }
+    } else {
+        ; ///console.warn("NO trailing path, therefore no inbound collection ID!");
+    }
+    if (collectionID) {
+        // TODO: Open this collection (and hide any other, IF changes are saved)
+        fetchAndShowCollection(collectionID);
+    }
+
 });
 
 function loadCollectionList(option) {

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -548,14 +548,12 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       </h3>
       <div style="color: #999; position: relative;">
         <p style="position: absolute; width: 170px; text-align: right;">
-            Collection ID:
+            Collection ID (direct link):
         </p>
         <p style="margin-left: 180px;">
-            <span id="collection-id-display"
-                  data-bind="text: getCollectionIDFromURL($data.data.url)">&nbsp;</span>
-           <!-- ko if: ('external_url' in $data) -->
-            <a data-bind="attr: { href: $data['external_url'] }" target="_blank">(on GitHub)</a>
-           <!-- /ko -->
+            <a id="collection-id-display"
+               data-bind="text: getCollectionIDFromURL($data.data.url),
+                          attr: { href: getCollectionDirectURL($data) }">&nbsp;</a>
         </p>
       </div>
     </div>
@@ -563,7 +561,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       <div class="tab-pane active">
           <form class="form-inline"
                 style="overflow: hidden; margin-bottom: 0px; margin-top: -12px; padding-top: 12px; margin-right: -6px;">
-           <div class="collection-actions">
+           <div class="collection-actions" style="padding-right: 8px;">
             <!-- action buttons, from right to left -->
 
            <!-- ko if: userIsEditingCollection($data) -->
@@ -578,8 +576,21 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
             -->
            <!-- /ko -->
 
+           <!-- ko if: ('external_url' in $data) -->
+            <!-- HISTORY button -->
+            <a data-bind="attr: { href: getCollectionHistoryURL($data) }"
+               title="See full version history on GitHub"
+               class="pull-right btn btn-mini row-controls-ghosted"
+               style="margin-left: 4px;"
+               href="#" target="_blank">
+               History 
+               <img src="/curator/static/images/GitHub-Mark-32px.png" 
+                    style="width: 14px; height: 14px; padding-left: 2px; margin-top: -2px;"/>
+            </a>
+           <!-- /ko -->
+
            <!-- ko if: !userIsEditingCollection($data) -->
-            <!-- DUPLICATE button -->
+            <!-- SHARE button -->
             <button data-bind="click: shareCollection,
                                visible: true"
                 title="Show the direct URL for this collection"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -580,13 +580,12 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
 
            <!-- ko if: !userIsEditingCollection($data) -->
             <!-- DUPLICATE button -->
-            <button data-bind="click: copyCollection,
-                                visible: true,
-                                attr: {'title': userIsLoggedIn() ? 'Copy this collection (you will own the copy)' : 'Copy this collection (requires login)'}"
-                title=""
+            <button data-bind="click: shareCollection,
+                               visible: true"
+                title="Show the direct URL for this collection"
                 class="pull-right btn btn-mini row-controls-ghosted"
                 style="margin-left: 4px;">
-                <i class="icon-share"></i>
+                Share <i class="icon-share"></i>
             </button>
 
            <!-- ko if: ('external_url' in $data) -->
@@ -596,7 +595,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                class="pull-right btn btn-mini row-controls-ghosted"
                style="margin-left: 4px;"
                href="#" target="_blank">
-                <i class="icon-download"></i>
+               Download <i class="icon-download"></i>
             </a>
            <!-- /ko -->
 
@@ -609,6 +608,16 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                 <i class="icon-list-alt"></i>
             </button>
             -->
+
+            <!-- DUPLICATE button -->
+            <button data-bind="click: copyCollection,
+                                visible: true,
+                                attr: {'title': userIsLoggedIn() ? 'Copy this collection (you will own the copy)' : 'Copy this collection (requires login)'}"
+                title=""
+                class="pull-right btn btn-mini row-controls-ghosted"
+                style="margin-left: 4px;">
+                Save a copy <i class="icon-repeat"></i>
+            </button>
            <!-- /ko -->
 
             <!-- EDIT button -->


### PR DESCRIPTION
Add support for a "direct URL" for each collection, and another to its history in GitHub. Revise collection popup UI to show these URLs. See commit messages for details. This is all working now on **devtree**.