### PR TITLE
Fix bare DOIs (for pub reference AND data deposit)

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -520,6 +520,8 @@ function getFocalCladeLink(study) {
 
     return '<a href="#" onclick="filterByClade(\''+ cladeName +'\'); return false;"'+'>'+ cladeName +'</a'+'>';
 }
+
+var urlPattern = new RegExp('http(s?)://\\S+');
 function getPubLink(study) {
     var urlNotFound = false;
     var pubURL;
@@ -534,7 +536,12 @@ function getPubLink(study) {
     if (urlNotFound) {
         return "";
     }
-    return '<a href="'+ pubURL +'" target="_blank"'+'>'+ pubURL +'</a'+'>';
+    if (urlPattern.test(pubURL) === true) {
+        // It's a proper URL, wrap it in a hyperlink
+        return '<a href="'+ pubURL +'" target="_blank"'+'>'+ pubURL +'</a'+'>';
+    }
+    // It's not a proper URL! Return the bare value.
+    return pubURL;
 }
 /*
 function getSuggestedActions(study) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8379,6 +8379,20 @@ function currentStudyVersionContributedToLatestSynthesis() {
     return (viewModel.startingCommitSHA === latestSynthesisSHA);
 }
 
+function getStudyPublicationLink() {
+    var url = $.trim(viewModel.nexml['^ot:studyPublication']['@href']);
+    // If there's no URL, we have nothing to say
+    if (url === '') {
+        return '';
+    }
+    if (urlPattern.test(url) === true) {
+        // It's a proper URL, wrap it in a hyperlink
+        return '<a target="_blank" href="'+ url +'">'+ url +'</a>';
+    }
+    // It's not a proper URL! Return the bare value.
+    return url;
+}
+
 function getDataDepositMessage() {
     // Returns HTML explaining where to find this study's data, or an empty
     // string if no URL is found. Some cryptic dataDeposit URLs may require
@@ -8408,8 +8422,12 @@ function getDataDepositMessage() {
 
     // TODO: Add other substitutions?
 
-    // default message simply repeats the dataDeposit URL
-    return 'Data for this study is permanently archived here:<br/><a href="'+ url +'" target="_blank">'+ url +'</a>';
+    if (urlPattern.test(url) === true) {
+        // Default message simply repeats the dataDeposit URL
+        return 'Data for this study is permanently archived here:<br/><a href="'+ url +'" target="_blank">'+ url +'</a>';
+    }
+    // It's not a proper URL! Return the bare value.
+    return url;
 }
 
 function showDownloadFormatDetails() {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -784,7 +784,14 @@ function loadSelectedStudy() {
             if (!(['^ot:studyPublicationReference'] in data.nexml)) {
                 data.nexml['^ot:studyPublicationReference'] = "";
             }
-            if (!(['^ot:studyPublication'] in data.nexml)) {
+            if (['^ot:studyPublication'] in data.nexml) {
+                // Convert a "bare" DOI, if found (e.g. from TreeBASE import)
+                var oldValue = data.nexml['^ot:studyPublication']['@href'];
+                var newValue = DOItoURL( oldValue );
+                if (newValue !== oldValue) {
+                    data.nexml['^ot:studyPublication']['@href'] = newValue;
+                }
+            } else {
                 data.nexml['^ot:studyPublication'] = {
                     '@href': ""
                 };
@@ -815,7 +822,14 @@ function loadSelectedStudy() {
             if (!(['^ot:comment'] in data.nexml)) {
                 data.nexml['^ot:comment'] = "";
             }
-            if (!(['^ot:dataDeposit'] in data.nexml)) {
+            if (['^ot:dataDeposit'] in data.nexml) {
+                // Convert a "bare" DOI, if found (e.g. from TreeBASE import)
+                var oldValue = data.nexml['^ot:dataDeposit']['@href'];
+                var newValue = DOItoURL( oldValue );
+                if (newValue !== oldValue) {
+                    data.nexml['^ot:dataDeposit']['@href'] = newValue;
+                }
+            } else {
                 data.nexml['^ot:dataDeposit'] = {
                     '@href': ""
                 };
@@ -7739,6 +7753,16 @@ function formatDOIAsURL() {
         return;
     }
     viewModel.nexml['^ot:studyPublication']['@href'] = newValue;
+    nudgeTickler('GENERAL_METADATA');
+}
+function formatDataDepositDOIAsURL() {
+    var oldValue = viewModel.nexml['^ot:dataDeposit']['@href'];
+    var newValue = DOItoURL( oldValue );
+    if (newValue === oldValue) {
+        // no change, so no further action needed
+        return;
+    }
+    viewModel.nexml['^ot:dataDeposit']['@href'] = newValue;
     nudgeTickler('GENERAL_METADATA');
 }
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -324,10 +324,10 @@ body {
                   <button type="button" class="btn btn-info" onclick="lookUpDOI(); return false;">Look up DOI...</button>
                 {{ else: }}
                   <p class="static-form-value">
-                  <!-- ko if: nexml['^ot:studyPublication']['@href'] !== '' -->
-                      <a target="_blank" data-bind="text: nexml['^ot:studyPublication']['@href'], attr: { href: nexml['^ot:studyPublication']['@href'] }"></a>
+                 <!-- ko if: getStudyPublicationLink() !== '' -->
+                      <span data-bind="html: getStudyPublicationLink()">&nbsp;</span>
                  <!-- /ko -->
-                 <!-- ko if: nexml['^ot:studyPublication']['@href'] === '' -->
+                 <!-- ko if: getStudyPublicationLink() === '' -->
                       <em>None</em>
                  <!-- /ko -->
                   </p>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -349,7 +349,7 @@ body {
                 {{ if viewOrEdit == 'EDIT': }}
                   <input data-bind="value: nexml['^ot:dataDeposit']['@href'],
                                     valueUpdate: ['afterkeydown', 'input'],
-                                    event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: validateAndTestDOI },
+                                    event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: formatDataDepositDOIAsURL },
                                     css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyDataDeposit" class="input-xlarge" placeholder="">
                 {{ else: }}
                   <p class="static-form-value">


### PR DESCRIPTION
More careful handling of DOI-or-URL fields `ot:studyPublication` and `ot:dataDeposit`. When loading a study, we'll convert bare DOIs to their URL form, if possible. This fixes bugs in both the
read-only and editable pages. Addresses https://github.com/OpenTreeOfLife/peyotl/issues/138, but not a complete solution.

In the read-only view of curation app, we've been making hyperlinks from user-entered values that are not bare DOIs _or_ proper URLs. Instead, we should just show these as the raw (string) value. The same fix applies to the main study list; we'll show invalid URLs _and_ bare DOIs as simple strings, instead of as broken hyperlinks.