### PR TITLE
Better feedback for new-taxon naming

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -865,7 +865,7 @@ tr.after-shims th {
 }
 
 .required-field {
-    border-color: red !important;
+ /* border-color: red !important; */
 }
 .required-field-marker {
     color: red !important;

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2316,10 +2316,14 @@ body {
                 <label class="control-label" for="">Original label</label>
                 <div class="controls">
                     <div class="static-form-value unmapped-label"
-                         style="color: #888; font-weight: normal;"
+                         style="color: #888; font-weight: normal; display: inline-block;"
                          data-bind="text: $data['^ot:originalLabel'],
                                     attr:{'title': '' }"
                          title="">...</div>
+                     <button class="btn btn-small" style="margin-left: 4px;"
+                             data-bind="click: useOriginalLabelForNewTaxon,
+                                        attr: {'disabled': newTaxonNameMatchesOriginalLabel()}"
+                     >Use as taxon name</button>
                 </div>
             </div>
             <div class="control-group">
@@ -2344,8 +2348,8 @@ body {
                                              'Label is a synonym',
                                              'Other (explain in comments below)'],
                                    optionsCaption: 'Choose reason for modification...',
-                                   attr:{'disabled': ($data.newTaxonMetadata.modifiedName() === $data.newTaxonMetadata.adjustedLabel)},
-                                   css: ($data.newTaxonMetadata.modifiedName() === $data.newTaxonMetadata.adjustedLabel) ? '' : 'required-field'
+                                   attr:{'disabled': newTaxonNameMatchesOriginalLabel()},
+                                   css: (newTaxonNameMatchesOriginalLabel() ? '' : 'required-field')
                                    ">
                     </select>
                 </div>


### PR DESCRIPTION
Addresses #1034. Includes these changes:
 - track label changes versus **original** label
 - add button to use/restore original label
 - smarter validation logic for label changes
 - remove unsightly red border on required fields