### PR TITLE
Allow printing (single page) tree views, and saving as SVG

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -708,6 +708,33 @@ tr:hover .row-controls-ghosted {
     /* try to make this offsetParent to all its contents */
     position: relative;
 }
+body.printing-tree-view * {
+    display: none;
+}
+body.printing-tree-view svg,
+body.printing-tree-view svg * {
+    display: block;
+    background-color: #fff !important;
+    position: absolute;
+    z-index: 1000000 !important;
+    top: 50px;
+    left: 0;
+    /* border: 1px red solid; */
+}
+body.printing-tree-view #tree-title,
+body.printing-tree-view #tree-title * {
+    display: block;
+    position: absolute;
+    z-index: 1000000 !important;
+    top: 0px;
+    left: 0;
+    background-color: #fff !important;
+    margin: 0;
+    border: 4px solid #fff;
+    width: 100%;
+}
+
+
 #tree-properties .bootstrap-tagsinput {
     margin-bottom: 0px;
 }

--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -218,7 +218,7 @@ if (!d3) { throw "d3 wasn't included!"};
       });
     var diagonal = options.diagonal || d3.phylogram.rightAngleDiagonal();
     var vis = options.vis || d3.select(selector).append("svg:svg")
-        .attr("width", w + 300)
+        .attr("width", w + 200)
         .attr("height", h + 30)
       .append("svg:g")
         .attr("transform", "translate(120, 20)");
@@ -455,6 +455,19 @@ if (!d3) { throw "d3 wasn't included!"};
         .attr("text-anchor", "start");
     }
 
+    /*
+    // Finalize SVG height/width/scale/left/top to match rendered labels
+    // (prevents cropping when some labels exceed our estimated `labelWidth` above)
+    var renderedBounds = vis.node().getBBox();
+    var svgNode = d3.select( vis.node().parentNode );
+    // match SVG size to the rendered bounds incl. all labels
+    svgNode.style('width', renderedBounds.width +'px')
+           .style('border', '1px red solid')
+           .style('height', renderedBounds.height +'px')
+    // re-center the main group to allow for assymetric label sizes
+    vis.attr('transform', 'translate('+ -(renderedBounds.x) +','+ -(renderedBounds.y) +')');
+    */
+
     return {tree: tree, vis: vis}
   }
 
@@ -462,7 +475,7 @@ if (!d3) { throw "d3 wasn't included!"};
     options = options || {}
     var w = options.width || d3.select(selector).style('width') || d3.select(selector).attr('width'),
         r = w / 2,
-        labelWidth = options.skipLabels ? 10 : options.labelWidth || 120;
+        labelWidth = options.skipLabels ? 10 : options.labelWidth || 160;
 
     var vis = d3.select(selector).append("svg:svg")
         .attr("width", r * 2)
@@ -504,6 +517,18 @@ if (!d3) { throw "d3 wasn't included!"};
         .attr("text-anchor", function(d) { return d.x < 180 ? "end" : "start"; })
         .attr("transform", function(d) { return d.x < 180 ? null : "rotate(180)"; });
     }
+
+    /*
+    // Finalize SVG height/width/scale/left/top to match rendered labels
+    // (prevents cropping when some labels exceed our estimated `labelWidth` above)
+    var renderedBounds = vis.node().getBBox();
+    var svgNode = d3.select( vis.node().parentNode );
+    // match SVG size to the rendered bounds incl. all labels
+    svgNode.style('width', renderedBounds.width +'px')
+           .style('height', renderedBounds.height +'px')
+    // re-center the main group to allow for assymetric label sizes
+    vis.attr('transform', 'translate('+ -(renderedBounds.x) +','+ -(renderedBounds.y) +')');
+    */
 
     return {tree: tree, vis: vis}
   }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -3871,6 +3871,31 @@ function showTreeViewer( tree, options ) {
         }
         */
 
+        /* Show or disable the print widget (requires full-screen support).
+         * This is used to briefly maximize the current tree view (SVG
+         * viewport) and print it on demand.
+         */
+        var $printTreeViewButton = $('button#print-tree-view');
+        if ($.fullscreen.isNativelySupported()) {
+            // ie, the current browser supports full-screen APIs
+            $printTreeViewButton.show();
+            $(document).bind('fscreenchange', function(e, state, elem) {
+                if ($.fullscreen.isFullScreen()) {
+                    //$('#exit-full-screen').show();
+                } else {
+                    //$('#exit-full-screen').hide();
+                }
+            });
+        } else {
+            // dim and disable the full-screen toggle
+            $printTreeViewButton.css("opacity: 0.5;")
+                                .click(function() {
+                                    alert("This browser does not support full-screen display, so it cannot print the tree.");
+                                    return false;
+                                })
+                             .show();
+        }
+
         // hide or show footer options based on tab chosen
         $treeViewerTabs.off('shown').on('shown', function (e) {
             var newTabTarget = $(e.target).attr('href').split('#')[1];
@@ -9875,4 +9900,11 @@ function proposedTaxonNameStatusColor(candidate) {
         default:
             return 'purple';
     }
+}
+
+function printCurrentTreeView() {
+    // go to fullscreen; print stuff; then restore view
+    $('#tree-phylogram svg').fullscreen();
+    //window.print();
+    //$.fullscreen.exit();
 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9903,8 +9903,46 @@ function proposedTaxonNameStatusColor(candidate) {
 }
 
 function printCurrentTreeView() {
-    // go to fullscreen; print stuff; then restore view
-    $('#tree-phylogram svg').fullscreen();
-    //window.print();
-    //$.fullscreen.exit();
+    var $treeViewer = $('#tree-viewer');
+    var $treeSVG = $treeViewer.find('#tree-phylogram svg');
+    var $treeTitle = $treeViewer.find('#tree-title');
+
+    // set a temporary title (becomes the default filename for a saved PDF)
+    var oldTitle = window.document.title;
+    var treeName = $treeTitle.find('span').text();
+    window.document.title = slugify( treeName );
+
+    // move printing elements to the foreground
+    var $svgHolder = $treeSVG.parent();
+    var $titleHolder = $treeTitle.parent();
+    var $pageBody = $('body');
+    $pageBody.append( $treeSVG );
+    $pageBody.append( $treeTitle );
+
+    // adjust SVG viewport (esp. for Firefox, Chrome doesn't need this)
+    // NOTE that we need to use el.setAttribute to keep mixed-case attribute names!
+    var treeSVG = $treeSVG[0];
+    var oldSVGWidth = treeSVG.getAttribute('width');
+    var oldSVGHeight = treeSVG.getAttribute('height');
+    var oldSVGViewBox = treeSVG.getAttribute('viewBox');
+    treeSVG.setAttribute('width', "8in");
+    treeSVG.setAttribute('height', "10in");
+    treeSVG.setAttribute('viewBox', "0 0 "+ oldSVGWidth +" "+ oldSVGHeight);
+
+    // adjust bg and positioning just for print, then undo
+    $pageBody.addClass('printing-tree-view');
+    window.print();
+    $pageBody.removeClass('printing-tree-view');
+
+    // restore SVG viewport for normal use
+    treeSVG.setAttribute('width', oldSVGWidth);
+    treeSVG.setAttribute('height', oldSVGHeight);
+    treeSVG.setAttribute('viewBox', oldSVGViewBox);
+
+    // put the printed elements back in place
+    $svgHolder.append( $treeSVG );
+    $treeTitle.insertBefore( $titleHolder.find('ul.nav-tabs') );
+
+    // restore the normal doc title
+    window.document.title = oldTitle;
 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9920,12 +9920,9 @@ function updateSaveTreeViewLink() {
 
     // confirm SVG has our CSS styles for the tree view (or add them now)
     if ($treeSVG.find('style').length === 0) {
-        // add CSS now, inside the existing `defs` element
-        if ($treeSVG.find('defs').length === 0) {
-            $treeSVG.append('<defs></defs>');
-        }
-        // copy the mainstylesheet exactly
-        $treeSVG.find('defs').eq(0).append( $treeStylesheet[0].outerHTML );
+        // copy the main page's tree-view stylesheet exactly
+        // N.B. putting it where even Inkscape can find it :-/
+        $treeSVG.prepend( $treeStylesheet[0].outerHTML );
     }
 
     // encode the current SVG

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9902,7 +9902,53 @@ function proposedTaxonNameStatusColor(candidate) {
     }
 }
 
+function updateSaveTreeViewLink() {
+    /* This is done on mouseover, so that clicking the link will save
+     * the current tree view as an SVG file. Very loosely adapted from
+     * <http://stackoverflow.com/a/4228053>
+     */
+    // Update the link to use current SVG
+    var $treeViewer = $('#tree-viewer');
+    var $treeStylesheet = $('#tree-view-style');
+    var $treeSVG = $treeViewer.find('#tree-phylogram svg');
+    var $treeTitle = $treeViewer.find('#tree-title');
+    var treeName = $treeTitle.find('span').text();
+    var fileName = slugify( treeName ) +'.svg';
+
+    // confirm SVG has needed attributes (missing in Firefox)
+    $treeSVG.attr({ version: '1.1' , xmlns:"http://www.w3.org/2000/svg"});
+
+    // confirm SVG has our CSS styles for the tree view (or add them now)
+    if ($treeSVG.find('style').length === 0) {
+        // add CSS now, inside the existing `defs` element
+        if ($treeSVG.find('defs').length === 0) {
+            $treeSVG.append('<defs></defs>');
+        }
+        // copy the mainstylesheet exactly
+        $treeSVG.find('defs').eq(0).append( $treeStylesheet[0].outerHTML );
+    }
+
+    // encode the current SVG
+    var base64src = b64EncodeUnicode( $treeSVG[0].outerHTML );
+
+    var $saveLink = $('#save-tree-view');
+    $saveLink.attr('href', 'data:image/svg+xml;base64,\n'+ base64src);
+    $saveLink.attr('download', fileName);
+}
+
+function b64EncodeUnicode(str) {
+    /* Safe encoding for Unicode text, from
+     *  <https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_.22Unicode_Problem.22>
+     */
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+        return String.fromCharCode('0x' + p1);
+    }));
+}
+
 function printCurrentTreeView() {
+    /* Print the current tree, sized to fit within a single vertical page
+     * (since Firefox has limited print support for SVG).
+     */
     var $treeViewer = $('#tree-viewer');
     var $treeSVG = $treeViewer.find('#tree-phylogram svg');
     var $treeTitle = $treeViewer.find('#tree-title');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4318,6 +4318,25 @@ function drawTree( treeOrID, options ) {
         });
 
     ///console.log("> done re-asserting click behaviors");
+
+    // Finalize SVG height/width/scale/left/top to match rendered labels
+    // (prevents cropping when some labels exceed our estimated `labelWidth` above)
+    var renderedBounds = vizInfo.vis.node().getBBox();
+    var svgNode = d3.select( vizInfo.vis.node().parentNode );
+    // match SVG size to the rendered bounds incl. all labels
+    /*
+    console.warn('old width: '+ svgNode.style('width'));
+    console.warn('new width: '+ renderedBounds.width);
+    console.warn('old height: '+ svgNode.style('height'));
+    console.warn('new height: '+ renderedBounds.height);
+    */
+    if (renderedBounds.height > 0) {
+        svgNode.style('height', parseInt(renderedBounds.height) +'px')
+             //.style('border', '1px solid orange')
+               .style('width', parseInt(renderedBounds.width) +'px');
+        // re-center the main group to allow for assymetric label sizes
+        vizInfo.vis.attr('transform', 'translate('+ -(renderedBounds.x) +','+ -(renderedBounds.y) +')');
+    }
 }
 
 function setTreeRoot( treeOrID, rootingInfo ) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4324,16 +4324,11 @@ function drawTree( treeOrID, options ) {
     var renderedBounds = vizInfo.vis.node().getBBox();
     var svgNode = d3.select( vizInfo.vis.node().parentNode );
     // match SVG size to the rendered bounds incl. all labels
-    /*
-    console.warn('old width: '+ svgNode.style('width'));
-    console.warn('new width: '+ renderedBounds.width);
-    console.warn('old height: '+ svgNode.style('height'));
-    console.warn('new height: '+ renderedBounds.height);
-    */
     if (renderedBounds.height > 0) {
-        svgNode.style('height', parseInt(renderedBounds.height) +'px')
-             //.style('border', '1px solid orange')
-               .style('width', parseInt(renderedBounds.width) +'px');
+        svgNode.attr({
+            width: renderedBounds.width,
+            height: renderedBounds.height
+        });
         // re-center the main group to allow for assymetric label sizes
         vizInfo.vis.attr('transform', 'translate('+ -(renderedBounds.x) +','+ -(renderedBounds.y) +')');
     }
@@ -9999,7 +9994,9 @@ function printCurrentTreeView() {
     // restore SVG viewport for normal use
     treeSVG.setAttribute('width', oldSVGWidth);
     treeSVG.setAttribute('height', oldSVGHeight);
-    treeSVG.setAttribute('viewBox', oldSVGViewBox);
+    if (oldSVGViewBox) {  // skip if null
+        treeSVG.setAttribute('viewBox', oldSVGViewBox);
+    }
 
     // put the printed elements back in place
     $svgHolder.append( $treeSVG );

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2567,7 +2567,7 @@ body {
               onclick="$('#full-screen-area').fullscreen(); return false;"><i class="icon-fullscreen"></i> Full screen</button>
       <button id="exit-full-screen" class="btn btn-small pull-right" style="margin-right: 25px; display: none;"
               onclick="$.fullscreen.exit(); return false;"><i class="icon-resize-small"></i> Exit full screen</button>
-      <h3 id='dialog-heading'>
+      <h3 id='tree-title'>
         {{ if viewOrEdit == 'EDIT': }}
             Edit tree
             <input type="text" style="font-size: inherit; vertical-align: baseline; color: #000; font-weight: bold; width: 50%;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -70,7 +70,7 @@ response.files.append(URL('static','js/d3.phylogram.js'))
     </div>
 </div>
 
-<style type="text/css">
+<style id="tree-view-style" type="text/css">
 body {
     overflow-y: scroll;
 }
@@ -3063,8 +3063,11 @@ body {
           <button id="treeview-fetch-conflict" class="btn btn-info" data-bind="click: showConflictDetailsWithHistory">GO!</button>
           <button id="treeview-clear-conflict" class="btn" data-bind="click: hideConflictDetailsWithHistory">Hide conflict</button>
       </div>
-      <button id="print-tree-view" class="btn Xpull-right" style="display: none;" title="Print the current tree view"
-              onclick="printCurrentTreeView(); return false;"><i class="icon-print"></i> Print</button>
+      <a id="save-tree-view" class="btn btn-mini" title="Save the current tree view (as SVG)"
+          href-lang='image/svg+xml' target='_blank' href='data:text/plain,NO IMAGE DATA (wait for tree view to render)'
+          download="not-yet-ready.txt" onmouseover="updateSaveTreeViewLink();"><i class="icon-download-alt"></i></a>
+      <button id="print-tree-view" class="btn btn-mini" style="display: none;" title="Print the current tree view"
+              onclick="printCurrentTreeView(); return false;"><i class="icon-print"></i></button>
       <a class="btn" style="margin-left: 12px;" onclick="$('#tree-viewer').modal('hide'); return false;">Close</a>
     </div>
   </div><!-- /#full-screen-area -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3062,9 +3062,10 @@ body {
           </select>
           <button id="treeview-fetch-conflict" class="btn btn-info" data-bind="click: showConflictDetailsWithHistory">GO!</button>
           <button id="treeview-clear-conflict" class="btn" data-bind="click: hideConflictDetailsWithHistory">Hide conflict</button>
-
       </div>
-      <a class="btn" style="margin-left: 25px;" onclick="$('#tree-viewer').modal('hide'); return false;">Close</a>
+      <button id="print-tree-view" class="btn Xpull-right" style="display: none;" title="Print the current tree view"
+              onclick="printCurrentTreeView(); return false;"><i class="icon-print"></i> Print</button>
+      <a class="btn" style="margin-left: 12px;" onclick="$('#tree-viewer').modal('hide'); return false;">Close</a>
     </div>
   </div><!-- /#full-screen-area -->
 </div>


### PR DESCRIPTION
This started as an attempt to address #998, but I mis-remembered it and was halfway to a print feature before I realized that a downloadable image file was really the goal. As it turns out, there's a lot of overlap between the two, and each feature seems useful, so I've kept them both. These appear in the footer of the curation app's tree viewer:

![screen shot 2016-09-16 at 7 07 37 pm]
(https://cloud.githubusercontent.com/assets/446375/18603593/e886d606-7c40-11e6-96f4-0c75252498ee.png)

In each case, the saved (or printed) tree will reflect the current layout and any displayed conflict information. The saved SVG is self-contained and editable in Inkscape (presumably also Illustrator, but confirmation would be great).

This is working now on **devtree**.  Tested in Chrome, Firefox, and Safari. Currently the printed tree is sized to fit on a single vertical page -- not ideal for a large tree, but some browsers are pretty... limited in how they handle SVG printing. _< Firefox :eyes: >_