### PR TITLE
Sort taxonomy releases by date (vs. version)

### DIFF
--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -310,7 +310,9 @@ def taxonomy_version():
 
     # Get OTT version from URL, or bounce to the latest version by default
     if len(request.args) == 0:
-        taxonomy_version = sorted([v.get('version') for v in ott], reverse=False)[-1]
+        # safer to sort by date-strings [yyyy-mm-dd] than version strings
+        sorted_ott = sorted(ott, key=lambda v: v['date'], reverse=False)
+        taxonomy_version = sorted_ott[-1].get('version')
         redirect(URL('opentree', 'about', 'taxonomy_version', 
             vars={}, 
             args=[taxonomy_version]))

--- a/webapp/static/statistics/ott.json
+++ b/webapp/static/statistics/ott.json
@@ -4,6 +4,7 @@
         "===": "Note that releases are listed in reverse chronological order.",
         "===": "taxon_count comes from `wc -l taxonomy.tsv`",
         "===": "visible_taxon_count comes from `cleaned_ott/index.html` in propinquity output",
+        "===": "For proper sorting, all `date` strings must be in the form {yyyy-mm-dd}!",
 
         "version": "ott2.10",
         "date": "2016-09-10",

--- a/webapp/views/about/taxonomy_version.html
+++ b/webapp/views/about/taxonomy_version.html
@@ -100,13 +100,20 @@ var relatedSynthReleases = {{= XML(json.dumps(related_synth_releases )) }};
 $(document).ready(function() {
     // show current profiles, or a notice if no data was found 
     if (taxonomy_stats) {
-        // load and sort versions in ascending order
+        // N.B. we sort by release date (yyyy-mm-dd), safer than sorting semantic versions
+        taxonomy_stats.sort(function(a,b) {
+            if (a.date < b.date) {
+                return -1;
+            }
+            return 1;
+        });
+        // extract just version strings, oldest first
         sortedTaxonomyVersions = $.map(
             taxonomy_stats, 
             function( versionInfo, i ) {
                 return versionInfo.version;
             }
-        ).sort();
+        );
 
         // start with the profile whose date is in the URL (or latest, by default)
         if (taxonomyVersion) {


### PR DESCRIPTION
This fixes problems on [the /taxonomy-version page](https://devtree.opentreeoflife.org/about/taxonomy-version). We were doing a naive alphabetic sort on version strings, so "ott2.10" was out of place vs "ott2.6", "ott2.9", etc. Now we sort on release dates instead, which are in the reliable format `{yyyy-mm-dd}`.

This is working now on **devtree**.