### PR TITLE
Consistent list sorting

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -226,6 +226,7 @@ function loadStudyList() {
             
             var matchedStudies = data['matched_studies'];
             sortStudiesByDOI(matchedStudies);
+            captureListPositions(matchedStudies, 'SORTED BY DOI?');
 
             viewModel = matchedStudies; /// ko.mapping.fromJS( fakeStudyList );  // ..., mappingOptions);
 
@@ -256,6 +257,9 @@ function loadStudyList() {
                 var order = viewModel.listFilters.STUDIES.order();
 
                 // map old array to new and return it
+                //captureListPositions(viewModel, 'viewModel BEFORE FILTER:');
+                restoreRelativeListPositions(viewModel);
+                captureListPositions(viewModel, 'viewModel AFTER RESTORING RELATIVE POSITIONS:');
                 var filteredList = ko.utils.arrayFilter( 
                     viewModel, 
                     function(study) {
@@ -299,7 +303,7 @@ function loadStudyList() {
                 );  // END of list filtering
                         
                 // apply selected sort order
-                captureListPositions(filteredList);
+                captureListPositions(filteredList, 'filteredList BEFORE SORT ORDER:');
                 switch(order) {
                     /* REMINDER: in sort functions, results are as follows:
                      *  -1 = a comes before b
@@ -308,6 +312,7 @@ function loadStudyList() {
                      */
                     case 'Newest publication first':
                         filteredList.sort(function(a,b) { 
+                            if (checkForInterestingStudies(a,b)) { debugger; }
                             if (a['ot:studyYear'] === b['ot:studyYear']) {
                                 return maintainRelativeListPositions(a, b);
                             };
@@ -322,7 +327,6 @@ function loadStudyList() {
                             }
                             return (a['ot:studyYear'] > b['ot:studyYear'])? 1 : -1;
                         });
-                        debugger;
                         break;
 
                     case 'Sort by primary author':
@@ -394,7 +398,7 @@ function loadStudyList() {
                         return false;
 
                 }
-                captureListPositions(filteredList);
+                captureListPositions(filteredList, 'filteredList AFTER SORT (order='+ order +':');
                 viewModel._filteredStudies( filteredList );
                 viewModel._filteredStudies.goToPage(1);
                 return viewModel._filteredStudies;

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -299,6 +299,7 @@ function loadStudyList() {
                 );  // END of list filtering
                         
                 // apply selected sort order
+                captureListPositions(filteredList);
                 switch(order) {
                     /* REMINDER: in sort functions, results are as follows:
                      *  -1 = a comes before b
@@ -307,16 +308,21 @@ function loadStudyList() {
                      */
                     case 'Newest publication first':
                         filteredList.sort(function(a,b) { 
-                            if (a['ot:studyYear'] === b['ot:studyYear']) return 0;
+                            if (a['ot:studyYear'] === b['ot:studyYear']) {
+                                return maintainRelativeListPositions(a, b);
+                            };
                             return (a['ot:studyYear'] > b['ot:studyYear'])? -1 : 1;
                         });
                         break;
 
                     case 'Oldest publication first':
                         filteredList.sort(function(a,b) {
-                            if (a['ot:studyYear'] === b['ot:studyYear']) return 0;
+                            if (a['ot:studyYear'] === b['ot:studyYear']) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (a['ot:studyYear'] > b['ot:studyYear'])? 1 : -1;
                         });
+                        debugger;
                         break;
 
                     case 'Sort by primary author':
@@ -324,10 +330,16 @@ function loadStudyList() {
                             var aRef = $.trim(a['ot:studyPublicationReference']);
                             var bRef = $.trim(b['ot:studyPublicationReference']);
                             if (aRef.localeCompare) {
-                                return aRef.localeCompare(bRef);
+                                var r = aRef.localeCompare(bRef);
+                                if (r === 0) {
+                                    r = maintainRelativeListPositions(a, b);
+                                } 
+                                return r;
                             }
                             // fallback do dumb alpha-sort on older browsers
-                            if (aRef === bRef) return 0;
+                            if (aRef === bRef) {
+                                return maintainRelativeListPositions(a, b);
+                            };
                             return (aRef > bRef) ? 1 : -1;
                         });
                         break;
@@ -337,10 +349,16 @@ function loadStudyList() {
                             var bRef = $.trim(b['ot:studyPublicationReference']);
                             var aRef = $.trim(a['ot:studyPublicationReference']);
                             if (bRef.localeCompare) {
-                                return bRef.localeCompare(aRef);
+                                var r = bRef.localeCompare(aRef);
+                                if (r === 0) {
+                                    r = maintainRelativeListPositions(a, b);
+                                } 
+                                return r;
                             }
                             // fallback do dumb alpha-sort on older browsers
-                            if (aRef === bRef) return 0;
+                            if (aRef === bRef) {
+                                return maintainRelativeListPositions(a, b);
+                            };
                             return (aRef < bRef) ? 1 : -1;
                         });
                         break;
@@ -355,14 +373,18 @@ function loadStudyList() {
                         filteredList.sort(function(a,b) { 
                             var aDisplayOrder = displayOrder[ a.workflowState ];
                             var bDisplayOrder = displayOrder[ b.workflowState ];
-                            if (aDisplayOrder === bDisplayOrder) return 0;
+                            if (aDisplayOrder === bDisplayOrder) {
+                                return maintainRelativeListPositions(a, b);
+                            };
                             return (aDisplayOrder < bDisplayOrder) ? -1 : 1;
                         });
                         break;
 
                     case 'Completeness':
                         filteredList.sort(function(a,b) { 
-                            if (a.completeness === b.completeness) return 0;
+                            if (a.completeness === b.completeness) {
+                                return maintainRelativeListPositions(a, b);
+                            };
                             return (a.completeness < b.completeness) ? -1 : 1;
                         });
                         break;
@@ -372,6 +394,7 @@ function loadStudyList() {
                         return false;
 
                 }
+                captureListPositions(filteredList);
                 viewModel._filteredStudies( filteredList );
                 viewModel._filteredStudies.goToPage(1);
                 return viewModel._filteredStudies;

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -225,8 +225,8 @@ function loadStudyList() {
             }
             
             var matchedStudies = data['matched_studies'];
+            captureDefaultSortOrder(matchedStudies);
             getDuplicateStudiesByDOI(matchedStudies);
-            captureListPositions(matchedStudies, 'SORTED BY DOI?');
 
             viewModel = matchedStudies; /// ko.mapping.fromJS( fakeStudyList );  // ..., mappingOptions);
 
@@ -257,9 +257,6 @@ function loadStudyList() {
                 var order = viewModel.listFilters.STUDIES.order();
 
                 // map old array to new and return it
-                //captureListPositions(viewModel, 'viewModel BEFORE FILTER:');
-                restoreRelativeListPositions(viewModel);
-                captureListPositions(viewModel, 'viewModel AFTER RESTORING RELATIVE POSITIONS:');
                 var filteredList = ko.utils.arrayFilter( 
                     viewModel, 
                     function(study) {
@@ -303,7 +300,6 @@ function loadStudyList() {
                 );  // END of list filtering
                         
                 // apply selected sort order
-                captureListPositions(filteredList, 'filteredList BEFORE SORT ORDER:');
                 switch(order) {
                     /* REMINDER: in sort functions, results are as follows:
                      *  -1 = a comes before b
@@ -312,20 +308,24 @@ function loadStudyList() {
                      */
                     case 'Newest publication first':
                         filteredList.sort(function(a,b) { 
-                            if (checkForInterestingStudies(a,b)) { debugger; }
-                            if (a['ot:studyYear'] === b['ot:studyYear']) {
+                            //if (checkForInterestingStudies(a,b)) { debugger; }
+                            var aYear = isNaN(a['ot:studyYear']) ? Infinity : Number(a['ot:studyYear']);
+                            var bYear = isNaN(b['ot:studyYear']) ? Infinity : Number(b['ot:studyYear']);
+                            if (aYear === bYear) {
                                 return maintainRelativeListPositions(a, b);
                             };
-                            return (a['ot:studyYear'] > b['ot:studyYear'])? -1 : 1;
+                            return (aYear > bYear)? -1 : 1;
                         });
                         break;
 
                     case 'Oldest publication first':
                         filteredList.sort(function(a,b) {
-                            if (a['ot:studyYear'] === b['ot:studyYear']) {
+                            var aYear = isNaN(a['ot:studyYear']) ? Infinity : Number(a['ot:studyYear']);
+                            var bYear = isNaN(b['ot:studyYear']) ? Infinity : Number(b['ot:studyYear']);
+                            if (aYear === bYear) {
                                 return maintainRelativeListPositions(a, b);
                             }
-                            return (a['ot:studyYear'] > b['ot:studyYear'])? 1 : -1;
+                            return (aYear > bYear)? 1 : -1;
                         });
                         break;
 
@@ -398,7 +398,6 @@ function loadStudyList() {
                         return false;
 
                 }
-                captureListPositions(filteredList, 'filteredList AFTER SORT (order='+ order +':');
                 viewModel._filteredStudies( filteredList );
                 viewModel._filteredStudies.goToPage(1);
                 return viewModel._filteredStudies;

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -225,7 +225,7 @@ function loadStudyList() {
             }
             
             var matchedStudies = data['matched_studies'];
-            sortStudiesByDOI(matchedStudies);
+            getDuplicateStudiesByDOI(matchedStudies);
             captureListPositions(matchedStudies, 'SORTED BY DOI?');
 
             viewModel = matchedStudies; /// ko.mapping.fromJS( fakeStudyList );  // ..., mappingOptions);
@@ -414,7 +414,7 @@ function loadStudyList() {
 
 /* gather any duplicate studies (with same DOI) */
 var studiesByDOI = {};
-function sortStudiesByDOI(studyList) {
+function getDuplicateStudiesByDOI(studyList) {
     studiesByDOI = {};
     $.each( studyList, function(i, study) {
         var studyID = study['ot:studyId'];

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2130,3 +2130,22 @@ function tokenizeSearchTextKeepingQuotes( text ) {
     })).filter(Boolean);
     return tokens;
 }
+
+/* Use ad-hoc properties to maintain the relative positions of list items which
+ * have been sorted "equally". This ensures identical sorting results across
+ * browsers despite their different ways of handling sorting pairs.
+ */
+function captureListPositions(targetList) {
+    // (Re)set the list-position property for each item
+    $.each(targetList, function(i, item) {
+        item.lastKnownPosition = i;
+    });
+}
+function maintainRelativeListPositions(a, b) {
+    if (typeof a.lastKnownPosition !== 'undefined' && typeof b.lastKnownPosition !== 'undefined') {
+        // the result will maintain their prior relative positions
+        return a.lastKnownPosition - b.lastKnownPosition;
+    }
+    return 0;
+}
+

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2146,11 +2146,11 @@ function maintainRelativeListPositions(a, b) {
         // the result will maintain their prior relative positions
         return (a.defaultSortOrder > b.defaultSortOrder) ? 1 : -1;
     }
-    /*
+
     console.error('defaultSortOrder not found on these items!');
     console.error(a);
     console.error(b);
-    */
+
     return 0;
 }
 function checkForInterestingStudies(a,b) {

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -535,7 +535,6 @@ function fetchAndShowCollection( collectionID, specialHandling ) {
             showErrorMessage("Unable to load collection '"+ collectionID +"'");
         },
         complete: function( jqXHR, textStatus ) {
-            //debugger;
             hideModalScreen();
         }
     });
@@ -2135,17 +2134,41 @@ function tokenizeSearchTextKeepingQuotes( text ) {
  * have been sorted "equally". This ensures identical sorting results across
  * browsers despite their different ways of handling sorting pairs.
  */
-function captureListPositions(targetList) {
+function captureListPositions(targetList, msg) {
     // (Re)set the list-position property for each item
+    console.log(msg || "FIRST ITEMS (OLD POSITIONS):");
+    /*
+    console.log(targetList[0]['ot:studyId'] +" - "+ targetList[0].lastKnownPosition);
+    console.log(targetList[1]['ot:studyId'] +" - "+ targetList[1].lastKnownPosition);
+    console.log(targetList[2]['ot:studyId'] +" - "+ targetList[2].lastKnownPosition);
+    console.log(targetList[3]['ot:studyId'] +" - "+ targetList[3].lastKnownPosition);
+    */
+    var allStudyIDs = $.map(targetList, function(obj,i) {
+        return (obj['ot:studyId']) || '';
+    });
+    console.log(allStudyIDs.join(','));
+
     $.each(targetList, function(i, item) {
         item.lastKnownPosition = i;
     });
 }
 function maintainRelativeListPositions(a, b) {
+    // Resolve "tied" items in a sort by respecting their (last known) relative positions
     if (typeof a.lastKnownPosition !== 'undefined' && typeof b.lastKnownPosition !== 'undefined') {
         // the result will maintain their prior relative positions
-        return a.lastKnownPosition - b.lastKnownPosition;
+        return (a.lastKnownPosition > b.lastKnownPosition) ? 1 : -1;
     }
     return 0;
 }
+function restoreRelativeListPositions(targetList) {
+    // Restores relative positions after browser-quirky operations like ko.filterArray
+    // N.B. this assumes that we've previously captured these using captureListPositions above.
+    targetList.sort(maintainRelativeListPositions);
+}
 
+function checkForInterestingStudies(a,b) {
+    var interestingIDs = ['tt_35', 'tt_99'];
+    if ($.inArray( a['ot:studyId'], interestingIDs ) === -1) return false;
+    if ($.inArray( b['ot:studyId'], interestingIDs ) === -1) return false;
+    return true;
+}

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2130,45 +2130,44 @@ function tokenizeSearchTextKeepingQuotes( text ) {
     return tokens;
 }
 
-/* Use ad-hoc properties to maintain the relative positions of list items which
- * have been sorted "equally". This ensures identical sorting results across
- * browsers despite their different ways of handling sorting pairs.
+/* Use ad-hoc `defaultSortOrder` property to maintain the relative positions of
+ * list items which have been sorted "equally". This ensures identical sorting
+ * results across browsers despite their different ways of handling sorting pairs.
  */
-function captureListPositions(targetList, msg) {
-    // (Re)set the list-position property for each item
-    console.log(msg || "FIRST ITEMS (OLD POSITIONS):");
-    /*
-    console.log(targetList[0]['ot:studyId'] +" - "+ targetList[0].lastKnownPosition);
-    console.log(targetList[1]['ot:studyId'] +" - "+ targetList[1].lastKnownPosition);
-    console.log(targetList[2]['ot:studyId'] +" - "+ targetList[2].lastKnownPosition);
-    console.log(targetList[3]['ot:studyId'] +" - "+ targetList[3].lastKnownPosition);
-    */
-    var allStudyIDs = $.map(targetList, function(obj,i) {
-        return (obj['ot:studyId']) || '';
-    });
-    console.log(allStudyIDs.join(','));
-
+function captureDefaultSortOrder(targetList) {
+    // Set a list-position property for each item, to enable "stable" sorting on all browsers.
     $.each(targetList, function(i, item) {
-        item.lastKnownPosition = i;
+        item.defaultSortOrder = i;
     });
 }
 function maintainRelativeListPositions(a, b) {
-    // Resolve "tied" items in a sort by respecting their (last known) relative positions
-    if (typeof a.lastKnownPosition !== 'undefined' && typeof b.lastKnownPosition !== 'undefined') {
+    // Resolve "tied" items in a sort by respecting their original list positions
+    if (typeof a.defaultSortOrder !== 'undefined' && typeof b.defaultSortOrder !== 'undefined') {
         // the result will maintain their prior relative positions
-        return (a.lastKnownPosition > b.lastKnownPosition) ? 1 : -1;
+        return (a.defaultSortOrder > b.defaultSortOrder) ? 1 : -1;
     }
+    /*
+    console.error('defaultSortOrder not found on these items!');
+    console.error(a);
+    console.error(b);
+    */
     return 0;
 }
-function restoreRelativeListPositions(targetList) {
-    // Restores relative positions after browser-quirky operations like ko.filterArray
-    // N.B. this assumes that we've previously captured these using captureListPositions above.
-    targetList.sort(maintainRelativeListPositions);
-}
-
 function checkForInterestingStudies(a,b) {
-    var interestingIDs = ['tt_35', 'tt_99'];
+    return false;
+    /*
+    // match both studies
+    var interestingIDs = ['tt_10', 'tt_25']; // ['pg_2886', 'tt_93'];
     if ($.inArray( a['ot:studyId'], interestingIDs ) === -1) return false;
     if ($.inArray( b['ot:studyId'], interestingIDs ) === -1) return false;
     return true;
+    */
+
+    // match just one study
+    var interestingIDs = ['tt_95'];
+    if ($.inArray( a['ot:studyId'], interestingIDs ) !== -1) return true;
+    if ($.inArray( b['ot:studyId'], interestingIDs ) !== -1) return true;
+    return false;
+    /*
+    */
 }

--- a/curator/static/js/curator-profile.js
+++ b/curator/static/js/curator-profile.js
@@ -287,7 +287,7 @@ function loadCollectionList(option) {
                      */
                     case 'Most recently modified':
                         filteredList.sort(function(a,b) { 
-                            // coerce any goofy dates to strings
+                            // coerce any missing/goofy dates to strings
                             var aMod = $.trim(a.lastModified.ISO_date);
                             var bMod = $.trim(b.lastModified.ISO_date);
                             if (aMod === bMod) {
@@ -299,7 +299,7 @@ function loadCollectionList(option) {
 
                     case 'Most recently modified (reversed)':
                         filteredList.sort(function(a,b) { 
-                            // coerce any goofy dates to strings
+                            // coerce any missing/goofy dates to strings
                             var aMod = a.lastModified.ISO_date;
                             var bMod = b.lastModified.ISO_date;
                             if (aMod === bMod) {
@@ -312,7 +312,7 @@ function loadCollectionList(option) {
                     case 'By owner/name':
                         filteredList.sort(function(a,b) { 
                             // first element is the ID with user-name/collection-name
-                            // (coerce any goofy values to strings)
+                            // (coerce any missing/goofy values to strings)
                             var aName = $.trim(a.id);
                             var bName = $.trim(b.id);
                             if (aName === bName) {
@@ -326,7 +326,7 @@ function loadCollectionList(option) {
                     case 'By owner/name (reversed)':
                         filteredList.sort(function(a,b) { 
                             // first element is the ID with user-name/collection-name
-                            // (coerce any goofy values to strings)
+                            // (coerce any missing/goofy values to strings)
                             var aName = $.trim(a.id);
                             var bName = $.trim(b.id);
                             if (aName === bName) {

--- a/curator/static/js/curator-profile.js
+++ b/curator/static/js/curator-profile.js
@@ -174,7 +174,7 @@ function loadCollectionList(option) {
                 showErrorMessage('Sorry, there is a problem with the tree-collection data.');
                 return;
             }
-            
+            captureDefaultSortOrder(data);
             viewModel = data;
 
             // enable sorting and filtering for lists in the editor
@@ -287,18 +287,24 @@ function loadCollectionList(option) {
                      */
                     case 'Most recently modified':
                         filteredList.sort(function(a,b) { 
-                            var aMod = a.lastModified.ISO_date;
-                            var bMod = b.lastModified.ISO_date;
-                            if (aMod === bMod) return 0;
+                            // coerce any goofy dates to strings
+                            var aMod = $.trim(a.lastModified.ISO_date);
+                            var bMod = $.trim(b.lastModified.ISO_date);
+                            if (aMod === bMod) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (aMod < bMod)? 1 : -1;
                         });
                         break;
 
                     case 'Most recently modified (reversed)':
                         filteredList.sort(function(a,b) { 
+                            // coerce any goofy dates to strings
                             var aMod = a.lastModified.ISO_date;
                             var bMod = b.lastModified.ISO_date;
-                            if (aMod === bMod) return 0;
+                            if (aMod === bMod) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (aMod > bMod)? 1 : -1;
                         });
                         break;
@@ -306,16 +312,28 @@ function loadCollectionList(option) {
                     case 'By owner/name':
                         filteredList.sort(function(a,b) { 
                             // first element is the ID with user-name/collection-name
-                            if (a.id === b.id) return 0;
-                            return (a.id < b.id) ? -1 : 1;
+                            // (coerce any goofy values to strings)
+                            var aName = $.trim(a.id);
+                            var bName = $.trim(b.id);
+                            if (aName === bName) {
+                                // N.B. this should not occur
+                                return maintainRelativeListPositions(a, b);
+                            }
+                            return (aName < bName) ? -1 : 1;
                         });
                         break;
 
                     case 'By owner/name (reversed)':
                         filteredList.sort(function(a,b) { 
                             // first element is the ID with user-name/collection-name
-                            if (a.id === b.id) return 0;
-                            return (a.id > b.id) ? -1 : 1;
+                            // (coerce any goofy values to strings)
+                            var aName = $.trim(a.id);
+                            var bName = $.trim(b.id);
+                            if (aName === bName) {
+                                // N.B. this should not occur
+                                return maintainRelativeListPositions(a, b);
+                            }
+                            return (aName > bName) ? -1 : 1;
                         });
                         break;
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1036,8 +1036,6 @@ function loadSelectedStudy() {
                     });
                 });
 
-                console.log("  filtering "+ allTrees.length +" trees...");
-
                 // map old array to new and return it
                 var filteredList = ko.utils.arrayFilter(
                     allTrees,
@@ -1114,6 +1112,7 @@ function loadSelectedStudy() {
 
                 // gather all OTUs from all 'otus' collections
                 var allOTUs = viewModel.elementTypes.otu.gatherAll(viewModel.nexml);
+                captureDefaultSortOrder(allOTUs);
 
                 var chosenTrees;
                 switch(scope) {
@@ -1182,12 +1181,14 @@ function loadSelectedStudy() {
                      *   1 = b comes before a
                      */
                     case 'Unmapped OTUs first':
-                        // Capture prior position first (for a more stable list during bulk mapping)
+                        /* Capture prior position first (for a more stable list during bulk mapping)
                         $.each(filteredList, function(i, otu) {
                             otu.priorPosition = i;
                         });
+                        */
                         filteredList.sort(function(a,b) {
                             // N.B. This works even if there's no such property.
+                            //if (checkForInterestingStudies(a,b)) { debugger; }
                             var aMapStatus = $.trim(a['^ot:ottTaxonName']) !== '';
                             var bMapStatus = $.trim(b['^ot:ottTaxonName']) !== '';
                             if (aMapStatus === bMapStatus) {
@@ -1198,30 +1199,37 @@ function loadSelectedStudy() {
                                     if (aFailedMapping === bFailedMapping) {
                                         // Try to retain their prior precedence in
                                         // the list (avoid items jumping around)
-                                        return (a.priorPosition < b.priorPosition) ? -1:1;
+                                        /*return (a.priorPosition < b.priorPosition) ? -1:1;
+                                         * Should this supercede our typical use of `maintainRelativeListPositions`?
+                                         */
+                                        return maintainRelativeListPositions(a, b);
                                     }
                                     if (aFailedMapping) {
                                         return 1;   // force a (failed) below b
                                     }
                                     return -1;   // force b (failed) below a
                                 } else {
-                                    return 0;
+                                    //return (a.priorPosition < b.priorPosition) ? -1:1;
+                                    return maintainRelativeListPositions(a, b);
                                 }
                             }
                             if (aMapStatus) return 1;
                             if (bMapStatus) return -1;
                         });
-                        // Toss the outdated prior positions
+                        /* Toss the outdated prior positions
                         $.each(filteredList, function(i, otu) {
                             delete otu.priorPosition;
                         });
+                        */
                         break;
 
                     case 'Mapped OTUs first':
                         filteredList.sort(function(a,b) {
                             var aMapStatus = $.trim(a['^ot:ottTaxonName']) !== '';
                             var bMapStatus = $.trim(b['^ot:ottTaxonName']) !== '';
-                            if (aMapStatus === bMapStatus) return 0;
+                            if (aMapStatus === bMapStatus) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             if (aMapStatus) return -1;
                             return 1;
                         });
@@ -1229,9 +1237,11 @@ function loadSelectedStudy() {
 
                     case 'Original label (A-Z)':
                         filteredList.sort(function(a,b) {
-                            var aOriginal = a['^ot:originalLabel'];
-                            var bOriginal = b['^ot:originalLabel'];
-                            if (aOriginal === bOriginal) return 0;
+                            var aOriginal = $.trim(a['^ot:originalLabel']);
+                            var bOriginal = $.trim(b['^ot:originalLabel']);
+                            if (aOriginal === bOriginal) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             if (aOriginal < bOriginal) return -1;
                             return 1;
                         });
@@ -1239,9 +1249,11 @@ function loadSelectedStudy() {
 
                     case 'Original label (Z-A)':
                         filteredList.sort(function(a,b) {
-                            var aOriginal = a['^ot:originalLabel'];
-                            var bOriginal = b['^ot:originalLabel'];
-                            if (aOriginal === bOriginal) return 0;
+                            var aOriginal = $.trim(a['^ot:originalLabel']);
+                            var bOriginal = $.trim(b['^ot:originalLabel']);
+                            if (aOriginal === bOriginal) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             if (aOriginal > bOriginal) return -1;
                             return 1;
                         });
@@ -2300,6 +2312,7 @@ function scrubNexsonForTransport( nexml ) {
     $.each( allOTUs, function(i, otu) {
         delete otu['selectedForAction'];  // only used in the curation app
         delete otu['newTaxonMetadata'];
+        delete otu['defaultSortOrder'];
         if ('^ot:altLabel' in otu) {
             var ottId = $.trim(otu['^ot:ottId']);
             if (ottId !== '') {
@@ -8510,6 +8523,7 @@ function loadCollectionList(option) {
             }
 
             viewModel.allCollections = data;
+            captureDefaultSortOrder(viewModel.allCollections);
 
             // enable sorting and filtering for lists in the editor
             // UI widgets bound to these variables will trigger the
@@ -8558,6 +8572,7 @@ function loadCollectionList(option) {
                 // map old array to new and return it
                 var currentStudyID = $('#current-study-id').val();
                 var currentTreeID = $('#current-tree-id').val();
+
                 var filteredList = ko.utils.arrayFilter(
                     viewModel.allCollections,
                     function(collection) {
@@ -8663,18 +8678,22 @@ function loadCollectionList(option) {
                      */
                     case 'Most recently modified':
                         filteredList.sort(function(a,b) {
-                            var aMod = a.lastModified.ISO_date;
-                            var bMod = b.lastModified.ISO_date;
-                            if (aMod === bMod) return 0;
+                            var aMod = $.trim(a.lastModified.ISO_date);
+                            var bMod = $.trim(b.lastModified.ISO_date);
+                            if (aMod === bMod) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (aMod < bMod)? 1 : -1;
                         });
                         break;
 
                     case 'Most recently modified (reversed)':
                         filteredList.sort(function(a,b) {
-                            var aMod = a.lastModified.ISO_date;
-                            var bMod = b.lastModified.ISO_date;
-                            if (aMod === bMod) return 0;
+                            var aMod = $.trim(a.lastModified.ISO_date);
+                            var bMod = $.trim(b.lastModified.ISO_date);
+                            if (aMod === bMod) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (aMod > bMod)? 1 : -1;
                         });
                         break;
@@ -8682,16 +8701,28 @@ function loadCollectionList(option) {
                     case 'By owner/name':
                         filteredList.sort(function(a,b) {
                             // first element is the ID with user-name/collection-name
-                            if (a.id === b.id) return 0;
-                            return (a.id < b.id) ? -1 : 1;
+                            // (coerce any missing/goofy values to strings)
+                            var aName = $.trim(a.id);
+                            var bName = $.trim(b.id);
+                            if (aName === bName) {
+                                // N.B. this should not occur
+                                return maintainRelativeListPositions(a, b);
+                            }
+                            return (aName < bName) ? -1 : 1;
                         });
                         break;
 
                     case 'By owner/name (reversed)':
                         filteredList.sort(function(a,b) {
                             // first element is the ID with user-name/collection-name
-                            if (a.id === b.id) return 0;
-                            return (a.id > b.id) ? -1 : 1;
+                            // (coerce any missing/goofy values to strings)
+                            var aName = $.trim(a.id);
+                            var bName = $.trim(b.id);
+                            if (aName === bName) {
+                                // N.B. this should not occur
+                                return maintainRelativeListPositions(a, b);
+                            }
+                            return (aName > bName) ? -1 : 1;
                         });
                         break;
 

--- a/curator/static/js/tree-collection-dashboard.js
+++ b/curator/static/js/tree-collection-dashboard.js
@@ -213,6 +213,7 @@ function loadCollectionList(option) {
                 return;
             }
             
+            captureDefaultSortOrder(data);
             viewModel = data;
 
             // enable sorting and filtering for lists in the editor
@@ -344,18 +345,24 @@ function loadCollectionList(option) {
                      */
                     case 'Most recently modified':
                         filteredList.sort(function(a,b) { 
-                            var aMod = a.lastModified.ISO_date;
-                            var bMod = b.lastModified.ISO_date;
-                            if (aMod === bMod) return 0;
+                            // coerce any missing/goofy dates to strings
+                            var aMod = $.trim(a.lastModified.ISO_date);
+                            var bMod = $.trim(b.lastModified.ISO_date);
+                            if (aMod === bMod) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (aMod < bMod)? 1 : -1;
                         });
                         break;
 
                     case 'Most recently modified (reversed)':
                         filteredList.sort(function(a,b) { 
-                            var aMod = a.lastModified.ISO_date;
-                            var bMod = b.lastModified.ISO_date;
-                            if (aMod === bMod) return 0;
+                            // coerce any missing/goofy dates to strings
+                            var aMod = $.trim(a.lastModified.ISO_date);
+                            var bMod = $.trim(b.lastModified.ISO_date);
+                            if (aMod === bMod) {
+                                return maintainRelativeListPositions(a, b);
+                            }
                             return (aMod > bMod)? 1 : -1;
                         });
                         break;
@@ -363,16 +370,28 @@ function loadCollectionList(option) {
                     case 'By owner/name':
                         filteredList.sort(function(a,b) { 
                             // first element is the ID with user-name/collection-name
-                            if (a.id === b.id) return 0;
-                            return (a.id < b.id) ? -1 : 1;
+                            // (coerce any missing/goofy values to strings)
+                            var aName = $.trim(a.id);
+                            var bName = $.trim(b.id);
+                            if (aName === bName) {
+                                // N.B. this should not occur
+                                return maintainRelativeListPositions(a, b);
+                            }
+                            return (aName < bName) ? -1 : 1;
                         });
                         break;
 
                     case 'By owner/name (reversed)':
                         filteredList.sort(function(a,b) { 
                             // first element is the ID with user-name/collection-name
-                            if (a.id === b.id) return 0;
-                            return (a.id > b.id) ? -1 : 1;
+                            // (coerce any missing/goofy values to strings)
+                            var aName = $.trim(a.id);
+                            var bName = $.trim(b.id);
+                            if (aName === bName) {
+                                // N.B. this should not occur
+                                return maintainRelativeListPositions(a, b);
+                            }
+                            return (aName > bName) ? -1 : 1;
                         });
                         break;
 


### PR DESCRIPTION
OK, this was a deeper rabbit hole than I expected. There's no ECMAScript standard for "stable" list sorting (resulting order of an "equal" pair), so we now capture the initial list position for each item and use this as a "tie breaker" during list sorting, where the outcome is otherwise tied. Fixes #1000.

See this link for useful background:
http://www.alex-arriaga.com/how-to-get-same-results-when-sorting-javascript-arrays-in-all-browsers/

I've also cleaned up some of the sorting comparators so that they always coerce properties to the expected data type, to avoid other browser quirks.

This is working now (consistent list displays on all browsers) on **devtree**.