### PR TITLE
Handle missing GitHub display name

### DIFF
--- a/curator/models/db.py
+++ b/curator/models/db.py
@@ -213,7 +213,8 @@ class GitHubAccount(OAuthAccount):
                                 github_auth_token = access_token,
                                 #   adding more (apparently) standard web2py fields, to make this work..
                                 first_name = user_json['login'],
-                                last_name = ("(%s)" % user_json.get('name', user_json['login'])),
+                                # skip 'name' if it's None!
+                                last_name = ("(%s)" % (user_json['name'] or user_json['login'])),
                                 username = user_json['login'],
                                 #password = 'TOP-SECRET',
                                 registration_key = user_json['login'],  

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -19,7 +19,7 @@ if active_user_found:
                         (<a href="%s" target="_blank"
                            title="Open GitHub profile in a new window"
                            >%s <span style="color: #333;">on GitHub</span></a>)</span>""" % (
-            user_info.get('name', user_info.get('login', '???')),
+            user_info['name'] or user_info.get('login', '???'),
             user_info.get('html_url'),
             user_info.get('login'),
         )

--- a/webapp/models/db.py
+++ b/webapp/models/db.py
@@ -207,7 +207,8 @@ class GitHubAccount(OAuthAccount):
                                 github_auth_token = access_token,
                                 #   adding more (apparently) standard web2py fields, to make this work..
                                 first_name = user_json['login'],
-                                last_name = ("(%s)" % user_json.get('name', user_json['login'])),
+                                # skip 'name' if it's None!
+                                last_name = ("(%s)" % (user_json['name'] or user_json['login'])),
                                 username = user_json['login'],
                                 #password = 'TOP-SECRET',
                                 registration_key = user_json['login'],  

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -141,9 +141,9 @@ def get_user_display_name():
     if auth.user.name:
         # this is a preset display name
         return auth.user.name
-    if auth.user.first_name and auth.user.last_name:
-        # combined first and last is also good
-        return '%s %s' % (auth.user.first_name, auth.user.last_name,)
+    # N.B. that auth.user.first_name and auth.user.last_name fields are not
+    # reliable in our apps! They're included for web2py compatibility, but we
+    # defer to the GitHub User API and use the 'name' field for this.
     if auth.user.username:
         # compact userid is our last resort
         return auth.user.username


### PR DESCRIPTION
An empty display name (in curator's GitHub profile) was creating a few bugs in our webapps:

 - goofy user name like "jimallman (None)" in the site header
 - the same pseudo-name saved in Nexson's `^ot:curatorName` field
 - ... and so appearing in the study list (on the curation home page)

Fixes #982 