### PR TITLE
Update the GitHub URL for Markdown help.

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -541,7 +541,7 @@ body {
                 {{ if viewOrEdit == 'EDIT': }}
                   <!-- markdown editor w/ preview option -->
                     <ul class="nav nav-pills pull-right" style="margin-bottom: 4px;">
-                        <li><a target="_blank" href="https://help.github.com/articles/markdown-basics">Markdown help</a></li>
+                        <li><a target="_blank" href="https://help.github.com/articles/basic-writing-and-formatting-syntax/">Markdown help</a></li>
                     </ul>
                     <div class="btn-group" style="margin-bottom: 8px;">
                       <button id="edit-comment-button" class="btn active" onclick="showStudyCommentEditor(); return false;">&nbsp; Edit (as Markdown) &nbsp;</button>


### PR DESCRIPTION
This follows a re-organization of the GitHub help sub-site, which resolves our old help URL to an awkward overview page.