### PR TITLE
Fix browse service url

### DIFF
--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -17,7 +17,7 @@
 # taxo = APIWrapper().taxomachine
 # print taxo.taxon(12345)
 
-default_api_base_url = 'https://devapi.opentreeoflife.org/'
+default_api_base_url = 'https://api.opentreeoflife.org/'
 
 import os
 import sys
@@ -34,7 +34,15 @@ headers = {
 # Main entry point.  Returns HTML as a string.
 
 def browse(id=None, name=None, limit=None, api_base=None):
-    if api_base == None: api_base = default_api_base_url
+    if api_base == None:
+        name = os.environ['SERVER_NAME']
+        # Kludge reflecting current Open Tree of Life server configuration
+        if 'devtree.' in name:
+            name = name.replace('devtree.', 'devapi.')
+            api_base = 'https://%s/' % name
+        else:
+            api_base = default_api_base_url
+
     output = StringIO.StringIO()
 
     try:


### PR DESCRIPTION
Fix it so that it gets services from api.opentreeoflife.org by default, or devapi.opentreeoflife.org if the location of the CGI script is devtree.opentreeoflife.org .