### PR TITLE
Link taxonomic amendments to source docs on GitHub

### DIFF
--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -333,6 +333,12 @@ def source_link(source_id):
                 # https://github.com/OpenTreeOfLife/peyotl/blob/3c32582e16be9dcf1029ce3d6481cdb09444890a/peyotl/amendments/amendments_umbrella.py#L33-L34
                 if (len(id_parts) > 1) and id_parts[0] in ('additions', 'changes', 'deletions',):
                     url = _AMENDMENT_REPO_URL_TEMPLATE.format(possible_amendment_id)
+                    # we use a special displayed format for amendments
+                    type_to_singular_prefix = {'additions':'addition' , 'changes':'change', 'deletions':'deletion'}
+                    prefix = type_to_singular_prefix.get(id_parts[0])
+                    node_id = parts[1]
+                    formatted_id = '%s:%s' % (prefix, node_id)
+                    return '<a href="%s">%s</a>' % (cgi.escape(url), cgi.escape(formatted_id))
 
     if url != None:
         return '<a href="%s">%s</a>' % (cgi.escape(url), cgi.escape(source_id))

--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -449,6 +449,7 @@ local_stylesheet = """
     span.name {
         font-weight: bold;
     }
+    span.sources, 
     span.flags {
         padding-left: 1em;
     }


### PR DESCRIPTION
We link to all other taxon sources in the taxonomy browser, so I thought we should try to clarify those added by taxonomic amendments. Here we link directly to the latest version of the amendment JSON on GitHub (after sniffing the API base URL to choose the appropriate source repo). 

This is obviously not pretty, but it will quickly answer particular questions about why a taxon was added, and by whom.

This is working now on **devtree**, see for example [this test entry 'Felis polydacta'](https://devtree.opentreeoflife.org/taxonomy/browse?name=Felis%20polydacta).