### PR TITLE
add extinct as feedback option per https://github.com/OpenTreeOfLife/…

### DIFF
--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -72,6 +72,7 @@ function capture_form() {
                 break;
             case 'Correction to relationships in the synthetic tree':
             case 'Correction to names (taxonomy)':
+            case 'Extinct/extant issue (taxonomy)':
                 $referenceURLField.attr('placeholder',"Provide a supporting article or web site (URL or DOI)");
                 $referenceURLField.show();
                 break;
@@ -588,6 +589,7 @@ def index():
                             OPTION('Correction to relationships in the synthetic tree'),
                             OPTION('Suggest a phylogeny to incorporate'),
                             OPTION('Correction to names (taxonomy)'),
+                            OPTION('Extinct/extant issue (taxonomy)'),
                             OPTION('Bug report (website behavior)'),
                             OPTION('New feature request'),
                         _name='feedback_type',value='',_style='width: 100%; margin-right: -4px;'),

--- a/webapp/views/plugin_localcomments/moderation.html
+++ b/webapp/views/plugin_localcomments/moderation.html
@@ -73,6 +73,9 @@ from gluon.contrib.markdown.markdown2 import markdown
             <li>
                 <a href="#" onclick="alert('TODO'); return false;">Feature request</a>
             </li>
+            <li>
+                <a href="#" onclick="alert('TODO'); return false;">Extinct/extant issue</a>
+            </li>
         </ul>
     </div>
     <div class="btn-group" style="float: left; margin-right: 5px;">


### PR DESCRIPTION
For motivation see https://github.com/OpenTreeOfLife/feedback/issues/59.  We currently have 4 open and 8 closed feedback issues simply noting that a taxon is extinct, and we should encourage people to submit lots more of them. Feel free to wordsmith and so on.