### PR TITLE
Restore missing side panels in zoomed browsers.

### DIFF
--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -104,7 +104,7 @@ div.viewer-frame {
 
 /* slide these using marker classes on #viewer-collection */
 .active-comments #comments-panel {   
-    margin-left: 0; 
+    margin-left: -1px;  /* ensures visibility in scaled browser */
     margin-right: 0; 
 }
 .active-comments div.viewer-frame {
@@ -128,7 +128,7 @@ div.viewer-frame {
 }
 .active-properties #provenance-panel {    
     margin-left: 0;
-    margin-right: 0; 
+    margin-right: -1px;  /* ensures visibility in scaled browser */
 }
 
 /* overrides for tablet-sized displays (matching Bootstrap media queries) */


### PR DESCRIPTION
We've had reports of missing panels (esp. the property panel), often
when resizing the browser window. This turned out to be a
CSS/dimensioning bug in some browsers when set to a non-default zoom
level. Addresses #970.