### PR TITLE
Return non-500 response if invalid NeXML uploaded.

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -678,7 +678,7 @@ def to_nexson():
                         dfj = get_ot_study_info_from_nexml(NEXML_FILEPATH,
                                                            nexson_syntax_version=NEXSON_VERSION)
                     except:
-                        raise HTTP(501, T("Submitted data is not a valid NeXML file, or cannot be converted."))
+                        raise HTTP(400, T("Submitted data is not a valid NeXML file, or cannot be converted."))
                     out = codecs.open(NEXSON_FILEPATH, 'w', encoding='utf-8')
                     json.dump(dfj, out, indent=0, sort_keys=True)
                     out.write('\n')

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -674,8 +674,11 @@ def to_nexson():
         try:
             with locket.lock_file(NEXSON_LOCKFILEPATH, timeout=0):
                 if not os.path.exists(NEXSON_DONE_FILEPATH):
-                    dfj = get_ot_study_info_from_nexml(NEXML_FILEPATH,
-                                                       nexson_syntax_version=NEXSON_VERSION)
+                    try:
+                        dfj = get_ot_study_info_from_nexml(NEXML_FILEPATH,
+                                                           nexson_syntax_version=NEXSON_VERSION)
+                    except:
+                        raise HTTP(501, T("Submitted data is not a valid NeXML file, or cannot be converted."))
                     out = codecs.open(NEXSON_FILEPATH, 'w', encoding='utf-8')
                     json.dump(dfj, out, indent=0, sort_keys=True)
                     out.write('\n')


### PR DESCRIPTION
This is to avoid a cryptic message that pushes the curator to reload the page (potentially losing work) for no good reason. The new exception (a 501 response) should give a friendly hint to examine the uploaded file more closely and choose the proper file format:

<img width="552" alt="screen shot 2016-11-15 at 8 23 47 pm" src="https://cloud.githubusercontent.com/assets/446375/20331375/ec9c96f2-ab72-11e6-9ce9-5e8e9f2bd503.png">

Fixes #1097.