### PR TITLE
Nudge incoming synth-tree URLs to latest synthesis.

### DIFF
--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -76,6 +76,8 @@ def index():
     if incomingDomSource not in ('ottol', latestSyntheticTreeVersion, ):
         treeview_dict['domSource'] = latestSyntheticTreeVersion
         treeview_dict['nudgingToLatestSyntheticTree'] = True
+        # mark this as a redirect to a different resource
+        response.status = 303
 
     # when all is said and done, do we have enough information to force the location?
     if treeview_dict['domSource'] and treeview_dict['nodeID']:

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -67,9 +67,13 @@ def index():
 
     # replace any invalid 'domSource' (typically this is "ottol" or a synth-tree version) 
     # with the latest synthetic tree version, and notify the user on the page
-    incomingDomSource = treeview_dict.get('domSource', None)
-    treeview_dict['incomingDomSource'] = incomingDomSource or 'none'
-    if incomingDomSource not in ('ottol', treeview_dict['draftTreeName'], ):
+    #
+    # N.B. that if this is unspecified ('none'), the user requested a shortened
+    # URL (e.g. https://tree.opentreeoflife.org/) that resolves to the latest
+    # synthetic tree.
+    incomingDomSource = treeview_dict.get('domSource', None) or latestSyntheticTreeVersion
+    treeview_dict['incomingDomSource'] = incomingDomSource
+    if incomingDomSource not in ('ottol', latestSyntheticTreeVersion, ):
         treeview_dict['domSource'] = latestSyntheticTreeVersion
         treeview_dict['nudgingToLatestSyntheticTree'] = True
 

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -716,6 +716,10 @@ function createArgus(spec) {
             // proceed directly to display (emulate browser history State object)
             updateTreeView({'data': o});
         }
+        // if we're still showing the initial "nudge" message, hide it now
+        if ($('#nudged-to-latest-synthetic-tree').is(':visible')) {
+            $('#nudged-to-latest-synthetic-tree').fadeOut();
+        }
     };
 
     argusObj.displayNode = function (o) {

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -38,7 +38,8 @@
 // factor function -- gradually going to encapsulate argus functions here for better
 //  information hiding and avoiding putting a lot of things into the global namespace
 // Attributes of spec:
-//      domSource = "ottol"  The name of the source of trees. Currently only "ottol" is supported.
+//      domSource = "ottol"  The name of the source of trees. Currently only "ottol" and the latest synthetic tree 
+//          (e.g. "opentree1.2") are supported.
 //      nodeID = the ID for the node (according to the system of the service indicated by domSource)
 //          if nodeID or domSource are lacking, they will *both* be parsed out of the URL query string (location.search)
 //              from node_id and domsource url-encoded GET parameters. If they are not found there, the defaults are

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -273,7 +273,7 @@ $(document).ready(function() {
             // apply the state as specified in the URL
             ///console.log("Applying state from incoming URL...");
             initialState.nudge = new Date().getTime();
-            History.pushState( initialState, historyStateToWindowTitle(initialState), historyStateToURL(initialState));
+            History.replaceState( initialState, historyStateToWindowTitle(initialState), historyStateToURL(initialState));
         } else if (!(priorState.data.nodeID)) {
             // replace incomplete" prior history (if found) with default view
             ///console.log("Correcting incomplete state with default view...");

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -761,6 +761,7 @@ function showObjectProperties( objInfo, options ) {
         }
 
         if (fullNode.node_id) {
+            // This sets up the node properties correctly, based on server-provided tree version
             var nodeLink = getSynthTreeViewerLinkForNodeID(fullNode.node_id, syntheticTreeID, fullNode.node_id);
             nodeSection.displayedProperties['Node id in synthetic tree'] = nodeLink;
         }

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -79,6 +79,11 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         var getTaxonInfo_url = "{{=getTaxonInfo_url}}";
         var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
         var singlePropertySearchForStudies_url = "{{=singlePropertySearchForStudies_url}}";
+      {{ if 'nudgingToLatestSyntheticTree' in locals(): }}
+        // notify the user if we've nudged an old synth-tree URL to the latest (in synth-tree view only)
+        // N.B. This JS variable is currently unused! See static alert '#nudged-to-latest-synthetic-tree' below.
+        var nudgingToLatestSyntheticTree = {{=nudgingToLatestSyntheticTree and 'true' or 'false'}};
+      {{ pass }}
     </script>
     {{pass}}
 
@@ -465,6 +470,18 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     </section>
 
 </div><!-- /.container -->
+
+{{ if 'nudgingToLatestSyntheticTree' in locals(): }}
+  {{ if nudgingToLatestSyntheticTree: }}
+    <div id="nudged-to-latest-synthetic-tree" class="alert alert-danger" style="position: absolute; margin: 6px 30px;">
+        <strong>Note:</strong> The requested synthetic tree version ('{{= incomingDomSource}}') is no longer available. 
+        This view reflects <a href="{{= URL('about', 'synthesis-release') }}">the latest version 
+        (<strong>{{= draftTreeName}}</strong>).</a>
+
+        <button type="button" id="closeflash" class="close" data-dismiss="alert">×</button>
+    </div>
+  {{ pass }}
+{{ pass }}
 
 <!-- Footer ================================================== -->
 <footer class="footer" id="footer">

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -473,7 +473,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
 
 {{ if 'nudgingToLatestSyntheticTree' in locals(): }}
   {{ if nudgingToLatestSyntheticTree: }}
-    <div id="nudged-to-latest-synthetic-tree" class="alert alert-danger" style="position: absolute; margin: 6px 30px;">
+    <div id="nudged-to-latest-synthetic-tree" class="alert alert-info" style="position: absolute; margin: 6px 30px;">
         <strong>Note:</strong> The requested synthetic tree version ('{{= incomingDomSource}}') is no longer available. 
         This view reflects <a href="{{= URL('about', 'synthesis-release') }}">the latest version 
         (<strong>{{= draftTreeName}}</strong>).</a>


### PR DESCRIPTION
This should happen in the event that someone uses a URL with an old synthesis version, or any other value besides the latest version or 'ottol'. We should redirect and show a one-time message to the user. Fixes #1031; look there for more description and a screenshot.

This change is live on **devtree**.