### PR TITLE
Handle new-style synth-node IDs in conflict.

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -6395,7 +6395,17 @@ function getNodeConflictDescription(tree, node) {
         case 'synth':
             if (node.conflictDetails.witness) {
                 // EXAMPLE:  https://tree.opentreeoflife.org/opentree/argus/ottol@770315/Homo-sapiens
-                witnessURL = "/opentree/argus/ottol@{NODE_ID}".replace('{NODE_ID}', node.conflictDetails.witness);
+                if (isNaN(node.conflictDetails.witness)) {
+                    // it's a synthetic-tree node ID (e.g. 'ott1234' or 'mrcaott123ott456')
+                    witnessURL = "/opentree/argus/synth@{NODE_ID}".replace('{NODE_ID}', node.conflictDetails.witness);
+                    /* N.B. Ideally, instead of 'synth' above we would use the current 
+                     * synth-version (e.g. 'opentree7.0'). But anything other than 
+                     * 'ottol' should show this node ID in the latest synthetic tree.
+                     */
+                } else {
+                    // it's a numeric OTT taxon ID (e.g. '1234')
+                    witnessURL = "/opentree/argus/ottol@{NODE_ID}".replace('{NODE_ID}', node.conflictDetails.witness);
+                }
             } else {
                 missingWitnessDescription = "anonymous synth node";
             }


### PR DESCRIPTION
Avoid a zero-day situation by handling old- _and_ new-style node ids returned from the conflict service for the synthetic tree. Addresses #1062.

Note that we'd ideally like to incorporate the latest synthesis release in the resulting URL, e.g. 'opentree7.0'. This could be done by including this string in the study-editor page, or by returning it as an additional property from the conflict service.