### PR TITLE
Show study count on main curation dashboard.

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -232,6 +232,11 @@ function loadStudyList() {
             }
             
             var matchedStudies = data['matched_studies'];
+            // populate and show study total
+            $('#study-count').text( matchedStudies.length );
+            // TODO: $('#tree-count').text( ???? );
+            $('#study-count-holder').show();
+
             captureDefaultSortOrder(matchedStudies);
             getDuplicateStudiesByDOI(matchedStudies);
 

--- a/curator/views/default/index.html
+++ b/curator/views/default/index.html
@@ -88,6 +88,14 @@ response.files.append(URL('static','js/knockout-bootstrap.min.js'))
         </p>
       </div>
 
+      <div id="study-count-holder" style="display: none; float: right; text-align: right;">
+          <span id="study-count" style="font-weight: bold;">?</span> studies
+         <!-- TODO: Add tree count, if we can get it quickly.
+          <br/>
+          <span id="tree-count" style="font-weight: bold;">?</span> trees
+         -->
+      </div>
+
       <a name="new-study-submit" class="btn btn-info" style="margin-bottom: 1em;" href="/curator/study/create"
 {{ if maintenance_info.get('maintenance_in_progress', False): }}
          onclick="showMaintenancePopup(); return false;"


### PR DESCRIPTION
NB This also has placeholders for a tree count on the second line, but I need to find the fastest way to capture this information. (I'm reckoning the study count using the complete list loaded via AJAX.)

Addresses #999 (see further discussion there).