### PR TITLE
Fix broken links to trees (References page)

### DIFF
--- a/webapp/views/about/references.html
+++ b/webapp/views/about/references.html
@@ -92,8 +92,8 @@ div.contributing-studies div.links .tree-links a {
                       ><span>Show links to included trees</span> ({{= len(study['tree_ids']) }})</a>
                   <div class="tree-links">
                      {{ for tree_id in study['tree_ids']: }}
-                     <a target="_blank" href="{{= URL(a='curator', c='study', f='view', args=[ study.get('ot:studyId') ], vars={'tab':'trees', 'tree': 'tree%s' % tree_id }) }}"
-                        title="Click to see this tree in the curation app">tree{{= tree_id }}</a>
+                     <a target="_blank" href="{{= URL(a='curator', c='study', f='view', args=[ study.get('ot:studyId') ], vars={'tab':'trees', 'tree': tree_id }) }}"
+                        title="Click to see this tree in the curation app">{{= tree_id }}</a>
                      {{ pass }}
                   </div>
                   <a target="_blank" 


### PR DESCRIPTION
Fixes #1011, by removing the standard 'tree' prefix from tree IDs when linkin from [the References page](http://devtree.opentreeoflife.org/about/references). This works properly now, which you can confirm by testing against these studies near the top of the list:
  - ~~Quintero et. al. (uses `tree*` for tree ids)~~
  - ~~da Marcela Vasco-Palacios et. al. (uses `Tr*` for tree ids)~~

~~**Note** that most links from the References page on **devtree** will fail, as they point to the dev phylesystem. To test these properly, adjust the web address of the _destination page_ by changing 'devtree' to 'tree'.~~

EDIT: The examples and cautions above were due to quirks in my local test system. Our shared **dev** system is internally consistent, so links from the References page should behave normally. I don't see any studies that use non-standard tree ids, but my local testing shows that they would be supported.
 