### PR TITLE
Show support and conflict relations

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2,6 +2,9 @@
  * Utilities common to multiple pages in the OpenTree study-curation tool.
  */
 
+// converts full reference to short reference for display purposes
+// duplicates function with same name in webapp/static/js/treeview.js,
+// so changes need to be made in both places
 function fullToCompactReference( fullReference ) {
     var compactReference = "(Untitled)";
     if ($.trim(fullReference) !== "") {
@@ -818,7 +821,7 @@ function searchForMatchingStudy() {
     var searchText = $.trim( $input.val() );
     var searchTokens = tokenizeSearchTextKeepingQuotes(searchText);
 
-    if ((searchTokens.length === 0) || 
+    if ((searchTokens.length === 0) ||
         (searchTokens.length === 1 && searchTokens[0].length < 2)) {
         $('#study-lookup-results').html('<li class="disabled"><a><span class="text-error">Enter two or more characters to search</span></a></li>');
         return false;

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1,5 +1,5 @@
-/*    
-@licstart  The following is the entire license notice for the JavaScript code in this page. 
+/*
+@licstart  The following is the entire license notice for the JavaScript code in this page.
 
     Copyright (c) 2013, Cody Hinchliff
     Copyright (c) 2013, Joseph W. Brown
@@ -133,7 +133,7 @@ function createArgus(spec) {
         "minTipRadius": 5, // the minimum radius of the node/tip circles. "r" in old argus
         "nodeDiamScalar": 1.0,  // how much internal nodes are scaled by logleafcount
         "nodesWidth": 100, // the distance between parent/child nodes
-            // TODO: try a wider setting (180?), or adapt to screen-width  
+            // TODO: try a wider setting (180?), or adapt to screen-width
         "nubDistScalar": 4, // the x/y distance of the nub from its child
         "tipOffset": 300,  // distance from right margin at which leaf nodes are drawn
         "xLabelMargin": 10, // the distance of the labels from the nodes
@@ -215,7 +215,7 @@ function createArgus(spec) {
         getArgusNodeByID: function ( nodeID ) {
             // NOTE depends on treeview.js methods
             return getTreeDataNode( function(node) {
-                return (node.node_id === nodeID); 
+                return (node.node_id === nodeID);
             });
         },
         // TODO: add a method to get node by OTT id?
@@ -239,7 +239,7 @@ function createArgus(spec) {
 
 
     argusObj.nodeHeight = (2 * argusObj.minTipRadius) + argusObj.yNodeMargin;
-    // helper function to create the URL and arg to be passed to URL. 
+    // helper function to create the URL and arg to be passed to URL.
     //  Argument:
     //      o.nodeID
     //      o.domSource (default "ottol")  @TEMP will need to be modified for cases when ottol is not the value
@@ -359,7 +359,7 @@ function createArgus(spec) {
                 // (where 0 = the right-most (leaf nodes) column, higher = further left)
                 node.treeColumn = node.isLocalLeafNode() ? 0 : (argusObj.treeData.max_node_depth - node.nodeDepth);
                 // TODO: pre-calculate node.x from this, if it never changes..?
-                
+
                 if (node.children) {
                     // sort and cluster children to build its display list
 
@@ -378,7 +378,8 @@ function createArgus(spec) {
                     // group children based on type of edge support
                     for (var i = 0; i < nchildren; i++) {
                         var testChild = node.children[i],
-                            sb = testChild.supported_by;
+                            sb = getSupportingSourceIDs(testChild);
+                            //sb = testChild.supported_by;
                         testChild.supportedByTaxonomy = (argus.supportingTaxonomyVersion in sb);
                         testChild.supportedByPhylogeny = Object.keys(sb).length > (testChild.supportedByTaxonomy ? 1 : 0);
 
@@ -393,7 +394,7 @@ function createArgus(spec) {
                     var nWithHybrid = nodesWithHybridSupport.length,
                         nWithPhylo = nodesWithPhyloSupport.length,
                         nWithoutPhylo = nodesWithoutPhyloSupport.length;
-                                                
+
                     // mark some less-interesting nodes for clustering
                     //
                     // sort first by number of descendants, so we always show the most
@@ -406,7 +407,7 @@ function createArgus(spec) {
                         nClusteredRemaining,
                         currentCluster = null,
                         nInCurrentCluster = 0;
-                    
+
                     // re-sort the smaller ones by name, then sort into clusters
                     clusteredNodes.sort(alphaSortByName);
 
@@ -431,7 +432,7 @@ function createArgus(spec) {
                                     clusters[node.node_id].push(newCluster);
                                     currentCluster = newCluster;
                                     nInCurrentCluster = 0;
-                                } 
+                                }
                                 // else toss the remaining few children into the last cluster
                             }
                         }
@@ -455,7 +456,7 @@ function createArgus(spec) {
                         nInCurrentCluster++;
                     }
                     // use names to label each cluster alphabetically
-                                                
+
                     // Use these groups and clusters to draw children
                     node.displayList = nodesWithHybridSupport.concat( nodesWithPhyloSupport );
 
@@ -487,7 +488,7 @@ function createArgus(spec) {
             };
 
             // clear the cluster registry first
-            argusObj.clusters = {}; 
+            argusObj.clusters = {};
 
             // recursively populate any missing (implied) node names
             buildAllMissingNodeNames(node);
@@ -533,7 +534,7 @@ function createArgus(spec) {
             defaultPaperWidth = paper.width;
             defaultPaperHeight = paper.height;
             setZoom();
-            
+
             // add dividers before anything else
             dividerBeforeEdges = paper.text(0,0,'');
             dividerBeforeLabels = paper.text(0,0,'');
@@ -546,7 +547,7 @@ function createArgus(spec) {
                 argusObj.anchoredControls = paper.set();
             }
 
-            /* 
+            /*
             // if we need a larger, shared background
             anchoredbg = paper.rect(0,0,120,90).attr({
                 "fill": this.bgColor,
@@ -580,7 +581,7 @@ function createArgus(spec) {
                     "cursor": "pointer"
                 }).insertBefore(dividerBeforeNodes)
             );
-            
+
             argusObj.provenanceHighlight.push(
               // Draw a lozenge shape, centered on its right focus
               // see http://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
@@ -612,7 +613,7 @@ function createArgus(spec) {
             argusObj.provenanceHighlight.hide();
 
             argusObj.provenanceHighlight.hover(
-                getHoverHandlerProvenanceHighlight('OVER', argusObj.provenanceHighlight, {}), 
+                getHoverHandlerProvenanceHighlight('OVER', argusObj.provenanceHighlight, {}),
                 getHoverHandlerProvenanceHighlight('OUT', argusObj.provenanceHighlight, { })
             );
             var handler = getClickHandlerProvenanceHighlight(); // just once!
@@ -658,7 +659,7 @@ function createArgus(spec) {
                         errMsg = 'Sorry, there was an error checking for taxon status.';
                         showErrorInArgusViewer(errMsg);
                         return;
-                    } 
+                    }
                     // check to see if we got a taxon record, or an error in JSON
                     var json = $.parseJSON(jqXHR.responseText);
                     // if (json['ott_id'] === ottID) { TODO: use this when we switch to v3 taxonomy API!
@@ -690,7 +691,7 @@ function createArgus(spec) {
             context: argusObj,
             crossDomain: true,
             contentType: 'application/json',
-            converters: { 
+            converters: {
                 // serialize this JSON into dedicated pseudo-classes
                 'text nodeTree': function(data) {
                     ///console.log(">>> pre-processing raw JSON string..." );
@@ -731,7 +732,7 @@ function createArgus(spec) {
 
         if (paper !== undefined) {
             $(this.container).unbind("scroll");
-            if (argusObj.anchoredControls) { 
+            if (argusObj.anchoredControls) {
                 argusObj.anchoredControls.remove();
                 argusObj.anchoredControls.clear();
             }
@@ -777,7 +778,7 @@ function createArgus(spec) {
                     nodeCircle = paper.getById('node-circle-'+ srcInfo.nodeID);
                     edgePath = targetShape;
                     break;
-                    
+
                 default:
                     console.warn("getHoverHandlerNodeAndEdge(): Unexpected type for targetShape: '"+ targetShape.type +"'!");
                     return;
@@ -789,10 +790,10 @@ function createArgus(spec) {
                     // copy source-node values from the target node to the highlight
 
                     argusObj.highlightedNodeInfo = srcInfo;
-                    
+
                     // move the highlight to this node
                     argusObj.provenanceHighlight.transform('t' + nodeCircle.attr('cx') + ',' + nodeCircle.attr('cy'));
-                    
+
                     if (edgePath) {
                         // move the highlight to this edge
                         // no easy x/y attributes for a path, need to use its bounding box
@@ -800,7 +801,7 @@ function createArgus(spec) {
 
                         argusObj.provenanceHighlight.forEach(function(element) {
                             if (element.type == 'rect') {
-                                var xScale = (bbox.width / 100); 
+                                var xScale = (bbox.width / 100);
                                 var pathScale = 'S '+ xScale +',1  t' + ((bbox.x + (bbox.width / 2.0)) / xScale) + ',' + bbox.y;
                                     // 100 is the natural width of the hilight path
                                 element.transform(pathScale);
@@ -815,7 +816,7 @@ function createArgus(spec) {
                         // hide edge-highlight rect if there's no upward edge
                         argusObj.provenanceHighlight.forEach(function(element) {
                             if (element.type == 'rect') {
-                                element.hide(); 
+                                element.hide();
                             }
                         });
                     }
@@ -858,11 +859,11 @@ function createArgus(spec) {
                     break;
                 case 'OUT':
                     // are we REALLY outside the lozenge, or just over the text?
-                      
+
                     // Test using client/page coordinates, instead of canvas.
                     // (This handles scaling, scrolling, etc. more reliably.)
                     var bbox = getClientBoundingBox( argusObj.provenanceHighlight );
-                    
+
                     if (Raphael.isPointInsideBBox( bbox, evt.pageX, evt.pageY )) {
                         // false alarm, it's just moved over text or the node circle
                         return;
@@ -888,7 +889,7 @@ function createArgus(spec) {
              */
             switch (e.type) {
                 case 'contextmenu':
-                    var urlSafeNodeName = encodeURIComponent(nodeName);  
+                    var urlSafeNodeName = encodeURIComponent(nodeName);
                     var nodeURL = '/opentree/'+ domSource +'@'+ nodeID +'/'+ urlSafeNodeName;
                     var newWindow = window.open( nodeURL, '_blank' );
                     if (newWindow) {
@@ -1005,7 +1006,7 @@ function createArgus(spec) {
             switch (e.type) {
                 case 'contextmenu':
                     var info = argusObj.highlightedNodeInfo;
-                    var urlSafeNodeName = encodeURIComponent(info.nodeName);  
+                    var urlSafeNodeName = encodeURIComponent(info.nodeName);
                     var nodeURL = '/opentree/'+ info.domSource +'@'+ info.nodeID +'/'+ urlSafeNodeName;
                     var newWindow = window.open( nodeURL, '_blank' );
                     if (newWindow) {
@@ -1031,12 +1032,12 @@ function createArgus(spec) {
         if (!parentNodeX) {
             // passed in arg is fastest, but this is now reliable
             var parentNode = argusObj.getArgusNodeByID(node.parentNodeID);
-            parentNodeX = (parentNode) ? 
+            parentNodeX = (parentNode) ?
               argusObj.xOffset - (argusObj.nodesWidth * parentNode.treeColumn) :
-              // if no parent ID, assume it's the local root node 
+              // if no parent ID, assume it's the local root node
               argusObj.xOffset - (argusObj.nodesWidth * argusObj.treeData.treeColumn);
         }
-        var depthFromTargetNode = obj.depthFromTargetNode || 0; 
+        var depthFromTargetNode = obj.depthFromTargetNode || 0;
         var domSource = obj.domSource;
         var fontSize = this.minTipRadius * this.fontScalar;
         var curLeaf = obj.curLeaf;
@@ -1107,7 +1108,7 @@ function createArgus(spec) {
         } else {
             node.r = this.minTipRadius + this.nodeDiamScalar * Math.log(node.num_tips);
         }
-        var nodeFill = this.nodeColor; 
+        var nodeFill = this.nodeColor;
         var nodeStroke = this.pathColor;
         // override for special cases
         if (node.isActualLeafNode()) {
@@ -1115,7 +1116,7 @@ function createArgus(spec) {
             nodeStroke = this.bgColor;
         } else if (node.isVisibleLeafNode()) {
             nodeFill = this.visibleLeafColor;
-        } else if (isTargetNode) { 
+        } else if (isTargetNode) {
             // add special styles for this?
         }
         if (circle) {
@@ -1190,7 +1191,7 @@ function createArgus(spec) {
                 // N.B. this is determined using vars above, COPIED from treeview.js!
                 var isCompoundNodeName = ((typeof node.name === 'string') &&
                                           (node.name.indexOf(compoundNodeNameDelimiter) !== -1) &&
-                                          (node.name.indexOf(compoundNodeNamePrefix) === 0) && 
+                                          (node.name.indexOf(compoundNodeNamePrefix) === 0) &&
                                           (node.name.indexOf(compoundNodeNameSuffix) === (node.name.length -1)));
                 displayLabel = (isCompoundNodeName ? '' : node.name || '');
             }
@@ -1221,12 +1222,13 @@ function createArgus(spec) {
                   .id = (nodeSpineElementID);
             }
         }
-        
+
         if (!isTargetNode) {
             // draw/update its "upward" branch to the parent's spine
             // TODO: nudge (vs create) if this already exists!
             var lineDashes, lineColor,
-                sb = node.supported_by,
+                //sb = node.supported_by,
+                sb = getSupportingSourceIDs(node),
                 supportedByTaxonomy = argus.supportingTaxonomyVersion in sb,
                 supportedByPhylogeny = Object.keys(sb).length > (supportedByTaxonomy ? 1 : 0);
 
@@ -1246,7 +1248,7 @@ function createArgus(spec) {
             }
 
             var branchSt = "M" + parentNodeX + " " + node.y + "L" + node.x + " " + node.y;
-                
+
             if (triggerBranch && visibleBranch) {
                 // update the existing elements
                 triggerBranch.attr({
@@ -1264,7 +1266,7 @@ function createArgus(spec) {
                 }).insertAfter(dividerBeforeEdges);
                 triggerBranch.id = (nodeTriggerBranchElementID);
                 // NOTE that these are pushed behind all visible paths!
-                
+
                 // ... and a congruent, visible path
                 visibleBranch = paper.path(branchSt).toBack().attr({
                     "stroke-width": 1,
@@ -1273,7 +1275,7 @@ function createArgus(spec) {
                     "stroke": lineColor          // this.pathColor
                 }).insertBefore(dividerBeforeLabels);
                 visibleBranch.id = (nodeVisibleBranchElementID);
-                    
+
                 // assign hover behaviors
                 triggerBranch.hover(getHoverHandlerNodeAndEdge('OVER', triggerBranch, {}), getHoverHandlerNodeAndEdge('OUT', triggerBranch, {}));
 
@@ -1330,7 +1332,7 @@ function createArgus(spec) {
 
                     if (i < maxUpwardNodes) {
                         // draw node circle and label
-                        labelX = endX - (this.minTipRadius * 1.25); 
+                        labelX = endX - (this.minTipRadius * 1.25);
                         labelY = endY + (this.minTipRadius * 1.25);
                         if (circle && label) {
                             // update the existing circle and label
@@ -1342,7 +1344,7 @@ function createArgus(spec) {
                                 'x': labelX,
                                 'y': labelY
                             });
-    
+
                         } else {
                             // create the new circle and label
                             circle = paper.circle(endX, endY, this.minTipRadius).attr({
@@ -1428,7 +1430,7 @@ function createArgus(spec) {
         if (box && label) {
             // update the existing box and label
             box.attr({
-                'x': clusterLeftEdge, 
+                'x': clusterLeftEdge,
                 'y': cluster.y - (this.nodeHeight / 2.0)
             });
             label.attr({
@@ -1464,18 +1466,18 @@ function createArgus(spec) {
             // assign behaviors to replace the minimized cluster with its nodes
             var minimizedClusterParts = [branch, minimizedCluster];
             minimizedCluster.click(getClickHandlerCluster(
-                minimizedClusterParts, 
-                parentNodeID, 
+                minimizedClusterParts,
+                parentNodeID,
                 clusterPosition,
                 depthFromTargetNode,
                 domSource,
                 currentYoffset
             ));
-            minimizedCluster.hover(getHoverHandlerCluster('OVER', 
-                box, { "fill": this.nodeColor }, 
+            minimizedCluster.hover(getHoverHandlerCluster('OVER',
+                box, { "fill": this.nodeColor },
                 label, { "fill": 'white' }
-            ), getHoverHandlerCluster('OUT', 
-                box, { "fill": this.bgColor }, 
+            ), getHoverHandlerCluster('OUT',
+                box, { "fill": this.bgColor },
                 label, { "fill": this.labelColor }
             ));
         }
@@ -1610,7 +1612,7 @@ function createArgus(spec) {
             "opacity": (conflictsInView) ? 1.0 : 0.4
         }).insertAfter(dividerBeforeAnchoredUI)
           .click(toggleAltRels(altrelsset));
-                        
+
         argusObj.anchoredControls.push(togglebox);
 
         togglelabel = paper.text(tx + (this.nodesWidth/2),
@@ -1622,18 +1624,18 @@ function createArgus(spec) {
             "title": (conflictsInView) ? conflictLabel : disabledConflictLabel,
             "opacity": (conflictsInView) ? 1.0 : 0.4
         }).insertAfter(dividerBeforeAnchoredUI);
-        
+
         // label on top needs identical action as box
         togglelabel.click(toggleAltRels(altrelsset));
         argusObj.anchoredControls.push(togglelabel);
         */
 
-        /* These are just under-powered history, remove them for now.. 
+        /* These are just under-powered history, remove them for now..
         // add clickable Back and Forward pointers (now redundant with browser Back/Fwd buttons)
         backStackPointer = forwardStackPointer = null;
         backStackPointer = paper.path("M21.871,9.814 15.684,16.001 21.871,22.188 18.335,25.725 8.612,16.001 18.335,6.276z")
             .attr({
-                fill: "#000", 
+                fill: "#000",
                 stroke: "none",
                 cursor: "pointer",
                 title: (argusObj.backStack.length > 0) ? "Show the previous view in history" : "No previous views in history",
@@ -1646,7 +1648,7 @@ function createArgus(spec) {
 
         forwardStackPointer = paper.path("M30.129,22.186 36.316,15.999 30.129,9.812 33.665,6.276 43.389,15.999 33.665,25.725z")
             .attr({
-                fill: "#000", 
+                fill: "#000",
                 stroke: "none",
                 cursor: "pointer",
                 title: (argusObj.forwardStack.length > 0) ? "Show the next view in history" : "No later views in history",
@@ -1672,9 +1674,9 @@ function createArgus(spec) {
         $argusContainer.scrollTop((this.targetNodeY) - ($argusContainer.height() / 2));
 
         // disable default right-click behavior in the argus view
-        $argusContainer.bind("contextmenu", function (e) { 
+        $argusContainer.bind("contextmenu", function (e) {
             e.preventDefault();
-            return false; 
+            return false;
         });
 
         // for each node found to have more than one parent
@@ -1856,10 +1858,10 @@ function sortByDescendantCount(a,b) {
     return 0;
 }
 
-/* Let's deserialize tree-view JSON elements into useful  pseudo-classes. This should 
+/* Let's deserialize tree-view JSON elements into useful  pseudo-classes. This should
  * simplify management of dynamic layouts, clustering, etc.
  */
-function ArgusNode() { // constructor 
+function ArgusNode() { // constructor
     // maintain ordered-and-clustered contents?
     this.nodeDepth = 0;  // 0 = root node, higher for descendants
     this.treeColumn = 0; // 0 = rightmost (leaf nodes), higher = further left
@@ -1907,7 +1909,7 @@ ArgusNode.prototype.updateDisplayBounds = function() {
                 bottomY = Math.max(bottomY, testChild.displayBounds.bottomY);
                 if (i === 0) {
                     firstChildY = testChild.y;
-                } 
+                }
                 if (i === displayListCount - 1) {
                     lastChildY = testChild.y;
                 }
@@ -1925,7 +1927,7 @@ ArgusNode.prototype.updateDisplayBounds = function() {
     return this.displayBounds;
 };
 
-function ArgusCluster() { // constructor 
+function ArgusCluster() { // constructor
     this.nodes = [ ];
     // each cluster is either minimized (default) or expanded
     this.expanded = false;
@@ -1950,9 +1952,9 @@ function getClientBoundingBox( elementSet ) {
     // Takes a RaphaelJS element set, reckons its full bounding box in
     // page/client coordinates.
     var bbox = {
-        x: Number.MAX_VALUE, 
-        y: Number.MAX_VALUE, 
-        x2: Number.MIN_VALUE, 
+        x: Number.MAX_VALUE,
+        y: Number.MAX_VALUE,
+        x2: Number.MIN_VALUE,
         y2: Number.MIN_VALUE
     };
     elementSet.forEach(function(e) {

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -48,25 +48,6 @@ var argus;
 // @TEMP - preserve incoming OTT id and source, so we can demo the Extract Subtree feature
 var incomingOttolID = null;
 
-// gets the sources with the supported_by flag
-function getSupportingSourceIDs( node ) {
-    return $.isPlainObject(node.supported_by) ? node.supported_by : null;
-}
-
-// gets the sources with the partial_path_of flag
-function getPartialPathSourceIDs( node ) {
-  return $.isPlainObject(node.partial_path_of) ? node.partial_path_of : null;
-}
-
-// gets the sources with the conflicts_with flag
-function getConflictingSourceIDs( node ) {
-    return $.isPlainObject(node.conflicts_with) ? node.conflicts_with : null;
-}
-
-// gets the sources with the terminal flag
-function getTerminalSourceIDs( node ) {
-  return $.isPlainObject(node.terminal) ? node.terminal : null;
-}
 
 function updateTreeView( State ) {
     /* N.B. This should respond identically to state changes in HTML5 History,
@@ -794,14 +775,9 @@ function showObjectProperties( objInfo, options ) {
             }
         }
 
-        // Show ALL source trees (phylo-trees + IDs) for this node
-
-        // add basic edge properties (TODO: handle multiple edges!?)
-        var fullNodeSupporters = $.extend( {},
-                                           getSupportingSourceIDs( fullNode ),
-                                           getPartialPathSourceIDs( fullNode ),
-                                           getTerminalSourceIDs( fullNode )
-                                         );
+        // get the list of ALL support types (supported_by, partial_path_of, terminal)
+        // we may later split this into separate sections for each type
+        var fullNodeSupporters = getSupportingSourceIDs( fullNode );
         if (fullNodeSupporters) {
             if (edgeSection) {
                 edgeSection.displayedProperties['Supporting trees'] = fullNodeSupporters;

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -879,7 +879,6 @@ function showObjectProperties( objInfo, options ) {
     // remove any old thumbnail image
     $('#provenance-panel .taxon-image').remove();
     // for nodes, load supporting information and a thumbnail silhouette from PhyloPic
-    // TODO: don't think we need this switch statement; only two cases which are treated same
     var fullNode = argus.getArgusNodeByID( objID );
     var objRelatedSources = null;
     // combine all supporting and conflicting studies/taxonomies

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -65,7 +65,7 @@ function getConflictingSourceIDs( node ) {
 
 // gets the sources with the terminal flag
 function getTerminalSourceIDs( node ) {
-  return $.isPlainObject(node.conflicts_with) ? node.conflicts_with : null;
+  return $.isPlainObject(node.terminal) ? node.terminal : null;
 }
 
 function updateTreeView( State ) {
@@ -800,7 +800,11 @@ function showObjectProperties( objInfo, options ) {
                 // Show ALL source trees (phylo-trees + IDs) for this node
 
                 // add basic edge properties (TODO: handle multiple edges!?)
-                var fullNodeSupporters = getSupportingSourceIDs( fullNode );
+                var fullNodeSupporters = $.extend( {},
+                                                   getSupportingSourceIDs( fullNode ),
+                                                   getPartialPathSourceIDs( fullNode ),
+                                                   getTerminalSourceIDs( fullNode )
+                                                 );
                 if (fullNodeSupporters) {
                     if (edgeSection) {
                         edgeSection.displayedProperties['Supporting trees'] = fullNodeSupporters;
@@ -809,6 +813,24 @@ function showObjectProperties( objInfo, options ) {
                         console.log(fullNode);
                     }
                 }
+                // var fullNodePartials = getPartialPathSourceIDs( fullNode );
+                // if (fullNodePartials) {
+                //     if (edgeSection) {
+                //         edgeSection.displayedProperties['??? trees'] = fullNodeConflicts;
+                //     } else {
+                //         console.log('>>> No edgeSection found for this node:');
+                //         console.log(fullNode);
+                //     }
+                // }
+                // var fullNodeTerminals = getTerminalSourceIDs( fullNode );
+                // if (fullNodeTerminals) {
+                //     if (edgeSection) {
+                //         edgeSection.displayedProperties['Supporting trees'] = fullNodeSupporters;
+                //     } else {
+                //         console.log('>>> No edgeSection found for this node:');
+                //         console.log(fullNode);
+                //     }
+                // }
                 var fullNodeConflicts = getConflictingSourceIDs( fullNode );
                 if (fullNodeConflicts) {
                     if (edgeSection) {
@@ -875,16 +897,9 @@ function showObjectProperties( objInfo, options ) {
             // combine all supporting and conflicting studies/taxonomies
             objRelatedSources = $.extend(
                                           {},
-                                          getSupportingSourceIDs( fullNode || objInfo ),
-                                          getConflictingSourceIDs( fullNode || objInfo )
+                                          fullNodeSupporters,
+                                          fullNodeConflicts
                                         );
-/*
-            if (fullNode) {
-                objRelatedSources = $.merge( $.merge( [], getSupportingSourceIDs( fullNode + ) ), getConflictingSourceIDs( fullNode ) );
-            } else {
-                objRelatedSources = $.merge( $.merge( [], getSupportingSourceIDs( objInfo ) ), getConflictingSourceIDs( objInfo ) );
-            }
-*/
             if (objRelatedSources) {
                 // fetch full supporting info, then display it
                 $.each(objRelatedSources, function(sourceID, sourceDetails) {
@@ -1065,7 +1080,7 @@ function showObjectProperties( objInfo, options ) {
                             markerClass = "UNKNOWN-related-tree"
                             console.error("Unknown related-study type: "+ dLabel);
                     }
-                    $details.append('<dt>'+ dLabel +'&nbsp; <a class="related-studies-toggle" data-related-type="'+ markerClass +'" href="#">[show all details]</a></dt>');
+                    $details.append('<dt class="'+ markerClass +'">'+ dLabel +'&nbsp; <a class="related-studies-toggle" data-related-type="'+ markerClass +'" href="#">[show all details]</a></dt>');
 
                     var supportedByTaxonomy = false;
                     var supportingTaxonomyVersion, supportingTaxonomyVersionURL;

--- a/webapp/static/js/webapp-helpers.js
+++ b/webapp/static/js/webapp-helpers.js
@@ -5,6 +5,39 @@
  */
 
 /*
+ * Set of functions that return support & conflict information for nodes
+*/
+
+// get all three of the supporting flags
+function getSupportingSourceIDs ( node ) {
+  return $.extend( {},
+                   getSupportedBySourceIDs( node ),
+                   getPartialPathSourceIDs( node ),
+                   getTerminalSourceIDs( node )
+                 );
+}
+
+// gets the sources with the supported_by flag
+function getSupportedBySourceIDs( node ) {
+   return $.isPlainObject(node.supported_by) ? node.supported_by : null;
+}
+
+// gets the sources with the partial_path_of flag
+function getPartialPathSourceIDs( node ) {
+ return $.isPlainObject(node.partial_path_of) ? node.partial_path_of : null;
+}
+
+// gets the sources with the conflicts_with flag
+function getConflictingSourceIDs( node ) {
+   return $.isPlainObject(node.conflicts_with) ? node.conflicts_with : null;
+}
+
+// gets the sources with the terminal flag
+function getTerminalSourceIDs( node ) {
+ return $.isPlainObject(node.terminal) ? node.terminal : null;
+}
+
+/*
 * Converts a full reference to a compact reference for display in properties panel
 * duplicates function with same name in curator/static/js/curation_helpers.js,
 * so changes need to be made in both places

--- a/webapp/static/js/webapp-helpers.js
+++ b/webapp/static/js/webapp-helpers.js
@@ -4,6 +4,24 @@
  * should eventually be moved over here.
  */
 
+/*
+* Converts a full reference to a compact reference for display in properties panel
+* duplicates function with same name in curator/static/js/curation_helpers.js,
+* so changes need to be made in both places
+*/
+ function fullToCompactReference( fullReference ) {
+     var compactReference = "(Untitled)";
+     if ($.trim(fullReference) !== "") {
+         // capture the first valid year in the reference
+         var yearMatches = fullReference.match(/(\d{4})/);
+         var compactYear = yearMatches ? yearMatches[0] : "[no year]";
+         // split on the year to get authors (before), and capture the first surname
+         var compactPrimaryAuthor = fullReference.split(compactYear)[0].split(',')[0];
+         var compactReference = compactPrimaryAuthor +", "+ compactYear;    // eg, "Smith, 1999";
+     }
+     return compactReference;
+ }
+
  /*
  * Returns a hyperlink to the taxonomy browser for a given OTT taxon
  * Note that this function replicated curator/static/js/curation-helpers.js,

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -364,10 +364,10 @@ a.related-studies-toggle {
 
 /* colors borrowed from curation app (CSS in views/study/edit.html) */
 .panel-content dl dt.supporting-tree {
-	  color: #36f;
+	  /*color: #36f;*/
 }
 .panel-content dl dt.conflicting-tree {
-	  color: #e80;
+	  /*color: #e80;*/
 }
 
 p#tree-description {

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -6,24 +6,24 @@ body {
    the desire to have a nice, big, fat search box.
 */
 .header {
-	margin: 2px; 
+	margin: 2px;
 	height: 85px;
 }
 .headerlogo {
 	float: left;
 }
-.sidebar-search {	
+.sidebar-search {
     background-color: #ffc;
     border: 1px solid #dda;
     border-radius: 4px;
     margin: -3px;
     padding: 8px 4px;
 }
-.sidebar-search form {	
+.sidebar-search form {
     margin: 0;
 }
 #search-results i {
-    display: block; 
+    display: block;
     margin: 8px 0 0;
 }
 .search-result {
@@ -68,7 +68,7 @@ body {
 #provenance-panel .panel-edges {
     background-color: #eee;
 }
-.vizcontent div.viewer-frame, 
+.vizcontent div.viewer-frame,
 #comments-panel,
 #provenance-panel {
     float: left;
@@ -103,30 +103,30 @@ div.viewer-frame {
 }
 
 /* slide these using marker classes on #viewer-collection */
-.active-comments #comments-panel {   
+.active-comments #comments-panel {
     margin-left: -1px;  /* ensures visibility in scaled browser */
-    margin-right: 0; 
+    margin-right: 0;
 }
 .active-comments div.viewer-frame {
     width: 50%;  /* N.B. Javascript will override this */
     margin-left: 0;
-    margin-right: 0; 
+    margin-right: 0;
 }
-.active-comments #provenance-panel {    
+.active-comments #provenance-panel {
     margin-left: 0;
-    margin-right: -100%; 
+    margin-right: -100%;
 }
 
-.active-properties #comments-panel {   
-    margin-left: -50%; 
-    margin-right: 0; 
+.active-properties #comments-panel {
+    margin-left: -50%;
+    margin-right: 0;
 }
 .active-properties div.viewer-frame {
     width: 50%;  /* N.B. Javascript will override this */
     margin-left: 0;
-    margin-right: 0; 
+    margin-right: 0;
 }
-.active-properties #provenance-panel {    
+.active-properties #provenance-panel {
     margin-left: 0;
     margin-right: -1px;  /* ensures visibility in scaled browser */
 }
@@ -158,22 +158,22 @@ div.viewer-frame {
     }
 
     /* slide these using marker classes on #viewer-collection */
-    .active-comments #comments-panel {   
-        margin-left: 0; 
+    .active-comments #comments-panel {
+        margin-left: 0;
         margin-right: 0;
     }
     .active-comments div.viewer-frame {
         width: 100%;
-        margin-left: 0; 
+        margin-left: 0;
         margin-right: -90%;
     }
-    .active-comments #provenance-panel {    
-        margin-left: 90%; 
+    .active-comments #provenance-panel {
+        margin-left: 90%;
         margin-right: -180%;
     }
 
-    .active-properties #comments-panel {   
-        margin-left: -90%; 
+    .active-properties #comments-panel {
+        margin-left: -90%;
         margin-right: 0;
     }
     .active-properties div.viewer-frame {
@@ -181,7 +181,7 @@ div.viewer-frame {
         margin-left: -90%;
         margin-right: 0;
     }
-    .active-properties #provenance-panel {    
+    .active-properties #provenance-panel {
         margin-left: 0;
         margin-right: 0;
     }
@@ -335,7 +335,9 @@ div.viewer-frame {
     color: #000;
     margin-bottom: 4px;
 }
-a.full-ref-toggle {
+a.full-ref-toggle,
+a.related-studies-toggle {
+	  font-weight: normal;
     color: #999 !important;
     text-decoration: none;
 }
@@ -345,8 +347,19 @@ a.full-ref-toggle {
     margin: 0px 12px 0px -6px;
     padding: 4px 6px;
 }
+.compact-ref {
+		background-color: #fff;
+		border: 1px solid #eee;
+		padding: 4px 6px;
+		display: inline-block;
+		margin-right: 8px;
+}
 .full-ref-curator {
     color: #777;
+}
+.related-study {
+	  border-bottom: 1px solid #ddd;
+		padding: 6px 0;
 }
 
 p#tree-description {
@@ -410,11 +423,11 @@ div#r0 {
     float: right;
 }
 #screen-size-indicator {
-    position: absolute; 
-    left: 0; 
-    top: 0; 
+    position: absolute;
+    left: 0;
+    top: 0;
     padding: 1px 6px;
-    background: red; 
+    background: red;
     color: white;
 }
 /* Warning banners appear when using DEVELOPMENT, STAGING servers */
@@ -452,7 +465,7 @@ div#r0 {
 .navbar-inverse .navbar-search .search-query::-webkit-input-placeholder {color: #555;}
 
 /* Optional style when field has focus
-.navbar-inverse .navbar-search .search-query:focus, 
+.navbar-inverse .navbar-search .search-query:focus,
 .navbar-inverse .navbar-search .search-query.focused {
     background-color: black;
     color: orange;
@@ -465,11 +478,11 @@ div#r0 {
     display: inline-block;
 }
 .navbar-search .left-inner-addon .search-query {
-    padding-left: 24px;    
+    padding-left: 24px;
 }
-.navbar-search .left-inner-addon .search-query:focus, 
+.navbar-search .left-inner-addon .search-query:focus,
 .navbar-search .left-inner-addon .search-query.focused {
-    padding-left: 25px;    
+    padding-left: 25px;
 }
 .navbar-search .left-inner-addon i {
     position: absolute;

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -362,6 +362,14 @@ a.related-studies-toggle {
 		padding: 6px 0;
 }
 
+/* colors borrowed from curation app (CSS in views/study/edit.html) */
+.panel-content dl dt.supporting-tree {
+	  color: #36f;
+}
+.panel-content dl dt.conflicting-tree {
+	  color: #e80;
+}
+
 p#tree-description {
     color: #aaa;
     font-size: 135%;


### PR DESCRIPTION
Two improvements here:

* shows both conflicting and supporting trees in the properties panel. In this first iteration, 'supporting' = supported_by + terminal + partial_path_of flags. Addresses #959 . A good example is [this node](https://devtree.opentreeoflife.org/opentree/opentree6.0@mrcaott2ott8384/Vitales--rosids). 
* draws edges with solid lines when any of the three 'supporting' relations apply to the edge

(you probably want to view the diff [without whitespace](https://github.com/OpenTreeOfLife/opentree/pull/1004/files?w=1))
