### PR TITLE
Add an external link from viewed taxon to OneZoom.

### DIFF
--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1288,7 +1288,7 @@ function showObjectProperties( objInfo, options ) {
               + '<li><a target="_blank" href="http://eol.org/search?q='+ urlSafeDisplayName +'" id="link-to-EOL">'
               +    'Search EOL for \''+ displayName +'\'</a></li>'
               + '<li><a target="onezoom" href="http://www.onezoom.org/life.html/@='+ itsTaxon.ott_id +'" id="link-to-OneZoom">'
-              +    'Browse \''+ displayName +'\' in OneZoom</a></li>'
+              +    'Browse '+ displayName +' in OneZoom</a></li>'
               + '</ul>');
         }
     }

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1284,7 +1284,12 @@ function showObjectProperties( objInfo, options ) {
             // Make this name safe for use in our EOL search URL
             // (prefer '+' to '%20', but carefully encode other characters)
             var urlSafeDisplayName = encodeURIComponent(displayName).replace(/%20/g,'+');
-            $details.after('<ul class="external-links"><li><a target="_blank" href="http://eol.org/search?q='+ urlSafeDisplayName +'" id="link-to-EOL">Search EOL for \''+ displayName +'\'</a></li></ul>');
+            $details.after('<ul class="external-links">' 
+              + '<li><a target="_blank" href="http://eol.org/search?q='+ urlSafeDisplayName +'" id="link-to-EOL">'
+              +    'Search EOL for \''+ displayName +'\'</a></li>'
+              + '<li><a target="onezoom" href="http://www.onezoom.org/life.html/@='+ itsTaxon.ott_id +'" id="link-to-OneZoom">'
+              +    'Browse \''+ displayName +'\' in OneZoom</a></li>'
+              + '</ul>');
         }
     }
 

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -317,6 +317,9 @@ div.viewer-frame {
     margin: 6px 0 12px 8px;
     list-style: none;
 }
+#provenance-panel .properties-section ul.external-links li {
+    margin: 4px 0;
+}
 #provenance-panel .properties-section.selected {
     border: 2px solid #d33;
 }


### PR DESCRIPTION
Add a link (below the EOL query) for OTT taxa in the synth-tree view. These will always open in a single named window/frame 'onezoom'. This is working now on **devtree**.

Addresses #1051; see comments there for possible bugs in the resulting OneZoom views.