### PR TITLE
Fix ottid subtree

### DIFF
--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -88,7 +88,7 @@ def download_subtree():
         # use the appropriate web service for this ID type
         fetch_url = method_dict['getDraftSubtree_url']
         if id_type == 'ottol-id':
-            fetch_args = {'ott_id': Number(node_or_ottol_id)}
+            fetch_args = {'ott_id': int(node_or_ottol_id)}
         else:
             fetch_args = {'node_id': node_or_ottol_id}
         fetch_args['format'] = 'newick';

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -87,6 +87,7 @@ def download_subtree():
 
         # use the appropriate web service for this ID type
         fetch_url = method_dict['getDraftSubtree_url']
+        newick_text = 'NEWICK_NOT_FETCHED'
         if id_type == 'ottol-id':
             fetch_args = {'ott_id': int(node_or_ottol_id)}
         else:


### PR DESCRIPTION
Fixed a bogus conversion (Javascript in a Python method!?) to restore fetching subtree Newick from an ottid. Addresses #977.