### PR TITLE
Change presentation of tree status vs. current and next synthesis

### DIFF
--- a/curator/README.md
+++ b/curator/README.md
@@ -63,14 +63,14 @@ The returned object (for the any ot:nexson format invocation) will have 2 keys:
   4. `dateTranslated`: "2014-02-23T05:17:12.607189", 
 and several of the arguments that are sent in in the original invocation 
 are echoed back, including:
-    'newTreesPreferred': true/false
+    'includeNewTreesInSynthesis': true/false
     'dataDeposit': 'http://example.org', 
     'filename': 'avian_ovomucoids.tre', 
     'idPrefix': '', 
     'inputFormat': 'newick', 
     'nexml2json': '0.0.0', 
-Note that even if newTreesPreferred is True, no trees are flagged as
-being candidates for synthesis.
+Note that even if includeNewTreesInSynthesis is True, no trees are flagged for
+inclusion on the server (this is echoed back and done in the curation webapp).
 
 Primarily for the sake of debugging, the intermediates can be fetched using the "output" argument. This can be one of: 'nexson', 'nexml', 'input', 'provenance'
 

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -521,14 +521,14 @@ def to_nexson():
         orig_args['uploadId'] = unique_id
         orig_args['inputFormat'] = inp_format
         orig_args['idPrefix'] = idPrefix
-        orig_args['newTreesPreferred'] = False
-        if 'newTreesPreferred' in request.vars:
-            v = request.vars.newTreesPreferred
+        orig_args['includeNewTreesInSynthesis'] = False
+        if 'includeNewTreesInSynthesis' in request.vars:
+            v = request.vars.includeNewTreesInSynthesis
             if isinstance(v, str) or isinstance(v, unicode):
                 if v.lower() in ["true", "yes", "1"]:
-                    orig_args['newTreesPreferred'] = True
+                    orig_args['includeNewTreesInSynthesis'] = True
             elif isinstance(v, bool) and v:
-                orig_args['newTreesPreferred'] = True
+                orig_args['includeNewTreesInSynthesis'] = True
         fa_tuples = [('first_tree_available_edge_id', 'firstAvailableEdgeID', 'e'), 
                      ('first_tree_available_node_id', 'firstAvailableNodeID', 'n'),
                      ('first_tree_available_otu_id', 'firstAvailableOTUID', 'o'),

--- a/curator/controllers/study.py
+++ b/curator/controllers/study.py
@@ -45,7 +45,10 @@ def view():
     view_dict['maintenance_info'] = get_maintenance_info(request)
     #view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
     view_dict['studyID'] = request.args[0]
-    view_dict['latestSynthesisSHA'] = _get_latest_synthesis_sha_for_study_id(view_dict['studyID'])
+    #view_dict['latestSynthesisSHA'] = _get_latest_synthesis_sha_for_study_id(view_dict['studyID'])
+    synth_details = _get_latest_synthesis_details_for_study_id(view_dict['studyID'])
+    view_dict['latestSynthesisSHA'] = synth_details.get('sha', '')
+    view_dict['latestSynthesisTreeIDs'] = synth_details.get('tree_ids')
     view_dict['viewOrEdit'] = 'VIEW'
     view_dict['userCanEdit'] = auth.is_logged_in() and True or False;
     return view_dict
@@ -75,13 +78,18 @@ def edit():
     view_dict = get_opentree_services_method_urls(request)
     view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
     view_dict['studyID'] = request.args[0]
-    view_dict['latestSynthesisSHA'] = _get_latest_synthesis_sha_for_study_id(view_dict['studyID'])
+    #view_dict['latestSynthesisSHA'] = _get_latest_synthesis_sha_for_study_id(view_dict['studyID'])
+    synth_details = _get_latest_synthesis_details_for_study_id(view_dict['studyID'])
+    view_dict['latestSynthesisSHA'] = synth_details.get('sha')
+    view_dict['latestSynthesisTreeIDs'] = synth_details.get('tree_ids')
     view_dict['viewOrEdit'] = 'EDIT'
     return view_dict
 
 
-def _get_latest_synthesis_sha_for_study_id( study_id ):
-    # Fetch this SHA from treemachine. If not found in contributing studies, return None
+def _get_latest_synthesis_details_for_study_id( study_id ):
+    # Fetch the contributing tree IDs and SHA from treemachine, if found. If
+    # this study is not found in the latest synth sources, return None for
+    # `sha` and an empty list for `tree_ids`.
     try:
         from gluon.tools import fetch
         import simplejson
@@ -94,33 +102,29 @@ def _get_latest_synthesis_sha_for_study_id( study_id ):
             # Prepend scheme to a scheme-relative URL
             fetch_url = "https:%s" % fetch_url
         # as usual, this needs to be a POST (pass empty fetch_args)
-        source_list_response = fetch(fetch_url, data='')
+        source_list_response = fetch(fetch_url, data={'include_source_list': True})
         source_list = simplejson.loads( source_list_response )
-
-        # split these source descriptions, which are in the form '{STUDY_ID_PREFIX}_{STUDY_NUMERIC_ID}_{TREE_ID}_{COMMIT_SHA}'
-        contributing_study_info = { }   # store (unique) study IDs as keys, commit SHAs as values
-
-        for source_desc in source_list:
-            if source_desc == 'taxonomy':
-                continue
-            source_parts = source_desc.split('_')
-            # add default prefix 'pg' to study ID, if not found
-            if source_parts[0].isdigit():
-                # prepend with default namespace 'pg'
-                study_id = 'pg_%s' % source_parts[0]
-            else:
-                study_id = '_'.join(source_parts[0:2])
-            if len(source_parts) == 4:
-                commit_SHA_in_synthesis = source_parts[3]
-            else:
-                commit_SHA_in_synthesis = None
-            contributing_study_info[ study_id ] = commit_SHA_in_synthesis
-
-        return contributing_study_info.get( study_id, '')
+        source_id_map = source_list.get('source_id_map', {})
+        # find all source trees belonging to this study, compile their tree IDs and compare SHAs
+        sha = ''
+        tree_ids = [ ]
+        for source_id in source_id_map:
+            source_details = source_id_map.get( source_id )
+            src_study_id = source_details.get('study_id', None)
+            if src_study_id == study_id:
+                src_tree_id = source_details.get('tree_id', '')
+                src_sha = source_details.get('git_sha', '')
+                tree_ids.append( src_tree_id )
+                if sha:  # no longer the empty string
+                    # all sources for this study should use the same SHA!
+                    assert src_sha == sha
+                else:    # set the SHA now
+                    sha = src_sha
+        return {'sha': sha, 'tree_ids': tree_ids}
 
     except Exception, e:
         # throw 403 or 500 or just leave it
-        raise HTTP(500, T('Unable to retrieve latest synthesis SHA for study {u}'.format(u=study_id)))
+        raise HTTP(500, T('Unable to retrieve latest synthesis details for study {u}'.format(u=study_id)))
 
 @auth.requires_login()
 def delete():

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1131,11 +1131,11 @@ function loadSelectedStudy() {
                     case 'In all trees':
                         chosenTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                         break;
-                    case 'In preferred trees':
-                        chosenTrees = getPreferredTrees()
+                    case 'In trees nominated for synthesis':
+                        chosenTrees = getTreesNominatedForSynthesis()
                         break;
-                    case 'In non-preferred trees':
-                        chosenTrees = getNonPreferredTrees()
+                    case 'In trees not yet nominated':
+                        chosenTrees = getTreesNotYetNominated()
                         break;
                     default:
                         chosenTrees = [];
@@ -1167,8 +1167,8 @@ function loadSelectedStudy() {
                         switch (scope) {
                             case 'In all trees':
                                 // N.B. Even here, we want to hide (but not preserve) OTUs that don't appear in any tree
-                            case 'In preferred trees':
-                            case 'In non-preferred trees':
+                            case 'In trees nominated for synthesis':
+                            case 'In trees not yet nominated':
                                 // check selected trees for this node
                                 var foundInMatchingTree = false;
                                 var otuID = otu['@id'];
@@ -2172,7 +2172,7 @@ function updateMappingStatus() {
                     // we can add more by including 'All trees'
                     detailsHTML = '<p'+'><strong>Congrtulations!</strong> '
                             +'Mapping is suspended because all OTUs in this '
-                            +'study\'s preferred trees have accepted labels already. To continue, '
+                            +'study\'s nominated trees have accepted labels already. To continue, '
                             +'reject some mapped labels with the '
                             +'<span class="btn-group" style="margin: -2px 0;">'
                             +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
@@ -2738,69 +2738,27 @@ function getAllTreeLabels() {
     });
 }
 
-function getPreferredTreeIDs() {
-    preferredTreeIDs = [];
-    var candidateTreeMarkers = ('^ot:candidateTreeForSynthesis' in viewModel.nexml) ?
-        makeArray( viewModel.nexml['^ot:candidateTreeForSynthesis'] ) : [];
-
-    $.each(candidateTreeMarkers, function(i, marker) {
-        var treeID = $.trim(marker);
-        switch(treeID) {  // non-empty points to a candidate tree
-            case '':
-            case '0':
-                break;
-            default:
-                preferredTreeIDs.push( treeID );
-        }
-    });
-    return preferredTreeIDs;
-}
-function getPreferredTrees() {
-    var preferredTreeIDs = getPreferredTreeIDs();
-    var allTrees = [];
-    $.each(viewModel.nexml.trees, function(i, treesCollection) {
-        $.each(treesCollection.tree, function(i, tree) {
-            allTrees.push( tree );
-        });
-    });
+function getTreesNominatedForSynthesis() {
+    var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
     return ko.utils.arrayFilter(
         allTrees,
-        isPreferredTree
+        isReadyForSynthesis
     );
 }
-function isPreferredTree(treeOrID) {
-    var treeID = ('@id' in treeOrID) ? treeOrID['@id'] : treeOrID;
-    var preferredTreeIDs = getPreferredTreeIDs();
-    var isPreferred = ($.inArray(treeID, preferredTreeIDs) !== -1);
-    return isPreferred;
-}
-function togglePreferredTree( tree ) {
-    var treeID = tree['@id'];
-    var alreadyPreferred = ($.inArray( treeID, getPreferredTreeIDs()) !== -1);
-    if (alreadyPreferred) {
-        // remove it from the list of preferred trees
-        removeFromArray( treeID, viewModel.nexml['^ot:candidateTreeForSynthesis'] );
-    } else {
-        // add it to the list of preferred trees
-        viewModel.nexml['^ot:candidateTreeForSynthesis'].push( treeID );
+function isReadyForSynthesis( treeOrID ) {
+    var tree = ('@id' in treeOrID) ? treeOrID : getTreeByID( treeOrID );
+    if (tree['^ot:readyForSynthesis'] === 'Include this tree') {
+        return true;
     }
-    nudgeTickler('TREES');
-    nudgeTickler('OTU_MAPPING_HINTS');
-    return true;  // to allow checkbox updates
+    return false;
 }
-function getNonPreferredTrees() {
-    var preferredTreeIDs = getPreferredTreeIDs();
-    var allTrees = [];
-    $.each(viewModel.nexml.trees, function(i, treesCollection) {
-        $.each(treesCollection.tree, function(i, tree) {
-            allTrees.push( tree );
-        });
-    });
+
+function getTreesNotYetNominated() {
+    var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
     return ko.utils.arrayFilter(
         allTrees,
-        function(tree) {
-            var isPreferred = ($.inArray(tree['@id'], preferredTreeIDs) !== -1);
-            return !isPreferred;
+        function (tree) {
+            return !(isReadyForSynthesis(tree));
         }
     );
 }
@@ -3068,8 +3026,8 @@ function TreeNode() {
  *      min threshold
  *      study data is complete
  *      nice-to-have (what are the finishing touches?)
- *      one preferred tree?
- *      preferred tree(s) is/are rooted? or "unrooted" disclaimer was chosen?
+ *      one tree nominated for synthesis?
+ *      nominated tree(s) is/are rooted? or "unrooted" disclaimer was chosen?
  *
  * integrity
  *      all taxon names mapped (perhaps this score is proportional)
@@ -3255,25 +3213,13 @@ var studyScoringRules = {
                 // TODO: add hint/URL/fragment for when curator clicks on suggested action?
         },
         {
-            description: "For studies nominated for synthesis, there should be at least one preferred tree.",
+            description: "Trees nominated for synthesis should not have duplicate (non-monophyletic) tips mapped to a single taxon.",
             test: function(studyData) {
-                // check for any candidate tree in the study
-                return getPreferredTrees().length > 0;
-            },
-            weight: 0.2,
-            successMessage: "There is at least one preferred tree, or this study is not nominated for synthesis.",
-            failureMessage: "There should be at least one preferred tree, or the study should not be nominated for synthesis.",
-            suggestedAction: "Mark at least one tree as preferred, or mark this study as not contributing to synthesis in Metadata."
-                // TODO: add hint/URL/fragment for when curator clicks on suggested action?
-        },
-        {
-            description: "Preferred trees should not have duplicate (non-monophyletic) tips mapped to a single taxon.",
-            test: function(studyData) {
-                // check preferred trees (synthesis candidates) only
+                // check nominated trees (synthesis candidates) only
                 //var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                 var duplicateNodesFound = false;
                 var startTime = new Date();
-                $.each(getPreferredTrees(), function(i, tree) {
+                $.each(getTreesNominatedForSynthesis(), function(i, tree) {
                     // disregard sibling-only duplicates (will be resolved on the server)
                     var duplicateData = getUnresolvedDuplicatesInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
                     if ( !($.isEmptyObject(duplicateData)) ) {
@@ -3285,7 +3231,7 @@ var studyScoringRules = {
                 return !(duplicateNodesFound);
             },
             weight: 0.2,
-            successMessage: "No duplicate tips (mapped to the same taxon) found in preferred trees.",
+            successMessage: "No duplicate tips (mapped to the same taxon) found in trees nominated for synthesis.",
             failureMessage: "Multiple tips map to the same taxon (no exemplar chosen).",
             suggestedAction: "Designate an exemplar for each set of tips mapped to the same taxon."
         },
@@ -3293,7 +3239,7 @@ var studyScoringRules = {
             description: "Internal node labels should have a defined type.",
             test: function(studyData) {
                 // TODO: opt-out if study not intended for synthesis?
-                // TODO: skip non-preferred trees?
+                // TODO: skip non-nominated trees?
                 // check all trees
                 var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                 var ambiguousLabelsFound = false;
@@ -3458,13 +3404,13 @@ var studyScoringRules = {
     ],
     */
     'OTU Mapping': [
-        // checks that all preferred tree tips mapped to OTT taxon names (i.e. pass / fail test)
+        // checks that all nominated trees' tips are mapped to OTT taxon names (i.e. pass / fail test)
         {
-            description: "All tip labels in preferred trees should be mapped to the Open Tree Taxonomy.",
+            description: "All tip labels (in trees nominated for synthesis) should be mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
+                // check the proportion of mapped leaf nodes in all nominated trees
                 var unmappedLeafNodes = false;
-                $.each(getPreferredTrees(), function(i, tree) {
+                $.each(getTreesNominatedForSynthesis(), function(i, tree) {
                     nodeCounts = getNodeCounts(tree)
                     if (nodeCounts.mappedTips != nodeCounts.totalTips) {
                       return true; // no need to look at other trees for pass / fail test
@@ -3475,21 +3421,21 @@ var studyScoringRules = {
             },
             weight: 0.5,
             successMessage: "Preferred trees (submitted for synthesis) have all tips mapped to Open Tree Taxonomy.",
-            failureMessage: "There are unmapped tip labels in preferred trees (submitted for synthesis).",
+            failureMessage: "There are unmapped tip labels in trees nominated for synthesis.",
             suggestedAction: "Review all unmapped tips in OTU Mapping."
                 // TODO: add hint/URL/fragment for when curator clicks on suggested action?
         }
         /* commenting this out for now because no way to deal with non pass-fail tests
         {
-            // checks fraction of OTUs mapped in preferred trees
+            // checks fraction of OTUs mapped in nominated trees
             // does not currently add to quality score (weight = 0)
-            description: "What fraction of tip labels in preferred trees are mapped to the Open Tree Taxonomy.",
+            description: "What fraction of tip labels in nominated trees are mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
+                // check the proportion of mapped leaf nodes in all nominated trees
                 var totalTips = 0;
                 var mappedTips = 0;
                 var fractionMapped = 0;
-                $.each(getPreferredTrees(), function(i, tree) {
+                $.each(getTreesNominatedForSynthesis(), function(i, tree) {
                     nodeCounts = getNodeCounts(tree)
                     totalTips += nodeCounts.totalTips
                     mappedTips += nodeCounts.mappedTips
@@ -3499,14 +3445,14 @@ var studyScoringRules = {
                 if (totalTips != 0) {
                   fractionMapped = mappedTips/totalTips;
                 }
-                console.log(mappedTips + "/" + totalTips + " = " + floatToPercent(fractionMapped) + "% of OTUs in preferred trees mapped")
+                console.log(mappedTips + "/" + totalTips + " = " + floatToPercent(fractionMapped) + "% of OTUs in nominated trees mapped")
                 return fractionMapped;
             },
             // would like to update weight based on fractionMapped, but in different scopes
             // with this setup
             weight: 0.5,
             successMessage: "Preferred trees (submitted for synthesis) have all tips mapped to Open Tree Taxonomy.",
-            failureMessage: "There are unmapped tip labels in preferred trees (submitted for synthesis).",
+            failureMessage: "There are unmapped tip labels in trees nominated for synthesis.",
             suggestedAction: "Review all unmapped tips in OTU Mapping."
                 // TODO: add hint/URL/fragment for when curator clicks on suggested action?
         }
@@ -3987,9 +3933,9 @@ function findOTUInTrees( otu, trees ) {
 function showOTUInContext() {
     // use the popup tree viewer to show this node in place (to clarify OTU mapping, etc)
     var otu = this;
-    // start with preferred trees (show best-quality results first)
-    var otuContextsToShow = findOTUInTrees( otu, getPreferredTrees() );
-    $.merge( otuContextsToShow, findOTUInTrees( otu, getNonPreferredTrees() ) );
+    // start with nominated trees (show best-quality results first)
+    var otuContextsToShow = findOTUInTrees( otu, getTreesNominatedForSynthesis() );
+    $.merge( otuContextsToShow, findOTUInTrees( otu, getTreesNotYetNominated() ) );
     // if this OTU is unused, something's very wrong; bail out now
     if (otuContextsToShow.length === 0) {
         alert("This OTU doesn't appear in any tree. (This is not expected.)");
@@ -4008,7 +3954,7 @@ function showOTUInContext() {
 function showDuplicateNodesInTreeViewer(tree) {
     // If there are no duplicates, fall back to simple tree view
     var duplicateData = getUnresolvedDuplicatesInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
-    if (!isPreferredTree(tree) || $.isEmptyObject(duplicateData)) {
+    if (!isReadyForSynthesis(tree) || $.isEmptyObject(duplicateData)) {
         showTreeWithHistory(tree);
         return;
     }
@@ -4981,9 +4927,9 @@ function returnFromNewTreeSubmission( jqXHR, textStatus ) {
         treesElement['tree'] = makeArray( treesElement['tree'] );
         $.each( treesElement.tree, function(i, tree) {
             normalizeTree( tree );
-            if (responseJSON.newTreesPreferred) {
-                // mark all new tree(s) as preferred, eg, a candidate for synthesis
-                viewModel.nexml['^ot:candidateTreeForSynthesis'].push( tree['@id'] );
+            if (responseJSON.includeNewTreesInSynthesis) {
+                // nominate this new tree for synthesis
+                tree['^ot:readyForSynthesis'] = 'Include this tree';
             }
         });
     });
@@ -5426,11 +5372,6 @@ function removeTree( tree ) {
     // TODO: remove any captive trees- and OTUs-collections
     // TODO: remove any otus not used elsewhere?
     // TODO: remove related annotation events and agents?
-
-    if ($.inArray(tree['@id'], getPreferredTreeIDs()) !== -1) {
-        // remove its ID from list of preferred (candidate) trees
-        togglePreferredTree( tree );
-    }
 
     // force rebuild of all tree-related lookups
     buildFastLookup('NODES_BY_ID');
@@ -7833,7 +7774,7 @@ function getDuplicateNodesInTree( tree ) {
     // 'exemplar' node to avoid problems in synthesis.
     var duplicateNodes = { };
 
-    if (!isPreferredTree(tree)) {
+    if (!isReadyForSynthesis(tree)) {
         // ignoring these for now...
         return duplicateNodes;
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8354,6 +8354,10 @@ function currentStudyVersionContributedToLatestSynthesis() {
     // compare SHA values and return true if they match
     return (viewModel.startingCommitSHA === latestSynthesisSHA);
 }
+function treeContributedToLatestSynthesis(tree) {
+    // check for a valid SHA from last synthesis
+    return ($.inArray( tree['@id'], latestSynthesisTreeIDs ) !== -1);
+}
 
 function getDataDepositMessage() {
     // Returns HTML explaining where to find this study's data, or an empty

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -832,10 +832,10 @@ function loadSelectedStudy() {
                 $.each(allTrees, function( i, tree ) {
                     if ($.inArray(tree['@id'], preferredTreeIDs) !== -1) {
                         // this was a preferred tree (chosen for inclusion in synthesis)
-                        tree['^ot:candidateForSynthesis'] = 'Include this tree';
+                        tree['^ot:candidateForSynthesis'] = 'ot:include';
                     } else {
                         // not a preferred tree, play it safe with default value
-                        tree['^ot:candidateForSynthesis'] = 'Not reviewed';
+                        tree['^ot:candidateForSynthesis'] = 'ot:notReviewed';
                     }
                 });
                 delete data.nexml['^ot:candidateTreeForSynthesis'];
@@ -2688,7 +2688,7 @@ function normalizeTree( tree ) {
         tree['^ot:unrootedTree'] = true;
     }
     if (!(['^ot:candidateForSynthesis'] in tree)) {
-        tree['^ot:candidateForSynthesis'] = 'Not reviewed';
+        tree['^ot:candidateForSynthesis'] = 'ot:notReviewed';
     }
 
     // metadata fields (with empty default values)
@@ -2744,6 +2744,30 @@ var treeCandidateForSynthesisDescriptions = [
     { value: 'ot:needsCuration', text: "Needs curation" },
     { value: 'ot:include',       text: "Include this tree" }
 ]
+function getCandidateForSynthesisDescriptionForValue( value ) {
+    var description = '';
+    $.each( treeCandidateForSynthesisDescriptions, function( i, item ) {
+        if (item.value === value) {
+            description = item.text;
+            return false;
+        }
+        return true;
+    });
+    return description;
+}
+function getCandidateForSynthesisDescriptionForTree( tree ) {
+    var rawModeValue = tree['^ot:candidateForSynthesis'];
+    var description = '';
+    $.each( treeCandidateForSynthesisDescriptions, function( i, item ) {
+        if (item.value === rawModeValue) {
+            description = item.text;
+            return false;
+        }
+        return true;
+    });
+    return description;
+}
+
 function getTreesNominatedForSynthesis() {
     var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
     return ko.utils.arrayFilter(
@@ -2753,7 +2777,7 @@ function getTreesNominatedForSynthesis() {
 }
 function isReadyForSynthesis( treeOrID ) {
     var tree = ('@id' in treeOrID) ? treeOrID : getTreeByID( treeOrID );
-    if (tree['^ot:candidateForSynthesis'] === 'Include this tree') {
+    if (tree['^ot:candidateForSynthesis'] === 'ot:include') {
         return true;
     }
     return false;
@@ -4935,7 +4959,7 @@ function returnFromNewTreeSubmission( jqXHR, textStatus ) {
             normalizeTree( tree );
             if (responseJSON.includeNewTreesInSynthesis) {
                 // nominate this new tree for synthesis
-                tree['^ot:candidateForSynthesis'] = 'Include this tree';
+                tree['^ot:candidateForSynthesis'] = 'ot:include';
             }
         });
     });

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -665,13 +665,6 @@ function loadSelectedStudy() {
                 return;
             }
             // pull data from bare NexSON repsonse or compound object (data + sha)
-            /*
-            if (response['data']) {
-                console.log("FOUND inner data (compound response)...");
-            } else {
-                console.log("inner data NOT found (bare NexSON)...");
-            }
-            */
             var data = response['data'] || response;
             if (typeof data !== 'object' || typeof(data['nexml']) == 'undefined') {
                 showErrorMessage('Sorry, there is a problem with the study data (missing NexSON).');
@@ -809,8 +802,10 @@ function loadSelectedStudy() {
             if (!(['^ot:focalCladeOTTTaxonName'] in data.nexml)) {
                 data.nexml['^ot:focalCladeOTTTaxonName'] = "";
             }
-            if (!(['^ot:notIntendedForSynthesis'] in data.nexml)) {
-                data.nexml['^ot:notIntendedForSynthesis'] = false;
+            if (['^ot:notIntendedForSynthesis'] in data.nexml) {
+                // Remove deprecated ot:notIntendedForSynthesis.
+                delete data.nexml['^ot:notIntendedForSynthesis'];
+                // TODO: Shift "preferred" trees to a per-tree property with default value
             }
             if (!(['^ot:comment'] in data.nexml)) {
                 data.nexml['^ot:comment'] = "";
@@ -3247,12 +3242,6 @@ var studyScoringRules = {
         {
             description: "For studies nominated for synthesis, there should be at least one preferred tree.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
                 // check for any candidate tree in the study
                 return getPreferredTrees().length > 0;
             },
@@ -3265,13 +3254,6 @@ var studyScoringRules = {
         {
             description: "Preferred trees should not have duplicate (non-monophyletic) tips mapped to a single taxon.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
-
                 // check preferred trees (synthesis candidates) only
                 //var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                 var duplicateNodesFound = false;
@@ -3465,13 +3447,6 @@ var studyScoringRules = {
         {
             description: "All tip labels in preferred trees should be mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
-
                 // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
                 var unmappedLeafNodes = false;
                 $.each(getPreferredTrees(), function(i, tree) {
@@ -3495,13 +3470,6 @@ var studyScoringRules = {
             // does not currently add to quality score (weight = 0)
             description: "What fraction of tip labels in preferred trees are mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
-
                 // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
                 var totalTips = 0;
                 var mappedTips = 0;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -832,10 +832,10 @@ function loadSelectedStudy() {
                 $.each(allTrees, function( i, tree ) {
                     if ($.inArray(tree['@id'], preferredTreeIDs) !== -1) {
                         // this was a preferred tree (chosen for inclusion in synthesis)
-                        tree['^ot:readyForSynthesis'] = 'Include this tree';
+                        tree['^ot:candidateForSynthesis'] = 'Include this tree';
                     } else {
                         // not a preferred tree, play it safe with default value
-                        tree['^ot:readyForSynthesis'] = 'Not reviewed';
+                        tree['^ot:candidateForSynthesis'] = 'Not reviewed';
                     }
                 });
                 delete data.nexml['^ot:candidateTreeForSynthesis'];
@@ -2687,8 +2687,8 @@ function normalizeTree( tree ) {
         // safest value, forces the curator to assert correctness
         tree['^ot:unrootedTree'] = true;
     }
-    if (!(['^ot:readyForSynthesis'] in tree)) {
-        tree['^ot:readyForSynthesis'] = 'Not reviewed';
+    if (!(['^ot:candidateForSynthesis'] in tree)) {
+        tree['^ot:candidateForSynthesis'] = 'Not reviewed';
     }
 
     // metadata fields (with empty default values)
@@ -2738,6 +2738,12 @@ function getAllTreeLabels() {
     });
 }
 
+var treeCandidateForSynthesisDescriptions = [
+    { value: 'ot:notReviewed',   text: "Not reviewed" },
+    { value: 'ot:doNotInclude',  text: "Do not use" },
+    { value: 'ot:needsCuration', text: "Needs curation" },
+    { value: 'ot:include',       text: "Include this tree" }
+]
 function getTreesNominatedForSynthesis() {
     var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
     return ko.utils.arrayFilter(
@@ -2747,7 +2753,7 @@ function getTreesNominatedForSynthesis() {
 }
 function isReadyForSynthesis( treeOrID ) {
     var tree = ('@id' in treeOrID) ? treeOrID : getTreeByID( treeOrID );
-    if (tree['^ot:readyForSynthesis'] === 'Include this tree') {
+    if (tree['^ot:candidateForSynthesis'] === 'Include this tree') {
         return true;
     }
     return false;
@@ -4929,7 +4935,7 @@ function returnFromNewTreeSubmission( jqXHR, textStatus ) {
             normalizeTree( tree );
             if (responseJSON.includeNewTreesInSynthesis) {
                 // nominate this new tree for synthesis
-                tree['^ot:readyForSynthesis'] = 'Include this tree';
+                tree['^ot:candidateForSynthesis'] = 'Include this tree';
             }
         });
     });

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -517,9 +517,9 @@ body {
                 </div>
               </div>
 
-              <!-- <div class="control-group">
+              <div class="control-group">
                 <div class="controls">
-
+<!--
                 {{ if viewOrEdit == 'EDIT': }}
                   <label class="checkbox">
                     <input type="checkbox" data-bind="checked: nexml['^ot:notIntendedForSynthesis'], event: { click: nudge.GENERAL_METADATA }"> This study should not contribute to synthesis.
@@ -528,12 +528,13 @@ body {
                   <p class="static-form-value" data-bind="css: nexml['^ot:notIntendedForSynthesis'] ? 'interesting-value' : 'boring-value',
                                                           text: nexml['^ot:notIntendedForSynthesis'] ? 'This study should not contribute to synthesis. (This is not typical.)' : 'This study should contribute to synthesis.'"></p>
                 {{ pass }}
+ -->
 
                   <p class="static-form-value interesting-value" data-bind="text: studyContributedToLatestSynthesis() ? (currentStudyVersionContributedToLatestSynthesis() ? 'This version was used to build the latest synthetic tree' : 'This study has changed since building the last synthetic tree.') : 'This study was not used in the latest synthesis.'"></p>
 
                 </div>
 
-              </div> -->
+              </div>
 
               <div class="control-group">
                 <label class="control-label">Curator notes</label>
@@ -655,7 +656,8 @@ body {
                         <th>Ingroup clade</th>
                         <th>Tree root</th>
                         <th>OTUs mapped</th>
-                        <th>Preferred</th>
+                        <th>In current synthesis?</th>
+                        <th>Ready for synthesis?</th>
                       {{ if viewOrEdit == 'EDIT': }}
                         <th>&nbsp;</th>
                       {{ pass }}
@@ -697,14 +699,21 @@ body {
                                style="cursor: pointer;">&nbsp;</td>
                         <td data-bind="html: getMappedTallyForTree(tree),
                                 css: viewModel.ticklers.TREES">&nbsp;</td>
+                        <!-- In current synthesis? -->
+                        <td>
+                            <span data-bind="text: treeContributedToLatestSynthesis(tree) ? 'Yes' : 'No'">?</span>
+                        </td>
+                        <!-- Ready for synthesis? -->
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
-                            <input type="checkbox" style="margin: 0px 20px; display: none;"
-            data-bind="attr: {'checked': jQuery.inArray(tree['@id'], getPreferredTreeIDs()) !== -1},
-                       click: togglePreferredTree,
-                       visible: true" /></td>
+                            <select style="width:160px;"
+                                    data-bind="value: tree['^ot:readyForSynthesis'], 
+                                               options: ['Not reviewed', 'Do not use', 'Needs curation', 'Include this tree'],
+                                               css: viewModel.ticklers.TREES">
+                            </select>
+                        </td>
                       {{ else: }}
-                        <td data-bind="text: (jQuery.inArray(tree['@id'], getPreferredTreeIDs()) !== -1) ? 'YES' : 'NO'">&nbsp;</td>
+                        <td data-bind="text: tree['^ot:readyForSynthesis'] || '???'">&nbsp;</td>
                       {{ pass }}
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
@@ -1940,6 +1949,7 @@ body {
 <script type='text/javascript'>
     var studyID = '{{= studyID }}';
     var latestSynthesisSHA = '{{= latestSynthesisSHA }}';
+    var latestSynthesisTreeIDs = '{{= ','.join(latestSynthesisTreeIDs) }}'.split(',');
     var viewOrEdit = '{{= viewOrEdit }}';
 
     var API_load_study_GET_url = '{{=API_load_study_GET_url}}';

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -706,7 +706,7 @@ body {
                             </select>
                         </td>
                       {{ else: }}
-                        <td data-bind="text: tree['^ot:candidateForSynthesis'] || '???'">&nbsp;</td>
+                        <td data-bind="text: getCandidateForSynthesisDescriptionForValue(tree['^ot:candidateForSynthesis'])">&nbsp;</td>
                       {{ pass }}
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -519,16 +519,6 @@ body {
 
               <div class="control-group">
                 <div class="controls">
-<!--
-                {{ if viewOrEdit == 'EDIT': }}
-                  <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: nexml['^ot:notIntendedForSynthesis'], event: { click: nudge.GENERAL_METADATA }"> This study should not contribute to synthesis.
-                  </label>
-                {{ else: }}
-                  <p class="static-form-value" data-bind="css: nexml['^ot:notIntendedForSynthesis'] ? 'interesting-value' : 'boring-value',
-                                                          text: nexml['^ot:notIntendedForSynthesis'] ? 'This study should not contribute to synthesis. (This is not typical.)' : 'This study should contribute to synthesis.'"></p>
-                {{ pass }}
- -->
 
                   <p class="static-form-value interesting-value" data-bind="text: studyContributedToLatestSynthesis() ? (currentStudyVersionContributedToLatestSynthesis() ? 'This version was used to build the latest synthetic tree' : 'This study has changed since building the last synthetic tree.') : 'This study was not used in the latest synthesis.'"></p>
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -697,14 +697,14 @@ body {
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
                             <select style="width:160px;"
-                                    data-bind="value: tree['^ot:readyForSynthesis'], 
+                                    data-bind="value: tree['^ot:candidateForSynthesis'], 
                                                options: ['Not reviewed', 'Do not use', 'Needs curation', 'Include this tree'],
                                                event: { keyup: nudge.TREES, change: nudge.TREES },
                                                css: viewModel.ticklers.TREES">
                             </select>
                         </td>
                       {{ else: }}
-                        <td data-bind="text: tree['^ot:readyForSynthesis'] || '???'">&nbsp;</td>
+                        <td data-bind="text: tree['^ot:candidateForSynthesis'] || '???'">&nbsp;</td>
                       {{ pass }}
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -698,7 +698,9 @@ body {
                         <td>
                             <select style="width:160px;"
                                     data-bind="value: tree['^ot:candidateForSynthesis'], 
-                                               options: ['Not reviewed', 'Do not use', 'Needs curation', 'Include this tree'],
+                                               options: treeCandidateForSynthesisDescriptions,
+                                               optionsValue: 'value',
+                                               optionsText: 'text',
                                                event: { keyup: nudge.TREES, change: nudge.TREES },
                                                css: viewModel.ticklers.TREES">
                             </select>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -699,6 +699,7 @@ body {
                             <select style="width:160px;"
                                     data-bind="value: tree['^ot:readyForSynthesis'], 
                                                options: ['Not reviewed', 'Do not use', 'Needs curation', 'Include this tree'],
+                                               event: { keyup: nudge.TREES, change: nudge.TREES },
                                                css: viewModel.ticklers.TREES">
                             </select>
                         </td>
@@ -779,10 +780,11 @@ body {
               </p>
         {{ if viewOrEdit == 'EDIT': }}
               <p>
-                See <strong>Add a tree to this study</strong>, below, to
-                add new trees from a file or pasted text. Mark the tree as
-                <strong>preferred</strong> to nominate it for inclusion in synthesis.
-                Preferred trees will undergo validation, generating warnings
+                See <strong>Add a tree to this study</strong>, below, to add
+                new trees from a file or pasted text. To nominate a tree for
+                inclusion in synthesis, choose <strong>Include this tree</strong> 
+                in the 'Ready for synthesis?' dropdown.
+                Nominated trees will undergo validation, generating warnings
                 for full OTU mapping and other quality checks.
               </p>
               <p>
@@ -791,7 +793,7 @@ body {
               </p>
         {{ else: }}
               <p>
-                Trees marked as <strong>preferred</strong> have been nominated
+                Trees marked <strong>Include this tree</strong> have been nominated
                 for inclusion in synthesis, generally because they
                 best represent the conclusions of the study. Inclusion in synthesis
                 also requires that trees be rooted correctly and have OTUs mapped.
@@ -886,8 +888,8 @@ body {
 -->
 
                   <label class="checkbox">
-                      <input name="newTreesPreferred" type="checkbox" value="true">
-                      Mark this tree as preferred for synthesis
+                      <input name="includeNewTreesInSynthesis" type="checkbox" value="true">
+                      Include uploaded tree(s) in synthesis
                   </label>
 
                   <div Xclass="form-actions" style="margin-top: 1em;">
@@ -1161,7 +1163,7 @@ body {
                             <span data-bind="text: viewModel.listFilters.OTUS.scope">SCOPE</span>
                             <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" data-bind="foreach: ['In all trees', 'In preferred trees', 'In non-preferred trees']">
+                        <ul class="dropdown-menu" data-bind="foreach: ['In all trees', 'In trees nominated for synthesis', 'In trees not yet nominated']">
                             <li data-bind="css: {'disabled': viewModel.listFilters.OTUS.scope() == $data }">
                                 <a href="#" data-bind="text: $data, click: function () { viewModel.listFilters.OTUS.scope($data); }">SCOPE</a>
                             </li>


### PR DESCRIPTION
Details in comments below. Addresses #1042 by implementing the [accepted solution shown here](https://github.com/OpenTreeOfLife/opentree/issues/1042#issuecomment-248663245).

N.B. This correctly captures trees marked as "preferred" in the old Nexson, but does not detect the prior inclusion of a tree in a synthesis collection! This will require a batch operation or more client-side
smarts.

This is working now on **devtree**.
