### PR TITLE
Implement a toggle to show all study details.

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -532,8 +532,7 @@ function getPubLink(study) {
         urlNotFound = true;
     }
     if (urlNotFound) {
-        return '<span style="color: #999;">No link to this publication.</span>';
-        //return '<span style="color: #ccc;">[DOI not found]</span>';
+        return "";
     }
     return '<a href="'+ pubURL +'" target="_blank"'+'>'+ pubURL +'</a'+'>';
 }

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -238,7 +238,8 @@ function loadStudyList() {
                     'match': ko.observable(""),
                     'workflow': ko.observable("Any workflow state"),
                     'order': ko.observable("Newest publication first"),
-                    'view': ko.observable("Compact view (hide details)")
+                    'view': ko.observable("Compact view (hide details)"),
+                    'page': ko.observable(1),
                 }
             };
             
@@ -256,6 +257,7 @@ function loadStudyList() {
                 var workflow = viewModel.listFilters.STUDIES.workflow();
                 var order = viewModel.listFilters.STUDIES.order();
                 var view = viewModel.listFilters.STUDIES.view();
+                var page = viewModel.listFilters.STUDIES.page();
 
                 // map old array to new and return it
                 var filteredList = ko.utils.arrayFilter( 
@@ -375,7 +377,7 @@ function loadStudyList() {
 
                 }
                 viewModel._filteredStudies( filteredList );
-                viewModel._filteredStudies.goToPage(1);
+                viewModel._filteredStudies.goToPage( page );
                 return viewModel._filteredStudies;
             }); // END of filteredStudies
                     

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -237,7 +237,8 @@ function loadStudyList() {
                     // TODO: add 'pagesize'?
                     'match': ko.observable(""),
                     'workflow': ko.observable("Any workflow state"),
-                    'order': ko.observable("Newest publication first")
+                    'order': ko.observable("Newest publication first"),
+                    'view': ko.observable("Compact view (hide details)")
                 }
             };
             
@@ -254,6 +255,7 @@ function loadStudyList() {
                     wholeWordMatchPattern = new RegExp( '\\b'+ $.trim(match) +'\\b', 'i' );
                 var workflow = viewModel.listFilters.STUDIES.workflow();
                 var order = viewModel.listFilters.STUDIES.order();
+                var view = viewModel.listFilters.STUDIES.view();
 
                 // map old array to new and return it
                 var filteredList = ko.utils.arrayFilter( 
@@ -517,6 +519,43 @@ function toggleStudyDetails( clicked ) {
         $fullRef.show();
         $toggle.text('[hide details]');
     }
+}
+function toggleAllStudyDetails( hidingOrShowing ) {
+    // Show (or hide) details for all visible studies
+    var $studyList = $('#study-list-container');
+    var $singleStudyToggles = $studyList.find('a.full-ref-toggle');
+    // IGNORE latent block with no toggle
+    //var $studyDetailBlocks = $studyList.find('div.full-study-ref');
+    var $studyDetailBlocks = $singleStudyToggles.closest('tr').next('tr').find('div.full-study-ref');
+    if ($.inArray(hidingOrShowing, ['SHOWING', 'HIDING']) === -1) {
+        // Operation not specified! Follow the current state of the detail blocks.
+        var $visibleStudyDetailBlocks = $studyDetailBlocks.filter(':visible');
+        if ($visibleStudyDetailBlocks.length === $singleStudyToggles.length) {
+            // all blocks found and currently visible, so we should hide all
+            hidingOrShowing = 'HIDING';
+        } else {
+            // show all blocks by default
+            hidingOrShowing = 'SHOWING';
+        }
+    }
+    $singleStudyToggles.each(function(i, toggle) {
+        var $toggle = $(toggle);
+        var $studyRow = $toggle.closest('tr');
+        var $studyDetailsRow = $studyRow.next('tr:has(.full-study-ref)');
+        if ($studyDetailsRow.length > 0) {
+            // there should always be a corresponding block
+            var detailsBlock = $studyDetailBlocks[i];
+            if ($(detailsBlock).is(':visible')) {
+                if (hidingOrShowing==='HIDING') {
+                    toggleStudyDetails($toggle);
+                }
+            } else {  // block is hidden
+                if (hidingOrShowing==='SHOWING') {
+                    toggleStudyDetails($toggle);
+                }
+            }
+        }
+    });
 }
 
 function filterByCurator( curatorID ) {

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -412,7 +412,7 @@ function loadStudyList() {
 
                 }
                 viewModel._filteredStudies( filteredList );
-                viewModel._filteredStudies.goToPage( page );
+                viewModel._filteredStudies.goToPage( Number(page) );
                 return viewModel._filteredStudies;
             }); // END of filteredStudies
                     

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2400,6 +2400,9 @@ function removeDiacritics( str ) {
      * N.B. this takes advantage of our collection of variants above, where the
      * first option is always a "safe" string comprised only of Latin characters.
      */
+    if (typeof str !== 'string') {
+        return str;  // return any number, etc. unchanged
+    }
     var dvCount = diacriticalVariants.length;
     var combinedVariants = diacriticalVariants.join('|');
     var finder = new RegExp(combinedVariants, 'g');

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -212,7 +212,7 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
              Xdata-bind="if: viewModel.filteredStudies()().length &gt; viewModel.filteredStudies().pagedItems().length">
           <ul>
             <li data-bind="css: { 'disabled': !viewModel.filteredStudies().prev.enabled() }" class="disabled">
-                <a href="#" onclick="if (viewModel.filteredStudies().prev.enabled()) viewModel.listFilters.STUDIES.page(viewModel.filteredStudies().current() - 1); return false;">&laquo;</a>
+                <a href="#" onclick="if (viewModel.filteredStudies().prev.enabled()) viewModel.listFilters.STUDIES.page(Number(viewModel.filteredStudies().current()) - 1); return false;">&laquo;</a>
             </li>
            <!-- ko foreach: getPageNumbers( viewModel.filteredStudies() ) -->
             <!-- ko if: isVisiblePage( $data, viewModel.filteredStudies() ) -->
@@ -225,7 +225,7 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             <!-- /ko -->
            <!-- /ko -->
             <li data-bind="css: { 'disabled': !viewModel.filteredStudies().next.enabled() }" class="disabled">
-                <a href="#" onclick="if (viewModel.filteredStudies().next.enabled()) viewModel.listFilters.STUDIES.page(viewModel.filteredStudies().current() + 1); return false;">&raquo;</a>
+                <a href="#" onclick="if (viewModel.filteredStudies().next.enabled()) viewModel.listFilters.STUDIES.page(Number(viewModel.filteredStudies().current()) + 1); return false;">&raquo;</a>
             </li>
           </ul>
         </div>

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -41,7 +41,8 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             'match': "",
             'workflow': "Any workflow state",
             'order': "Newest publication first",
-            'view': "Compact view (hide details)"
+            'view': "Compact view (hide details)",
+            'page': 1
         }
     };
     var filterDefaults = listFilterDefaults.STUDIES;
@@ -211,20 +212,20 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
              Xdata-bind="if: viewModel.filteredStudies()().length &gt; viewModel.filteredStudies().pagedItems().length">
           <ul>
             <li data-bind="css: { 'disabled': !viewModel.filteredStudies().prev.enabled() }" class="disabled">
-                <a href="#" onclick="viewModel.filteredStudies().prev(); return false;">&laquo;</a>
+                <a href="#" onclick="if (viewModel.filteredStudies().prev.enabled()) viewModel.listFilters.STUDIES.page(viewModel.filteredStudies().current() - 1); return false;">&laquo;</a>
             </li>
            <!-- ko foreach: getPageNumbers( viewModel.filteredStudies() ) -->
             <!-- ko if: isVisiblePage( $data, viewModel.filteredStudies() ) -->
             <li data-bind="css: { 'active': (viewModel.filteredStudies().current() === $data) }" class="active">
-                <a href="#" data-bind="text: $data, click: function() { viewModel.filteredStudies().goToPage($data); return false; }">0</a>
+                <a href="#" data-bind="text: $data, click: function() { viewModel.listFilters.STUDIES.page($data); return false; }">0</a>
             </li>
             <!-- /ko -->
             <!-- ko if: ! isVisiblePage( $data, viewModel.filteredStudies() ) -->
-            <li><a class="pagination-spacer" href="#" data-bind="click: function() { viewModel.filteredStudies().goToPage($data); return false; }">&nbsp;</a></li>
+            <li><a class="pagination-spacer" href="#" data-bind="click: function() { viewModel.listFilters.STUDIES.page($data); return false; }">&nbsp;</a></li>
             <!-- /ko -->
            <!-- /ko -->
             <li data-bind="css: { 'disabled': !viewModel.filteredStudies().next.enabled() }" class="disabled">
-                <a href="#" onclick="viewModel.filteredStudies().next(); return false;">&raquo;</a>
+                <a href="#" onclick="if (viewModel.filteredStudies().next.enabled()) viewModel.listFilters.STUDIES.page(viewModel.filteredStudies().current() + 1); return false;">&raquo;</a>
             </li>
           </ul>
         </div>

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -40,7 +40,8 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             // TODO: add 'pagesize'?
             'match': "",
             'workflow': "Any workflow state",
-            'order': "Newest publication first"
+            'order': "Newest publication first",
+            'view': "Compact view (hide details)"
         }
     };
     var filterDefaults = listFilterDefaults.STUDIES;
@@ -127,6 +128,17 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                     </li>
                 </ul>
             </li>
+            <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                  <span data-bind="text: viewModel.listFilters.STUDIES.view">VIEW</span>
+                  <b class="caret"></b>
+                </a>
+                <ul class="dropdown-menu" data-bind="foreach: ['Compact view (hide details)', 'Full view (show details)'] ">
+                    <li data-bind="css: {'disabled': viewModel.listFilters.STUDIES.view() == $data }">
+                        <a href="#" data-bind="text: $data, click: function () { toggleAllStudyDetails($data === 'Compact view (hide details)' ? 'HIDING' : 'SHOWING'); viewModel.listFilters.STUDIES.view($data); }">VIEW</a>
+                    </li>
+                </ul>
+            </li>
         </ul>
        </div>
       </div>
@@ -165,7 +177,8 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
             </tr>
             <tr>
                 <td colspan="4" style="border-top: none; padding-top: 0px;">
-                    <div class="full-study-ref" style="display: none; overflow: visible;">
+                    <div class="full-study-ref" style="overflow: visible;"
+                         data-bind="visible: study['ot:studyPublicationReference'] && viewModel.listFilters.STUDIES.view() === 'Full view (show details)'">
                         <div Xclass=""
                              data-bind="html: study['ot:studyPublicationReference']">&nbsp;</div>
                         <div style="margin-top: 3px; overflow: hidden;">

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -180,15 +180,14 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                 <td colspan="4" style="border-top: none; padding-top: 0px;">
                     <div class="full-study-ref" style="overflow: visible;"
                          data-bind="visible: study['ot:studyPublicationReference'] && viewModel.listFilters.STUDIES.view() === 'Full view (show details)'">
-                        <div Xclass=""
-                             data-bind="html: study['ot:studyPublicationReference']">&nbsp;</div>
-                        <div style="margin-top: 3px; overflow: hidden;">
-                            <span style="color: #999; float: right;">
+                        <div>
+                            <span style="color: #999; float: right; margin-left: 2em;">
                                 Study ID: <span data-bind="text: study['ot:studyId']">&nbsp;</span>
                             </span>
-                            <span style="color: #999; float: left;" data-bind="html: getPubLink(study)"> &nbsp;</span>
+                            <span data-bind="html: study['ot:studyPublicationReference']">&nbsp;</span>
+                            &nbsp;
+                            <span style="color: #999;" data-bind="html: getPubLink(study)"> &nbsp;</span>
                         </div>
-
                         <label style="display: inline-block" data-bind="visible: (study['ot:tag'])">Tags&nbsp;</label>
                         <div class="bootstrap-tagsinput"
                              style="display: inline-block; border: none; margin-bottom: 0; padding: 0 0 4px 0;"

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -192,15 +192,12 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
                         <label style="display: inline-block" data-bind="visible: (study['ot:tag'])">Tags&nbsp;</label>
                         <div class="bootstrap-tagsinput"
                              style="display: inline-block; border: none; margin-bottom: 0; padding: 0 0 4px 0;"
-                             data-bind="visible: study['ot:tag'] !== ''">
+                             data-bind="visible: (study['ot:tag'])">
                         <!-- ko foreach: makeArray(study['ot:tag']) -->
                             <a class="tag label label-info" style="display: none;"
                                href="#" data-bind="text: $data, visible: true"
                                onclick="filterByTag($(this).text()); return false;">&nbsp;</a>
                         <!-- /ko -->
-                            <span style="color: #999; display: none;" data-bind="visible: !(study['ot:tag'])">
-                                This study has not been tagged.
-                            </span>
                         </div>
                     </div>
                 </td>


### PR DESCRIPTION
This is done as a stateful view ("compact" or "full"), so it can be shared in a URL and easily reloaded automatically. Addresses #986.

This is working now on **devtree**. See the issue above for more details.