### PR TITLE
Force explicit time-unit choice, add Kyr and coalescent units

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2384,10 +2384,11 @@ body {
 
                 <span data-bind="visible: viewModel.ticklers.TREES() && $data['^ot:branchLengthMode'] === 'ot:time'" >
                     <label style="margin-left: 10px;">Time unit: </label>
-                    <select data-bind="options: ['Myr'],
-                        value: $data['^ot:branchLengthTimeUnit'],
-                        event: { keyup: nudge.TREES, change: nudge.TREES },
-                        css: viewModel.ticklers.TREES
+                    <select data-bind="options: ['Myr'], 
+                                       optionsCaption: 'Choose a unit of time...',
+                                       value: $data['^ot:branchLengthTimeUnit'],
+                                       event: { keyup: nudge.TREES, change: nudge.TREES },
+                                       css: viewModel.ticklers.TREES
                         ">TYPE</select>
                 </span>
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2384,7 +2384,7 @@ body {
 
                 <span data-bind="visible: viewModel.ticklers.TREES() && $data['^ot:branchLengthMode'] === 'ot:time'" >
                     <label style="margin-left: 10px;">Time unit: </label>
-                    <select data-bind="options: ['Myr'], 
+                    <select data-bind="options: ['Myr', 'Kyr', 'Coalescent time units'], 
                                        optionsCaption: 'Choose a unit of time...',
                                        value: $data['^ot:branchLengthTimeUnit'],
                                        event: { keyup: nudge.TREES, change: nudge.TREES },


### PR DESCRIPTION
This includes a fix for #985 (forces an explicit choice of time units) and adds options for 'Kyr' and 'Coalescent time units' (see related discussion at #987). This is available for review on **devtree**.