### PR TITLE
Coerce new taxon DOIs to URLs (in curation app)

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7773,6 +7773,9 @@ function formatDataDepositDOIAsURL() {
 */
 function DOItoURL( doi ) {
     /* Return the DOI provided (if any) in URL form */
+    if (!doi) {  // null, undefined, or empty string
+        return "";
+    }
     if (urlPattern.test(doi) === true) {
         // It's already in the form of a URL, return unchanged
         return doi;
@@ -9596,10 +9599,28 @@ function disableRankDivider(option, item) {
 
 function updateActiveTaxonSources() {
     // trigger validation, updates to next/previous buttons
+    coerceTaxonSourceDOIsToURLs();
     currentTaxonCandidate.valueHasMutated();
     updateTaxonSourceDetails();
     updateTaxonSourceTypeOptions();
     taxonCondidateIsValid(currentTaxonCandidate());
+}
+
+function coerceTaxonSourceDOIsToURLs() {
+    var activeSources = getActiveTaxonSources(currentTaxonCandidate());
+    $.each(activeSources(), function(i, source) {
+        switch( source.type ) {
+            case undefined:
+            case '':
+            case 'The taxon is described in this study':
+            case 'Other':
+                break;
+            default:
+                // its value should be a valid URL (convert simple DOIs)
+                source.value = DOItoURL( source.value );
+                break;
+        }
+    });
 }
 
 function updateTaxonSourceDetails( ) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9618,6 +9618,7 @@ function coerceTaxonSourceDOIsToURLs() {
             default:
                 // its value should be a valid URL (convert simple DOIs)
                 source.value = DOItoURL( source.value );
+                activeSources.replace(source, source);
                 break;
         }
     });


### PR DESCRIPTION
This replaces the prior fixes in peyotl. Addresses OpenTreeOfLife/peyotl#155.

This is working now on **devtree**.