### PR TITLE
moar inclusive regex to match words

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1599,8 +1599,8 @@ body {
                        <!-- NOTE the convention here... value="{OLD} =:= {NEW}" -->
                         <option value="\bsp(\.|\b) =:= ">Remove 'sp.'</option>
                         <option value="foo =:= bar">Replace 'foo' with 'bar'</option>
-                        <option value="^(\w*)\s+\b =:= ">Remove first of multiple words</option>
-                        <option value="\b\s+(\w*)$ =:= ">Remove last of multiple words</option>
+                        <option value="^(\S*)\s+\b =:= ">Remove first of multiple words</option>
+                        <option value="\b\s+(\S*)$ =:= ">Remove last of multiple words</option>
                         <option value="^(\S*\s+\S*).* =:= $1">Keep first two words</option>
                         <option value=".*\s+(\w*)\s*$ =:= $1">Isolate trailing ID</option>
                       </select>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1602,7 +1602,7 @@ body {
                         <option value="^(\S*)\s+\b =:= ">Remove first of multiple words</option>
                         <option value="\b\s+(\S*)$ =:= ">Remove last of multiple words</option>
                         <option value="^(\S*\s+\S*).* =:= $1">Keep first two words</option>
-                        <option value=".*\s+(\w*)\s*$ =:= $1">Isolate trailing ID</option>
+                        <option value=".*\s+(\S*)\s*$ =:= $1">Isolate trailing ID</option>
                       </select>
                   </div>
                   <div style="margin-top: 1em;">


### PR DESCRIPTION
Built-in regex patterns for removing first/last words were failing on matching when a dash was involved in the string. These two changes will match any non-whitespace characters, so should work in all circumstances.  :pineapple: