### PR TITLE
Improved tree synth status

### DIFF
--- a/curator/README.md
+++ b/curator/README.md
@@ -63,14 +63,14 @@ The returned object (for the any ot:nexson format invocation) will have 2 keys:
   4. `dateTranslated`: "2014-02-23T05:17:12.607189", 
 and several of the arguments that are sent in in the original invocation 
 are echoed back, including:
-    'newTreesPreferred': true/false
+    'includeNewTreesInSynthesis': true/false
     'dataDeposit': 'http://example.org', 
     'filename': 'avian_ovomucoids.tre', 
     'idPrefix': '', 
     'inputFormat': 'newick', 
     'nexml2json': '0.0.0', 
-Note that even if newTreesPreferred is True, no trees are flagged as
-being candidates for synthesis.
+Note that even if includeNewTreesInSynthesis is True, no trees are flagged for
+inclusion on the server (this is echoed back and done in the curation webapp).
 
 Primarily for the sake of debugging, the intermediates can be fetched using the "output" argument. This can be one of: 'nexson', 'nexml', 'input', 'provenance'
 

--- a/curator/README.md
+++ b/curator/README.md
@@ -63,14 +63,11 @@ The returned object (for the any ot:nexson format invocation) will have 2 keys:
   4. `dateTranslated`: "2014-02-23T05:17:12.607189", 
 and several of the arguments that are sent in in the original invocation 
 are echoed back, including:
-    'includeNewTreesInSynthesis': true/false
     'dataDeposit': 'http://example.org', 
     'filename': 'avian_ovomucoids.tre', 
     'idPrefix': '', 
     'inputFormat': 'newick', 
     'nexml2json': '0.0.0', 
-Note that even if includeNewTreesInSynthesis is True, no trees are flagged for
-inclusion on the server (this is echoed back and done in the curation webapp).
 
 Primarily for the sake of debugging, the intermediates can be fetched using the "output" argument. This can be one of: 'nexson', 'nexml', 'input', 'provenance'
 

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -521,14 +521,6 @@ def to_nexson():
         orig_args['uploadId'] = unique_id
         orig_args['inputFormat'] = inp_format
         orig_args['idPrefix'] = idPrefix
-        orig_args['includeNewTreesInSynthesis'] = False
-        if 'includeNewTreesInSynthesis' in request.vars:
-            v = request.vars.includeNewTreesInSynthesis
-            if isinstance(v, str) or isinstance(v, unicode):
-                if v.lower() in ["true", "yes", "1"]:
-                    orig_args['includeNewTreesInSynthesis'] = True
-            elif isinstance(v, bool) and v:
-                orig_args['includeNewTreesInSynthesis'] = True
         fa_tuples = [('first_tree_available_edge_id', 'firstAvailableEdgeID', 'e'), 
                      ('first_tree_available_node_id', 'firstAvailableNodeID', 'n'),
                      ('first_tree_available_otu_id', 'firstAvailableOTUID', 'o'),

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -521,14 +521,14 @@ def to_nexson():
         orig_args['uploadId'] = unique_id
         orig_args['inputFormat'] = inp_format
         orig_args['idPrefix'] = idPrefix
-        orig_args['newTreesPreferred'] = False
-        if 'newTreesPreferred' in request.vars:
-            v = request.vars.newTreesPreferred
+        orig_args['includeNewTreesInSynthesis'] = False
+        if 'includeNewTreesInSynthesis' in request.vars:
+            v = request.vars.includeNewTreesInSynthesis
             if isinstance(v, str) or isinstance(v, unicode):
                 if v.lower() in ["true", "yes", "1"]:
-                    orig_args['newTreesPreferred'] = True
+                    orig_args['includeNewTreesInSynthesis'] = True
             elif isinstance(v, bool) and v:
-                orig_args['newTreesPreferred'] = True
+                orig_args['includeNewTreesInSynthesis'] = True
         fa_tuples = [('first_tree_available_edge_id', 'firstAvailableEdgeID', 'e'), 
                      ('first_tree_available_node_id', 'firstAvailableNodeID', 'n'),
                      ('first_tree_available_otu_id', 'firstAvailableOTUID', 'o'),

--- a/curator/controllers/study.py
+++ b/curator/controllers/study.py
@@ -14,7 +14,9 @@
 from applications.opentree.modules.opentreewebapputil import(
     get_opentree_services_method_urls, 
     fetch_current_TNRS_context_names,
+    fetch_trees_queued_for_synthesis,
     get_maintenance_info)
+
 # N.B. This module is shared with tree-browser app, which is aliased as
 # 'opentree'. Any name changes will be needed here as well!
 
@@ -48,6 +50,7 @@ def view():
     view_dict['latestSynthesisSHA'], view_dict['latestSynthesisTreeIDs'] = _get_latest_synthesis_details_for_study_id(view_dict['studyID'])
     view_dict['viewOrEdit'] = 'VIEW'
     view_dict['userCanEdit'] = auth.is_logged_in() and True or False
+    view_dict['treesQueuedForSynthesis'] = fetch_trees_queued_for_synthesis(request)
     return view_dict
 
 @auth.requires_login()
@@ -74,6 +77,7 @@ def edit():
     # the header search of the main opentree webapp
     view_dict = get_opentree_services_method_urls(request)
     view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
+    view_dict['treesQueuedForSynthesis'] = fetch_trees_queued_for_synthesis(request)
     view_dict['studyID'] = request.args[0]
     view_dict['latestSynthesisSHA'], view_dict['latestSynthesisTreeIDs'] = _get_latest_synthesis_details_for_study_id(view_dict['studyID'])
     view_dict['viewOrEdit'] = 'EDIT'

--- a/curator/private/config.example
+++ b/curator/private/config.example
@@ -64,6 +64,8 @@ treeConflictStatus_url = {conflict_api_domain}/v2/conflict/conflict-status?tree1
 phylesystem_config_url = {opentree_api_domain}/phylesystem/v1/phylesystem_config
 render_markdown_url = {opentree_api_domain}/phylesystem/v1/render_markdown
 getTreesQueuedForSynthesis_url = {opentree_api_domain}/phylesystem/v1/trees_in_synth
+includeTreeInSynthesis_url = {opentree_api_domain}/phylesystem/v1/include_tree_in_synth
+excludeTreeFromSynthesis_url = {opentree_api_domain}/phylesystem/v1/exclude_tree_from_synth
 
 # Open Tree API - RESTful URLs for managing studies in remote storage (note HTTP verbs for each)
 #

--- a/curator/private/config.example
+++ b/curator/private/config.example
@@ -63,6 +63,7 @@ treeConflictStatus_url = {conflict_api_domain}/v2/conflict/conflict-status?tree1
 # NOTE that some general utility methods are called from original v1 code.
 phylesystem_config_url = {opentree_api_domain}/phylesystem/v1/phylesystem_config
 render_markdown_url = {opentree_api_domain}/phylesystem/v1/render_markdown
+getTreesQueuedForSynthesis_url = {opentree_api_domain}/phylesystem/v1/trees_in_synth
 
 # Open Tree API - RESTful URLs for managing studies in remote storage (note HTTP verbs for each)
 #

--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -564,11 +564,16 @@ img.tool-icon {
     background-repeat: repeat-x;
 }
 
-tr .row-controls-ghosted {
+tr .row-controls-ghosted,
+tr .row-controls-ghosted.btn[disabled]
+{
     opacity: 0.3;
 }
 tr:hover .row-controls-ghosted {
     opacity: 1.0;
+}
+tr:hover .row-controls-ghosted.btn[disabled] {
+    opacity: 0.65;
 }
 .mapping-needs-attention {
     background-color: #ddf5ff;

--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -564,6 +564,7 @@ img.tool-icon {
     background-repeat: repeat-x;
 }
 
+/*
 tr .row-controls-ghosted,
 tr .row-controls-ghosted.btn[disabled]
 {
@@ -574,6 +575,10 @@ tr:hover .row-controls-ghosted {
 }
 tr:hover .row-controls-ghosted.btn[disabled] {
     opacity: 0.65;
+}
+*/
+.btn.disabled, .btn[disabled] {
+    opacity: 0.5;
 }
 .mapping-needs-attention {
     background-color: #ddf5ff;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2989,6 +2989,15 @@ function nominateTreeForSynthesis( tree, collectionID ) {
     return;
 }
 
+function showTreeSynthDetailsPopup() {
+    // show details in a popup (already bound)
+    $('#tree-synth-details').modal('show');
+}
+function hideTreeSynthDetailsPopup() {
+    $('#tree-synth-details').modal('hide');
+}
+
+
 /* support classes for objects in arrays
  * (TODO: use these instead of generic observables?)
  */

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4644,7 +4644,9 @@ function setTreeRoot( treeOrID, rootingInfo ) {
     //  - a single node (make this the new root)
     //  - a single root-node ID (for the new root)
     //  - an array of nodes or IDs (add a root between these)
-    //  - null (un-root this tree)
+    //  - null (un-root this tree)  [DEPRECATED]
+    // All but the last option should set the tree's rooted status to indicate
+    // a confirmed root. (Un-rooting, if allowed, would do the reverse.)
 
     var tree = null;
     if (typeof(treeOrID) === 'object') {
@@ -4696,6 +4698,7 @@ function setTreeRoot( treeOrID, rootingInfo ) {
 
     // update tree and node properties
     tree['^ot:specifiedRoot'] = newRootNodeID;
+    tree['^ot:unrootedTree'] = false;
     newRootNode['@root'] = true;
     // selective deletion of d3 parent
     delete newRootNode['parent'];
@@ -6619,6 +6622,9 @@ function showNodeOptionsMenu( tree, node, nodePageOffset, importantNodeIDs ) {
 
     if (nodeID == importantNodeIDs.treeRoot) {
         nodeInfoBox.append('<span class="node-type specifiedRoot">tree root</span>');
+        if ((viewOrEdit === 'EDIT') && (tree['^ot:unrootedTree'])) {
+            nodeMenu.append('<li><a href="#" onclick="hideNodeOptionsMenu(); setTreeRoot( \''+ tree['@id'] +'\', \''+ nodeID +'\' ); return false;">Confirm as root of this tree</a></li>');
+        }
     } else {
         if ((viewOrEdit === 'EDIT') && !(node['^ot:isLeaf'])) {
             nodeMenu.append('<li><a href="#" onclick="hideNodeOptionsMenu(); setTreeRoot( \''+ tree['@id'] +'\', \''+ nodeID +'\' ); return false;">Mark as root of this tree</a></li>');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2985,6 +2985,104 @@ function getSynthStatusDescriptionForTree( tree ) {
         }
     }
 }
+
+function getTreeSynthStatusSummary( tree ) {
+    // This appears in the tree-synth details popup
+    // Did this tree contribute to the latest synthesis?
+    var contributedToLastSynth = contributedToLastSynthesis(tree);
+    // Is this tree in a collection that will contribute to the next synthesis?
+    var queuedForNextSynth = isQueuedForNewSynthesis(tree);
+    // Are there any listed reasons to exclude this tree?
+    var thereAreReasonsToExclude = tree['^ot:reasonsToExcludeFromSynthesis'] && (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0);
+    // TODO: fetch and include the latest synth version)?
+    if (contributedToLastSynth) {
+        if (queuedForNextSynth) {
+            if (thereAreReasonsToExclude) {
+                return 'This tree <strong>was included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'and it is <strong>queued</strong> '
+                      +'for future synthesis, despite the warnings listed below.';
+            } else {
+                return 'This tree <strong>was included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'and it is <strong>queued</strong> '
+                      +'for future synthesis.';
+            }
+        } else {
+                return 'This tree <strong>was included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'but it is <strong>not queued</strong> '
+                      +'for future synthesis.';
+        }
+    } else {
+        if (queuedForNextSynth) {
+            if (thereAreReasonsToExclude) {
+                return 'This tree was <strong>not included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'but it is <strong>queued</strong> '
+                      +'for future synthesis, despite the warnings listed below.';
+            } else {
+                return 'This tree was <strong>not included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'but it is <strong>queued</strong> '
+                      +'for future synthesis.';
+            }
+        } else {
+            if (thereAreReasonsToExclude) {
+                return 'This tree was <strong>not included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'and it is <strong>not queued</strong> '
+                      +'for future synthesis.';
+            } else {
+                // This indicates a new, unreviewed tree (or out-of-band collection editing)
+                return 'This tree was <strong>not included</strong> in the '
+                      +'<a href="/about/synthesis-release" target="_blank">latest synthetic tree</a>, '
+                      +'and it is <strong>not currently queued</strong> '
+                      +'for future synthesis.';
+            }
+        }
+    }
+}
+function getTreeSynthValidationSummary( tree ) {
+    var rootConfirmed = !(tree['^ot:unrootedTree']); // missing, false, or empty
+    var moreThanTwoMappings = getNodeCounts(tree).mappedTips > 2;
+
+    var firstPara = '<p style="margin-bottom: 0.0em;">';
+    if (rootConfirmed && moreThanTwoMappings) {
+        firstPara += 'It <strong>passes</strong> our minimal validation for synthesis:';
+    } else {
+        firstPara += 'It <strong>fails</strong> our minimal validation for synthesis:';
+    }
+    firstPara += '</p>';
+
+    var testList = '<ul style="margin-bottom: 0.2em;">';
+    if (rootConfirmed) {
+         testList += '  <li>Its root has been confirmed by a curator.</li>'
+    } else {
+         testList += '  <li style="color: #b94a48;">Its root has <strong>not</strong> been confirmed by a curator.</li>'
+    }
+    if (moreThanTwoMappings) {
+         testList += '  <li>It has more than two mapped OTUs.</li>';
+    } else {
+         testList += '  <li style="color: #b94a48;">It has <strong>fewer</strong> than two mapped OTUs.</li>';
+    }
+    testList += '</ul>';
+    return firstPara +'\n'+ testList;
+}
+
+function contributedToLastSynthesis(tree) {
+    // Check this tree against latest-synth details
+    return ($.inArray(tree['@id'], latestSynthesisTreeIDs) !== -1);
+}
+function isQueuedForNewSynthesis(tree) {
+    return false; // TODO
+}
+function nominateTreeForSynthesis( tree, collectionID ) {
+    // 'collectionID' is optional! else use our default synth-input collection
+    // TODO: submit this tree using AJAX, then re-check status and update UI
+    return;
+}
+
 function contributedToLastSynthesis(tree) {
     // Check this tree against latest-synth details
     return ($.inArray(tree['@id'], latestSynthesisTreeIDs) !== -1);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -666,13 +666,6 @@ function loadSelectedStudy() {
                 return;
             }
             // pull data from bare NexSON repsonse or compound object (data + sha)
-            /*
-            if (response['data']) {
-                console.log("FOUND inner data (compound response)...");
-            } else {
-                console.log("inner data NOT found (bare NexSON)...");
-            }
-            */
             var data = response['data'] || response;
             if (typeof data !== 'object' || typeof(data['nexml']) == 'undefined') {
                 showErrorMessage('Sorry, there is a problem with the study data (missing NexSON).');
@@ -817,8 +810,10 @@ function loadSelectedStudy() {
             if (!(['^ot:focalCladeOTTTaxonName'] in data.nexml)) {
                 data.nexml['^ot:focalCladeOTTTaxonName'] = "";
             }
-            if (!(['^ot:notIntendedForSynthesis'] in data.nexml)) {
-                data.nexml['^ot:notIntendedForSynthesis'] = false;
+            if (['^ot:notIntendedForSynthesis'] in data.nexml) {
+                // Remove deprecated ot:notIntendedForSynthesis.
+                delete data.nexml['^ot:notIntendedForSynthesis'];
+                // TODO: Shift "preferred" trees to a per-tree property with default value
             }
             if (!(['^ot:comment'] in data.nexml)) {
                 data.nexml['^ot:comment'] = "";
@@ -3289,12 +3284,6 @@ var studyScoringRules = {
         {
             description: "For studies nominated for synthesis, there should be at least one preferred tree.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
                 // check for any candidate tree in the study
                 return getPreferredTrees().length > 0;
             },
@@ -3307,13 +3296,6 @@ var studyScoringRules = {
         {
             description: "Preferred trees should not have duplicate (non-monophyletic) tips mapped to a single taxon.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
-
                 // check preferred trees (synthesis candidates) only
                 //var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                 var duplicateNodesFound = false;
@@ -3507,13 +3489,6 @@ var studyScoringRules = {
         {
             description: "All tip labels in preferred trees should be mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
-
                 // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
                 var unmappedLeafNodes = false;
                 $.each(getPreferredTrees(), function(i, tree) {
@@ -3537,13 +3512,6 @@ var studyScoringRules = {
             // does not currently add to quality score (weight = 0)
             description: "What fraction of tip labels in preferred trees are mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check for opt-out flag
-                var optOutFlag = studyData.nexml['^ot:notIntendedForSynthesis'];
-                if (optOutFlag) {
-                    // submitter has explicitly said this study is not intended for synthesis
-                    return true;
-                }
-
                 // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
                 var totalTips = 0;
                 var mappedTips = 0;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -3123,18 +3123,18 @@ function testForPossibleTreeExclusion(tree) {
 
 function tryToIncludeTreeInSynth(tree) {
     if (isQueuedForNewSynthesis(tree)) {
-        showErrorMessage("This tree is already included (queued).");
+        showInfoMessage("This tree is already included (queued).");
         return;
     }
     if (!treeIsValidForSynthesis(tree)) {
         var rootConfirmed = !(tree['^ot:unrootedTree']); // missing, false, or empty
         var moreThanTwoMappings = getNodeCounts(tree).mappedTips > 2;
         if (!rootConfirmed && !moreThanTwoMappings) {
-            showErrorMessage("This tree needs further curation (confirmed root, 3+ OTUs mapped).");
+            showInfoMessage("This tree needs further curation (confirmed root, 3+ OTUs mapped).");
         } else if (!rootConfirmed) {
-            showErrorMessage("This tree needs further curation (confirmed root node).");
+            showInfoMessage("This tree needs further curation (confirmed root node).");
         } else {
-            showErrorMessage("This tree needs further curation (3 or more OTUs mapped).");
+            showInfoMessage("This tree needs further curation (3 or more OTUs mapped).");
         }
         return;
     }
@@ -3172,7 +3172,7 @@ function tryToIncludeTreeInSynth(tree) {
 }
 function tryToExcludeTreeFromSynth(tree) {
     if (!isQueuedForNewSynthesis(tree)) {
-        showErrorMessage("This tree is already excluded (not yet queued)..");
+        showInfoMessage("This tree is already excluded (not yet queued)..");
         return;
     }
     console.warn('Now I would remove it from all synth-input collections');
@@ -5716,7 +5716,7 @@ function addSupportingFileFromURL() {
 
 function removeTree( tree ) {
     // let's be sure, since adding may be slow...
-    if (!confirm("Are you sure you want to delete this tree?")) {
+    if (!confirm("Are you sure you want to delete this tree from the study?")) {
         return;
     }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1134,11 +1134,11 @@ function loadSelectedStudy() {
                     case 'In all trees':
                         chosenTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                         break;
-                    case 'In preferred trees':
-                        chosenTrees = getPreferredTrees()
+                    case 'In trees nominated for synthesis':
+                        chosenTrees = getTreesNominatedForSynthesis()
                         break;
-                    case 'In non-preferred trees':
-                        chosenTrees = getNonPreferredTrees()
+                    case 'In trees not yet nominated':
+                        chosenTrees = getTreesNotYetNominated()
                         break;
                     default:
                         chosenTrees = [];
@@ -1170,8 +1170,8 @@ function loadSelectedStudy() {
                         switch (scope) {
                             case 'In all trees':
                                 // N.B. Even here, we want to hide (but not preserve) OTUs that don't appear in any tree
-                            case 'In preferred trees':
-                            case 'In non-preferred trees':
+                            case 'In trees nominated for synthesis':
+                            case 'In trees not yet nominated':
                                 // check selected trees for this node
                                 var foundInMatchingTree = false;
                                 var otuID = otu['@id'];
@@ -2160,7 +2160,7 @@ function updateMappingStatus() {
                     // we can add more by including 'All trees'
                     detailsHTML = '<p'+'><strong>Congrtulations!</strong> '
                             +'Mapping is suspended because all OTUs in this '
-                            +'study\'s preferred trees have accepted labels already. To continue, '
+                            +'study\'s nominated trees have accepted labels already. To continue, '
                             +'reject some mapped labels with the '
                             +'<span class="btn-group" style="margin: -2px 0;">'
                             +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
@@ -2723,69 +2723,27 @@ function getAllTreeLabels() {
     });
 }
 
-function getPreferredTreeIDs() {
-    preferredTreeIDs = [];
-    var candidateTreeMarkers = ('^ot:candidateTreeForSynthesis' in viewModel.nexml) ?
-        makeArray( viewModel.nexml['^ot:candidateTreeForSynthesis'] ) : [];
-
-    $.each(candidateTreeMarkers, function(i, marker) {
-        var treeID = $.trim(marker);
-        switch(treeID) {  // non-empty points to a candidate tree
-            case '':
-            case '0':
-                break;
-            default:
-                preferredTreeIDs.push( treeID );
-        }
-    });
-    return preferredTreeIDs;
-}
-function getPreferredTrees() {
-    var preferredTreeIDs = getPreferredTreeIDs();
-    var allTrees = [];
-    $.each(viewModel.nexml.trees, function(i, treesCollection) {
-        $.each(treesCollection.tree, function(i, tree) {
-            allTrees.push( tree );
-        });
-    });
+function getTreesNominatedForSynthesis() {
+    var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
     return ko.utils.arrayFilter(
         allTrees,
-        isPreferredTree
+        isReadyForSynthesis
     );
 }
-function isPreferredTree(treeOrID) {
-    var treeID = ('@id' in treeOrID) ? treeOrID['@id'] : treeOrID;
-    var preferredTreeIDs = getPreferredTreeIDs();
-    var isPreferred = ($.inArray(treeID, preferredTreeIDs) !== -1);
-    return isPreferred;
-}
-function togglePreferredTree( tree ) {
-    var treeID = tree['@id'];
-    var alreadyPreferred = ($.inArray( treeID, getPreferredTreeIDs()) !== -1);
-    if (alreadyPreferred) {
-        // remove it from the list of preferred trees
-        removeFromArray( treeID, viewModel.nexml['^ot:candidateTreeForSynthesis'] );
-    } else {
-        // add it to the list of preferred trees
-        viewModel.nexml['^ot:candidateTreeForSynthesis'].push( treeID );
+function isReadyForSynthesis( treeOrID ) {
+    var tree = ('@id' in treeOrID) ? treeOrID : getTreeByID( treeOrID );
+    if (tree['^ot:readyForSynthesis'] === 'Include this tree') {
+        return true;
     }
-    nudgeTickler('TREES');
-    nudgeTickler('OTU_MAPPING_HINTS');
-    return true;  // to allow checkbox updates
+    return false;
 }
-function getNonPreferredTrees() {
-    var preferredTreeIDs = getPreferredTreeIDs();
-    var allTrees = [];
-    $.each(viewModel.nexml.trees, function(i, treesCollection) {
-        $.each(treesCollection.tree, function(i, tree) {
-            allTrees.push( tree );
-        });
-    });
+
+function getTreesNotYetNominated() {
+    var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
     return ko.utils.arrayFilter(
         allTrees,
-        function(tree) {
-            var isPreferred = ($.inArray(tree['@id'], preferredTreeIDs) !== -1);
-            return !isPreferred;
+        function (tree) {
+            return !(isReadyForSynthesis(tree));
         }
     );
 }
@@ -3095,8 +3053,8 @@ function TreeNode() {
  *      min threshold
  *      study data is complete
  *      nice-to-have (what are the finishing touches?)
- *      one preferred tree?
- *      preferred tree(s) is/are rooted? or "unrooted" disclaimer was chosen?
+ *      one tree nominated for synthesis?
+ *      nominated tree(s) is/are rooted? or "unrooted" disclaimer was chosen?
  *
  * integrity
  *      all taxon names mapped (perhaps this score is proportional)
@@ -3282,25 +3240,13 @@ var studyScoringRules = {
                 // TODO: add hint/URL/fragment for when curator clicks on suggested action?
         },
         {
-            description: "For studies nominated for synthesis, there should be at least one preferred tree.",
+            description: "Trees nominated for synthesis should not have duplicate (non-monophyletic) tips mapped to a single taxon.",
             test: function(studyData) {
-                // check for any candidate tree in the study
-                return getPreferredTrees().length > 0;
-            },
-            weight: 0.2,
-            successMessage: "There is at least one preferred tree, or this study is not nominated for synthesis.",
-            failureMessage: "There should be at least one preferred tree, or the study should not be nominated for synthesis.",
-            suggestedAction: "Mark at least one tree as preferred, or mark this study as not contributing to synthesis in Metadata."
-                // TODO: add hint/URL/fragment for when curator clicks on suggested action?
-        },
-        {
-            description: "Preferred trees should not have duplicate (non-monophyletic) tips mapped to a single taxon.",
-            test: function(studyData) {
-                // check preferred trees (synthesis candidates) only
+                // check nominated trees (synthesis candidates) only
                 //var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                 var duplicateNodesFound = false;
                 var startTime = new Date();
-                $.each(getPreferredTrees(), function(i, tree) {
+                $.each(getTreesNominatedForSynthesis(), function(i, tree) {
                     // disregard sibling-only duplicates (will be resolved on the server)
                     var duplicateData = getUnresolvedDuplicatesInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
                     if ( !($.isEmptyObject(duplicateData)) ) {
@@ -3312,7 +3258,7 @@ var studyScoringRules = {
                 return !(duplicateNodesFound);
             },
             weight: 0.2,
-            successMessage: "No duplicate tips (mapped to the same taxon) found in preferred trees.",
+            successMessage: "No duplicate tips (mapped to the same taxon) found in trees nominated for synthesis.",
             failureMessage: "Multiple tips map to the same taxon (no exemplar chosen).",
             suggestedAction: "Designate an exemplar for each set of tips mapped to the same taxon."
         },
@@ -3320,7 +3266,7 @@ var studyScoringRules = {
             description: "Internal node labels should have a defined type.",
             test: function(studyData) {
                 // TODO: opt-out if study not intended for synthesis?
-                // TODO: skip non-preferred trees?
+                // TODO: skip non-nominated trees?
                 // check all trees
                 var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                 var ambiguousLabelsFound = false;
@@ -3485,13 +3431,13 @@ var studyScoringRules = {
     ],
     */
     'OTU Mapping': [
-        // checks that all preferred tree tips mapped to OTT taxon names (i.e. pass / fail test)
+        // checks that all nominated trees' tips are mapped to OTT taxon names (i.e. pass / fail test)
         {
-            description: "All tip labels in preferred trees should be mapped to the Open Tree Taxonomy.",
+            description: "All tip labels (in trees nominated for synthesis) should be mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
+                // check the proportion of mapped leaf nodes in all nominated trees
                 var unmappedLeafNodes = false;
-                $.each(getPreferredTrees(), function(i, tree) {
+                $.each(getTreesNominatedForSynthesis(), function(i, tree) {
                     nodeCounts = getNodeCounts(tree)
                     if (nodeCounts.mappedTips != nodeCounts.totalTips) {
                       return true; // no need to look at other trees for pass / fail test
@@ -3502,21 +3448,21 @@ var studyScoringRules = {
             },
             weight: 0.5,
             successMessage: "Preferred trees (submitted for synthesis) have all tips mapped to Open Tree Taxonomy.",
-            failureMessage: "There are unmapped tip labels in preferred trees (submitted for synthesis).",
+            failureMessage: "There are unmapped tip labels in trees nominated for synthesis.",
             suggestedAction: "Review all unmapped tips in OTU Mapping."
                 // TODO: add hint/URL/fragment for when curator clicks on suggested action?
         }
         /* commenting this out for now because no way to deal with non pass-fail tests
         {
-            // checks fraction of OTUs mapped in preferred trees
+            // checks fraction of OTUs mapped in nominated trees
             // does not currently add to quality score (weight = 0)
-            description: "What fraction of tip labels in preferred trees are mapped to the Open Tree Taxonomy.",
+            description: "What fraction of tip labels in nominated trees are mapped to the Open Tree Taxonomy.",
             test: function(studyData) {
-                // check the proportion of mapped leaf nodes in all candidate ("preferred") trees
+                // check the proportion of mapped leaf nodes in all nominated trees
                 var totalTips = 0;
                 var mappedTips = 0;
                 var fractionMapped = 0;
-                $.each(getPreferredTrees(), function(i, tree) {
+                $.each(getTreesNominatedForSynthesis(), function(i, tree) {
                     nodeCounts = getNodeCounts(tree)
                     totalTips += nodeCounts.totalTips
                     mappedTips += nodeCounts.mappedTips
@@ -3526,14 +3472,14 @@ var studyScoringRules = {
                 if (totalTips != 0) {
                   fractionMapped = mappedTips/totalTips;
                 }
-                console.log(mappedTips + "/" + totalTips + " = " + floatToPercent(fractionMapped) + "% of OTUs in preferred trees mapped")
+                console.log(mappedTips + "/" + totalTips + " = " + floatToPercent(fractionMapped) + "% of OTUs in nominated trees mapped")
                 return fractionMapped;
             },
             // would like to update weight based on fractionMapped, but in different scopes
             // with this setup
             weight: 0.5,
             successMessage: "Preferred trees (submitted for synthesis) have all tips mapped to Open Tree Taxonomy.",
-            failureMessage: "There are unmapped tip labels in preferred trees (submitted for synthesis).",
+            failureMessage: "There are unmapped tip labels in trees nominated for synthesis.",
             suggestedAction: "Review all unmapped tips in OTU Mapping."
                 // TODO: add hint/URL/fragment for when curator clicks on suggested action?
         }
@@ -4039,9 +3985,9 @@ function findOTUInTrees( otu, trees ) {
 function showOTUInContext() {
     // use the popup tree viewer to show this node in place (to clarify OTU mapping, etc)
     var otu = this;
-    // start with preferred trees (show best-quality results first)
-    var otuContextsToShow = findOTUInTrees( otu, getPreferredTrees() );
-    $.merge( otuContextsToShow, findOTUInTrees( otu, getNonPreferredTrees() ) );
+    // start with nominated trees (show best-quality results first)
+    var otuContextsToShow = findOTUInTrees( otu, getTreesNominatedForSynthesis() );
+    $.merge( otuContextsToShow, findOTUInTrees( otu, getTreesNotYetNominated() ) );
     // if this OTU is unused, something's very wrong; bail out now
     if (otuContextsToShow.length === 0) {
         alert("This OTU doesn't appear in any tree. (This is not expected.)");
@@ -4060,7 +4006,7 @@ function showOTUInContext() {
 function showDuplicateNodesInTreeViewer(tree) {
     // If there are no duplicates, fall back to simple tree view
     var duplicateData = getUnresolvedDuplicatesInTree( tree, {INCLUDE_MONOPHYLETIC: false} );
-    if (!isPreferredTree(tree) || $.isEmptyObject(duplicateData)) {
+    if (!isReadyForSynthesis(tree) || $.isEmptyObject(duplicateData)) {
         showTreeWithHistory(tree);
         return;
     }
@@ -5047,9 +4993,9 @@ function returnFromNewTreeSubmission( jqXHR, textStatus ) {
         treesElement['tree'] = makeArray( treesElement['tree'] );
         $.each( treesElement.tree, function(i, tree) {
             normalizeTree( tree );
-            if (responseJSON.newTreesPreferred) {
-                // mark all new tree(s) as preferred, eg, a candidate for synthesis
-                viewModel.nexml['^ot:candidateTreeForSynthesis'].push( tree['@id'] );
+            if (responseJSON.includeNewTreesInSynthesis) {
+                // nominate this new tree for synthesis
+                tree['^ot:readyForSynthesis'] = 'Include this tree';
             }
         });
     });
@@ -5492,11 +5438,6 @@ function removeTree( tree ) {
     // TODO: remove any captive trees- and OTUs-collections
     // TODO: remove any otus not used elsewhere?
     // TODO: remove related annotation events and agents?
-
-    if ($.inArray(tree['@id'], getPreferredTreeIDs()) !== -1) {
-        // remove its ID from list of preferred (candidate) trees
-        togglePreferredTree( tree );
-    }
 
     // force rebuild of all tree-related lookups
     buildFastLookup('NODES_BY_ID');
@@ -7932,7 +7873,7 @@ function getDuplicateNodesInTree( tree ) {
     // 'exemplar' node to avoid problems in synthesis.
     var duplicateNodes = { };
 
-    if (!isPreferredTree(tree)) {
+    if (!isReadyForSynthesis(tree)) {
         // ignoring these for now...
         return duplicateNodes;
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -3129,7 +3129,7 @@ function tryToIncludeTreeInSynth(tree) {
 function tryToExcludeTreeFromSynth(tree) {
     console.warn('TRYING TO EXCLUDE');
     console.log(tree);
-    if (isQueuedForNewSynthesis(tree)) {
+    if (!isQueuedForNewSynthesis(tree)) {
         alert("This tree is already excluded (not yet queued).");
         return;
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2961,6 +2961,8 @@ function getSynthStatusDescriptionForTree( tree ) {
     var queuedForNextSynth = isQueuedForNewSynthesis(tree);
     // Are there any listed reasons to exclude this tree?
     var thereAreReasonsToExclude = tree['^ot:reasonsToExcludeFromSynthesis'] && (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0);
+    // Does this tree meet minimum standards for synthesis?
+    var validForSynthesis = treeIsValidForSynthesis(tree);
 
     if (contributedToLastSynth) {
         if (queuedForNextSynth) {
@@ -2982,9 +2984,11 @@ function getSynthStatusDescriptionForTree( tree ) {
         } else {
             if (thereAreReasonsToExclude) {
                 return "Excluded";
-            } else {
+            } else if (validForSynthesis) {
                 // This indicates a new, unreviewed tree (or out-of-band collection editing)
                 return "Needs review";
+            } else {
+                return "Needs curation";
             }
         }
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -46,7 +46,8 @@ var History = window.History; // Note: capital H refers to History.js!
 
 // these variables should already be defined in the main HTML page
 var studyID;
-var latestSynthesisSHA;   // the SHA for this study (if any) that was last used in synthesis
+var latestSynthesisSHA;      // the SHA for this study (if any) that was last used in synthesis
+var latestSynthesisTreeIDs;  // ids of any trees in this study included in the latest synthesis
 var API_load_study_GET_url;
 var API_update_study_PUT_url;
 var API_remove_study_DELETE_url;
@@ -3010,9 +3011,51 @@ function getInGroupCladeDescriptionForTree( tree ) {
     return nodeName;
 }
 
+function getSynthStatusDescriptionForTree( tree ) {
+    // Did this tree contribute to the latest synthesis?
+    var contributedToLastSynth = contributedToLastSynthesis(tree);
+    // Is this tree in a collection that will contribute to the next synthesis?
+    var queuedForNextSynth = queuedForNewSynthesis(tree);
+    // Are there any listed reasons to exclude this tree?
+    var thereAreReasonsToExclude = tree['^ot:reasonsToExcludeFromSynthesis'] && (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0);
+
+    if (contributedToLastSynth) {
+        if (queuedForNextSynth) {
+            if (thereAreReasonsToExclude) {
+                return "Included despite warnings";
+            } else {
+                return "Included";
+            }
+        } else {
+            return "To be removed";
+        }
+    } else {
+        if (queuedForNextSynth) {
+            if (thereAreReasonsToExclude) {
+                return "Queued despite warnings";
+            } else {
+                return "Queued";
+            }
+        } else {
+            if (thereAreReasonsToExclude) {
+                return "Excluded";
+            } else {
+                // This indicates a new, unreviewed tree (or out-of-band collection editing)
+                return "Needs review";
+            }
+        }
+    }
+}
+function contributedToLastSynthesis(tree) {
+    // Check this tree against latest-synth details
+    return ($.inArray(tree['@id'], latestSynthesisTreeIDs) !== -1);
+}
+function queuedForNewSynthesis(tree) {
+    return false; // TODO
+}
 
 /* support classes for objects in arrays
- * (TODO: use these instead of generlc observables?)
+ * (TODO: use these instead of generic observables?)
  */
 function MetaTag( name, type, value ) {
     var self = this;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4990,11 +4990,6 @@ function returnFromNewTreeSubmission( jqXHR, textStatus ) {
         treesElement['tree'] = makeArray( treesElement['tree'] );
         $.each( treesElement.tree, function(i, tree) {
             normalizeTree( tree );
-            if (responseJSON.includeNewTreesInSynthesis) {
-                // add this new tree to a synth collection
-                nominateTreeForSynthesis(tree);
-                // TODO: wait on this, until there's some curation?
-            }
         });
     });
 

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -414,7 +414,7 @@ elif active_user_found:
                     title="Delete this tree collection"
                     class="pull-right btn btn-mini btn-danger row-controls-ghosted"
                     style="margin-left: 14px; display: none;">
-                    Delete <i class="icon-remove icon-white"></i>
+                    Delete <i class="icon-trash icon-white"></i>
                 </button>
             </td>
         </tr>

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -571,7 +571,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                 title="Delete this tree collection"
                 class="pull-right btn btn-mini btn-danger row-controls-ghosted"
                 style="margin-left: 14px;">
-                Delete <i class="icon-remove icon-white"></i>
+                Delete <i class="icon-trash icon-white"></i>
             </button>
             -->
            <!-- /ko -->
@@ -805,7 +805,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                                       title="Remove this tree from the collection"
                                       class="pull-right btn btn-mini btn-danger row-controls-ghosted"
                                       style="margin-left: 4px;">
-                                  <i class="icon-remove icon-white"></i>
+                                  <i class="icon-trash icon-white"></i>
                               </button>
                               <a data-bind="html: name,
                                             attr: { href: getTreeViewURL($data) }"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -639,18 +639,17 @@ body {
                     <tr>
                       {{ if viewOrEdit == 'EDIT': }}
                         <th>Tree name (click to edit tree)</th>
+                        <th colspan="2">Included in synthesis?</th>
                       {{ else: }}
                         <th>Tree name (click to view)</th>
+                        <th>Synthesis status</th>
                       {{ pass }}
                         <th>Inference method</th>
                         <th>Ingroup clade</th>
                         <th>Tree root</th>
                         <th>OTUs mapped</th>
                       {{ if viewOrEdit == 'EDIT': }}
-                        <th colspan="2">Included in synthesis?</th>
                         <th>&nbsp;</th>
-                      {{ else: }}
-                        <th>Synthesis status</th>
                       {{ pass }}
                     </tr>
                   </thead>
@@ -680,16 +679,6 @@ body {
                                 Review ambiguous labels
                             </a>
                         </td>
-                        <td data-bind="text: tree['^ot:curatedType'] || 'Unspecified',
-                                css: viewModel.ticklers.TREES">&nbsp;</td>
-                        <td data-bind="text: getInGroupCladeDescriptionForTree(tree),
-                                css: viewModel.ticklers.TREES">&nbsp;</td>
-                        <td data-bind="html: getRootedDescriptionForTree(tree),
-                                       click: showArbitraryRootExplanationInTreeViewer,
-                                       css: viewModel.ticklers.TREES"
-                               style="cursor: pointer;">&nbsp;</td>
-                        <td data-bind="html: getMappedTallyForTree(tree),
-                                css: viewModel.ticklers.TREES">&nbsp;</td>
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
                             <span data-bind="text: getSynthStatusDescriptionForTree($data),
@@ -724,13 +713,23 @@ body {
                           </div>
                         </td>
                       {{ pass }}
+                        <td data-bind="text: tree['^ot:curatedType'] || 'Unspecified',
+                                css: viewModel.ticklers.TREES">&nbsp;</td>
+                        <td data-bind="text: getInGroupCladeDescriptionForTree(tree),
+                                css: viewModel.ticklers.TREES">&nbsp;</td>
+                        <td data-bind="html: getRootedDescriptionForTree(tree),
+                                       click: showArbitraryRootExplanationInTreeViewer,
+                                       css: viewModel.ticklers.TREES"
+                               style="cursor: pointer;">&nbsp;</td>
+                        <td data-bind="html: getMappedTallyForTree(tree),
+                                css: viewModel.ticklers.TREES">&nbsp;</td>
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
                             <button data-bind="click: removeTree,
                                                visible: true"
                                 class="pull-right btn btn-mini btn-danger row-controls-ghosted"
                                 title="Click to delete this tree from the study"
-                                style="display: none; margin-left: 5px;">
+                                style="display: none;">
                                 <i class="icon-trash icon-white"></i>
                             </button>
                         </td>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2288,17 +2288,9 @@ body {
     <div class="modal-body" style="max-height: none; padding-bottom: 0px;">
       <div class="tab-pane active">
           <form class="form-inline" style="overflow: hidden;margin-bottom: 0px;margin-top: -12px;padding-top: 4px;margin-right: -6px;">
-            <p style="margin-bottom: 0.6em;">
-              This tree was <strong>not included</strong> in the latest synthesis (<a href="#">v4.15</a>),
-              but it is <strong>queued</strong> for the next synthesis, despite the warnings listed below.
-            </p>
-            <p style="margin-bottom: 0.0em;">
-              It <strong>passes</strong> our minimal validation for synthesis:
-            </p>
-            <ul style="margin-bottom: 0.2em;">
-              <li>Its root has been confirmed by a curator.</li>
-              <li>It has more than two rooted OTUs.</li>
-            </ul>
+            <p style="margin-bottom: 0.6em;"
+               data-bind="html: getTreeSynthStatusSummary($root)">?</p>
+            <div data-bind="html: getTreeSynthValidationSummary($root)"></div>
           <!-- ko foreach: { data: [$data['^ot:reasonsToExcludeFromSynthesis']], as: 'warnings' }-->
             <div style="overflow: auto; max-height: 257px;">
                 <p style="margin-top: 0.4em; margin-bottom: 0.2em;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -692,7 +692,8 @@ body {
                                 css: viewModel.ticklers.TREES">&nbsp;</td>
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
-                            <span data-bind="text: getSynthStatusDescriptionForTree($data)"></span>
+                            <span data-bind="text: getSynthStatusDescriptionForTree($data),
+                                             css: viewModel.ticklers.TREES"></span>
                         </td>
                         <td>
                             <div style="white-space: nowrap;">
@@ -714,7 +715,8 @@ body {
                       {{ else: }}
                         <td>
                           <div style="white-space: nowrap;">
-                              <span data-bind="text: getSynthStatusDescriptionForTree($data)"></span>
+                              <span data-bind="text: getSynthStatusDescriptionForTree($data),
+                                               css: viewModel.ticklers.TREES"></span>
                               <a class="badge" href="#" style="padding: 2px 6px;"
                                  data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0)? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
                                             css: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0 ? 'badge badge-warning' : 'badge badge-info') +' '+ viewModel.ticklers.TREES(),

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2345,17 +2345,23 @@ body {
             </div>
 
             <div xclass="form-actions" style="margin-top: 0px; margin-bottom: 0.25em;">
+              <div id="add-reason-to-exclude" class="empty-list-prompt" style="margin-bottom: 6px; display:none;">
+                  Why this tree should be excluded? Add your reason(s) here.
+              </div>
               <button type="submit" class="btn btn-small btn-info"
                   data-bind="click: function() {addReasonToExcludeTree($parent); return false;},
                              visible: (viewOrEdit == 'EDIT')"><span data-bind="text: (warnings.length > 0) ? 'Add another reason to exclude this tree' : 'Add a reason to exclude this tree'">?</span>
                     &nbsp;<i class="icon-plus Xicon-upload icon-white"></i>
               </button>
+              <div id="override-reasons-to-exclude" class="empty-list-prompt" style="margin-top: 6px; display:none;">
+                  Are you sure you want to override (or remove) the reasons listed above?
+              </div>
             </div>
             <div class="pull-right" style="position: relative; margin: 9px 2px;"
                  data-bind="visible: (viewOrEdit == 'EDIT')">
               <a class="btn btn-success row-controls-ghosted"
                  data-bind="attr: {disabled: !(testForPossibleTreeInclusion($root))},
-                            click: function() {tryToIncludeTreeInSynth($root)}">
+                            click: function() {tryToIncludeTreeInSynth($root, {FORCE_OVERRIDE: true})}">
                 <strong>Include</strong> this tree in synthesis</a>
               &nbsp;
               <a class="btn btn-danger row-controls-ghosted"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -697,10 +697,10 @@ body {
                             <div style="white-space: nowrap;">
                               <a class="btn btn-mini btn-success row-controls-ghosted">Include</a>
                               <a class="btn btn-mini btn-danger row-controls-ghosted" disabled="disabled">Exclude</a>
-                              <a class="badge badge-info" href="#" style="padding: 2px 6px;"
+                              <a class="badge" href="#" style="padding: 2px 6px;"
                                  title="Click to see details about this tree in synthesis"
-                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'])? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
-                                            css: {'class': (tree['^ot:reasonsToExcludeFromSynthesis'])? 'badge badge-warning' : 'badge badge-info'},
+                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0)? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
+                                            css: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0 ? 'badge badge-warning' : 'badge badge-info') +' '+ viewModel.ticklers.TREES(),
                                             click: showTreeSynthDetailsPopup">?</a>
                             </div>
                         </td>
@@ -708,9 +708,10 @@ body {
                         <td>
                           <div style="white-space: nowrap;">
                               <span data-bind="text: getSynthStatusDescriptionForTree($data)"></span>
-                              <a class="badge badge-info" href="#" style="padding: 2px 6px;"
-                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'])? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
-                                            css: {'class': (tree['^ot:reasonsToExcludeFromSynthesis'])? 'badge badge-warning' : 'badge badge-info'}">?</a>
+                              <a class="badge" href="#" style="padding: 2px 6px;"
+                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0)? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
+                                            css: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0 ? 'badge badge-warning' : 'badge badge-info') +' '+ viewModel.ticklers.TREES(),
+                                            click: showTreeSynthDetailsPopup">?</a>
                           </div>
                         </td>
                       {{ pass }}
@@ -2279,8 +2280,9 @@ body {
 <div class="modal hide fade" id="tree-synth-details" style="display: none;">
     <div class="modal-header" style="padding-bottom: 0;">
       <a class="close" onclick="$('#tree-synth-details').modal('hide'); return false;">×</a>
-      <h3 Xid="tree-title">
-          Tree <span style="color: #999;">Bayesian</span> (id:<span style="color: #999;">tree4602</span>)
+      <h3>
+          Tree <span style="color: #999;" data-bind="html: $data['@label']">???</span>
+          (id:<span style="color: #999;" data-bind="text: $data['@id']">???</span>)
       </h3>
     </div>
     <div class="modal-body" style="max-height: none; padding-bottom: 0px;">
@@ -2297,47 +2299,66 @@ body {
               <li>Its root has been confirmed by a curator.</li>
               <li>It has more than two rooted OTUs.</li>
             </ul>
-            <div Xid="tree-list-holder" style="overflow: auto; max-height: 257px;">
-      <p style="margin-top: 0.4em; margin-bottom: 0;">
-  Curators have submitted <strong>2 reasons</strong> to exclude this tree from synthesis:
-</p>
-                <table Xid="tree-collection-decision-holder" class="table table-condensed table-hover" style="margin-bottom: 2px; position: relative;" data-bind="visible: true"><!-- TODO: hide if no trees found -->
+          <!-- ko foreach: { data: [$data['^ot:reasonsToExcludeFromSynthesis']], as: 'warnings' }-->
+            <div style="overflow: auto; max-height: 257px;">
+                <p style="margin-top: 0.4em; margin-bottom: 0.2em;"
+                   data-bind="visible: warnings.length > 0">
+                  Curators have submitted
+                  <strong><span data-bind="text: warnings.length">?</span>
+                    <span data-bind="visible: warnings.length === 1">reason</span>
+                    <span data-bind="visible: warnings.length > 1">reasons</span>
+                  </strong> to exclude this tree from synthesis:
+                </p>
+                <p style="margin-top: 0.4em; margin-bottom: 0.2em;"
+                   data-bind="visible: warnings.length === 0">
+                  There are currently <strong>no listed reasons</strong>
+                  to exclude this tree from synthesis.
+                </p>
+                <table id="synth-warnings-holder" class="table table-condensed table-hover" style="margin-bottom: 2px; position: relative;" data-bind="visible: true"><!-- TODO: hide if no trees found -->
 
-                  <tbody Xid="tree-collection-decisions" data-bind="foreach: { data: $data.data.decisions, as: 'decision' }">
-                      <tr class="single-tree-row">
-  <td>
-    <button data-bind="click: function() {removeTreeFromCollection($data, $parent); return false;}" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
-      <i class="icon-remove icon-white"></i>
-    </button>
-    <div>The confirmed rooting in Felis does not agree with most published phylogenies.</div>
-  </td>
-</tr>
-<tr class="single-tree-row">
-  <td>
-    <button data-bind="click: function() {removeTreeFromCollection($data, $parent); return false;}" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
-      <i class="icon-remove icon-white"></i>
-    </button>
-    <div>This requires more curation, esp. OTU mapping!</div>
-  </td>
-</tr>
+                  <tbody Xid="tree-collection-decisions"
+                         data-bind="foreach: { data: warnings, as: 'warning' }">
+                    <tr class="single-tree-row">
+                      <td>
+                        <button data-bind="click: function() {removeReasonToExcludeTree($index(), $root); return false;},
+                                           visible: (viewOrEdit == 'EDIT')" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
+                          <i class="icon-remove icon-white"></i>
+                        </button>
+                        <textarea class="input-block-level"
+                            style="width: 470px; margin-bottom: 4px;"
+                            data-bind="value: warning.$,
+                                       valueUpdate: ['afterkeydown', 'input'],
+                                       visible: (viewOrEdit == 'EDIT')"
+                            placeholder="Example: This tree needs more mapped OTUs."></textarea>
+<!-- event: { keyup: updateReasonToExcludeTree($index(), $root), change: updateReasonToExcludeTree($index(), $root) }, -->
+                        <div data-bind="html: warning.$,
+                                        visible: (viewOrEdit == 'VIEW')">?</div>
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
-      <!-- /ko -->
-            </div><!-- /#tree-list-holder -->
+            </div>
 
-          <!-- ko if: userIsEditingCollection($data) -->
-            <!-- TODO: Put add-collection widgets! -->
             <div xclass="form-actions" style="margin-top: 0px; margin-bottom: 0.25em;">
-              <button Xid="new-collection-tree-start" type="submit" class="btn btn-small btn-info Xbtn-info-disabled" onclick="return false;"><span data-bind="text: ($data.data.decisions.length > 0) ? 'Add another tree' : 'Add a tree to this collection'">Add another reason to exclude this tree</span>
+              <button type="submit" class="btn btn-small btn-info"
+                  data-bind="click: function() {addReasonToExcludeTree($parent); return false;},
+                             visible: (viewOrEdit == 'EDIT')"><span data-bind="text: (warnings.length > 0) ? 'Add another reason to exclude this tree' : 'Add a reason to exclude this tree'">?</span>
                     &nbsp;<i class="icon-plus Xicon-upload icon-white"></i>
               </button>
             </div>
-            <div class="pull-right" style="position: relative; margin: 9px 2px;">
-              <a class="btn btn-success row-controls-ghosted"><strong>Include</strong> this tree in synthesis</a>
+            <div class="pull-right" style="position: relative; margin: 9px 2px;"
+                 data-bind="visible: (viewOrEdit == 'EDIT')">
+              <a class="btn btn-success row-controls-ghosted" onclick="return false;"><strong>Include</strong> this tree in synthesis</a>
               &nbsp;
-              <a class="btn btn-danger row-controls-ghosted"><strong>Exclude</strong> this tree from synthesis</a>
+              <a class="btn btn-danger row-controls-ghosted" onclick="return false;"><strong>Exclude</strong> this tree from synthesis</a>
             </div>
+            <div class="pull-right" style="position: relative; margin: 9px 2px;"
+                 data-bind="visible: (viewOrEdit == 'VIEW')">
+              <a class="btn" onclick="$('#tree-synth-details').modal('hide'); return false;">OK</a>
+            </div>
+
           <!-- /ko -->
+
             </form>
           </div>
     </div><!-- end of .modal-body -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -731,7 +731,7 @@ body {
                                 class="pull-right btn btn-mini btn-danger row-controls-ghosted"
                                 title="Click to delete this tree from the study"
                                 style="display: none; margin-left: 5px;">
-                                <i class="icon-remove icon-white"></i>
+                                <i class="icon-trash icon-white"></i>
                             </button>
                         </td>
                       {{ pass }}
@@ -1000,11 +1000,11 @@ body {
                                 class="pull-right btn btn-mini btn-danger"
                                 style="opacity: 0.3 !important;"
                                 onclick="alert('You must delete the associated tree(s) to remove this file.'); return false;">
-                                <i class="icon-remove icon-white"></i>
+                                <i class="icon-trash icon-white"></i>
                             </button>
                             <button data-bind="css: viewModel.ticklers.TREES, visible: getAssociatedTrees(file).length === 0, click: removeSupportingFile"
                                 class="pull-right btn btn-mini btn-danger row-controls-ghosted">
-                                <i class="icon-remove icon-white"></i>
+                                <i class="icon-trash icon-white"></i>
                             </button>
                         </td>
                     {{ else: }}
@@ -1602,7 +1602,7 @@ body {
                             <td align="center" valign="center">
                                 <a href="#" title="Click to remove this substitution."
                                    data-bind="click: function(data, event) { removeSubstitution(data);  }" />
-                                    <i class="icon-remove"></i></a>
+                                    <i class="icon-trash"></i></a>
                             </td>
                         </tr>
                     </tbody>
@@ -2328,7 +2328,7 @@ body {
                       <td>
                         <button data-bind="click: function() {removeReasonToExcludeTree($index(), $root); return false;},
                                            visible: (viewOrEdit == 'EDIT')" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
-                          <i class="icon-remove icon-white"></i>
+                          <i class="icon-trash icon-white"></i>
                         </button>
                         <textarea class="input-block-level"
                             style="width: 470px; margin-bottom: 4px;"
@@ -2627,7 +2627,7 @@ body {
                                        attr: {'disabled': sharedTaxonSources()}"
                         class="pull-right btn btn-mini btn-danger row-controls-ghosted"
                         style="display: none;">
-                        <i class="icon-remove icon-white"></i>
+                        <i class="icon-trash icon-white"></i>
                     </button>
                   </td>
                  </tr><!-- end of .taxon-source -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -700,7 +700,8 @@ body {
                               <a class="badge badge-info" href="#" style="padding: 2px 6px;"
                                  title="Click to see details about this tree in synthesis"
                                  data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'])? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
-                                            css: {'class': (tree['^ot:reasonsToExcludeFromSynthesis'])? 'badge badge-warning' : 'badge badge-info'}">?</a>
+                                            css: {'class': (tree['^ot:reasonsToExcludeFromSynthesis'])? 'badge badge-warning' : 'badge badge-info'},
+                                            click: showTreeSynthDetailsPopup">?</a>
                             </div>
                         </td>
                       {{ else: }}
@@ -2271,6 +2272,80 @@ body {
       <a data-dismiss="modal" class="btn" >Close</a>
     </div>
 </div>
+
+
+
+<!-- hidden template for popup describing a tree's status vs. synthesis -->
+<div class="modal hide fade" id="tree-synth-details" style="display: none;">
+    <div class="modal-header" style="padding-bottom: 0;">
+      <a class="close" onclick="$('#tree-synth-details').modal('hide'); return false;">×</a>
+      <h3 Xid="tree-title">
+          Tree <span style="color: #999;">Bayesian</span> (id:<span style="color: #999;">tree4602</span>)
+      </h3>
+    </div>
+    <div class="modal-body" style="max-height: none; padding-bottom: 0px;">
+      <div class="tab-pane active">
+          <form class="form-inline" style="overflow: hidden;margin-bottom: 0px;margin-top: -12px;padding-top: 4px;margin-right: -6px;">
+            <p style="margin-bottom: 0.6em;">
+              This tree was <strong>not included</strong> in the latest synthesis (<a href="#">v4.15</a>),
+              but it is <strong>queued</strong> for the next synthesis, despite the warnings listed below.
+            </p>
+            <p style="margin-bottom: 0.0em;">
+              It <strong>passes</strong> our minimal validation for synthesis:
+            </p>
+            <ul style="margin-bottom: 0.2em;">
+              <li>Its root has been confirmed by a curator.</li>
+              <li>It has more than two rooted OTUs.</li>
+            </ul>
+            <div Xid="tree-list-holder" style="overflow: auto; max-height: 257px;">
+      <p style="margin-top: 0.4em; margin-bottom: 0;">
+  Curators have submitted <strong>2 reasons</strong> to exclude this tree from synthesis:
+</p>
+                <table Xid="tree-collection-decision-holder" class="table table-condensed table-hover" style="margin-bottom: 2px; position: relative;" data-bind="visible: true"><!-- TODO: hide if no trees found -->
+
+                  <tbody Xid="tree-collection-decisions" data-bind="foreach: { data: $data.data.decisions, as: 'decision' }">
+                      <tr class="single-tree-row">
+  <td>
+    <button data-bind="click: function() {removeTreeFromCollection($data, $parent); return false;}" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
+      <i class="icon-remove icon-white"></i>
+    </button>
+    <div>The confirmed rooting in Felis does not agree with most published phylogenies.</div>
+  </td>
+</tr>
+<tr class="single-tree-row">
+  <td>
+    <button data-bind="click: function() {removeTreeFromCollection($data, $parent); return false;}" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
+      <i class="icon-remove icon-white"></i>
+    </button>
+    <div>This requires more curation, esp. OTU mapping!</div>
+  </td>
+</tr>
+                  </tbody>
+                </table>
+      <!-- /ko -->
+            </div><!-- /#tree-list-holder -->
+
+          <!-- ko if: userIsEditingCollection($data) -->
+            <!-- TODO: Put add-collection widgets! -->
+            <div xclass="form-actions" style="margin-top: 0px; margin-bottom: 0.25em;">
+              <button Xid="new-collection-tree-start" type="submit" class="btn btn-small btn-info Xbtn-info-disabled" onclick="return false;"><span data-bind="text: ($data.data.decisions.length > 0) ? 'Add another tree' : 'Add a tree to this collection'">Add another reason to exclude this tree</span>
+                    &nbsp;<i class="icon-plus Xicon-upload icon-white"></i>
+              </button>
+            </div>
+            <div class="pull-right" style="position: relative; margin: 9px 2px;">
+              <a class="btn btn-success row-controls-ghosted"><strong>Include</strong> this tree in synthesis</a>
+              &nbsp;
+              <a class="btn btn-danger row-controls-ghosted"><strong>Exclude</strong> this tree from synthesis</a>
+            </div>
+          <!-- /ko -->
+            </form>
+          </div>
+    </div><!-- end of .modal-body -->
+    <div class="modal-footer" style="padding: 5px;"><!-- nothing here! --></div>
+</div>
+
+
+
 
 <!-- hidden template for new-taxon form (for adding taxa to OT Taxonomy) -->
 <div class="modal hide fade" id="new-taxa-popup" style="display: none;">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -694,6 +694,11 @@ body {
                         <td>
                             <span data-bind="text: getSynthStatusDescriptionForTree($data),
                                              css: viewModel.ticklers.TREES"></span>
+                            <a class="badge" href="#" style="padding: 2px 6px;"
+                               title="Click to see details about this tree in synthesis"
+                               data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0)? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
+                                          css: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0 ? 'badge badge-warning' : 'badge badge-info') +' '+ viewModel.ticklers.TREES(),
+                                          click: showTreeSynthDetailsPopup">?</a>
                         </td>
                         <td>
                             <div style="white-space: nowrap;">
@@ -705,11 +710,6 @@ body {
                                  data-bind="attr: {disabled: !(testForPossibleTreeExclusion($data))},
                                             css: viewModel.ticklers.TREES,
                                             click: tryToExcludeTreeFromSynth">Exclude</a>
-                              <a class="badge" href="#" style="padding: 2px 6px;"
-                                 title="Click to see details about this tree in synthesis"
-                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0)? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
-                                            css: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0 ? 'badge badge-warning' : 'badge badge-info') +' '+ viewModel.ticklers.TREES(),
-                                            click: showTreeSynthDetailsPopup">?</a>
                             </div>
                         </td>
                       {{ else: }}

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -520,15 +520,6 @@ body {
               <!-- <div class="control-group">
                 <div class="controls">
 
-                {{ if viewOrEdit == 'EDIT': }}
-                  <label class="checkbox">
-                    <input type="checkbox" data-bind="checked: nexml['^ot:notIntendedForSynthesis'], event: { click: nudge.GENERAL_METADATA }"> This study should not contribute to synthesis.
-                  </label>
-                {{ else: }}
-                  <p class="static-form-value" data-bind="css: nexml['^ot:notIntendedForSynthesis'] ? 'interesting-value' : 'boring-value',
-                                                          text: nexml['^ot:notIntendedForSynthesis'] ? 'This study should not contribute to synthesis. (This is not typical.)' : 'This study should contribute to synthesis.'"></p>
-                {{ pass }}
-
                   <p class="static-form-value interesting-value" data-bind="text: studyContributedToLatestSynthesis() ? (currentStudyVersionContributedToLatestSynthesis() ? 'This version was used to build the latest synthetic tree' : 'This study has changed since building the last synthetic tree.') : 'This study was not used in the latest synthesis.'"></p>
 
                 </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -695,8 +695,12 @@ body {
                         </td>
                         <td>
                             <div style="white-space: nowrap;">
-                              <a class="btn btn-mini btn-success row-controls-ghosted">Include</a>
-                              <a class="btn btn-mini btn-danger row-controls-ghosted" disabled="disabled">Exclude</a>
+                              <a class="btn btn-mini btn-success row-controls-ghosted"
+                                 data-bind="attr: {disabled: !(testForPossibleTreeInclusion($data))},
+                                            click: tryToIncludeTreeInSynth">Include</a>
+                              <a class="btn btn-mini btn-danger row-controls-ghosted"
+                                 data-bind="attr: {disabled: !(testForPossibleTreeExclusion($data))},
+                                            click: tryToExcludeTreeFromSynth">Exclude</a>
                               <a class="badge" href="#" style="padding: 2px 6px;"
                                  title="Click to see details about this tree in synthesis"
                                  data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'].length > 0)? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
@@ -1947,6 +1951,7 @@ body {
     var studyID = '{{= studyID }}';
     var latestSynthesisSHA = '{{= latestSynthesisSHA }}';
     var latestSynthesisTreeIDs = {{= XML( json.dumps(latestSynthesisTreeIDs) ) }};
+    var treesQueuedForSynthesis = {{=XML( json.dumps(treesQueuedForSynthesis) ) }};
     var viewOrEdit = '{{= viewOrEdit }}';
 
     var API_load_study_GET_url = '{{=API_load_study_GET_url}}';
@@ -2016,6 +2021,7 @@ body {
     var doTNRSForMappingOTUs_url = "{{=doTNRSForMappingOTUs_url}}";
     var getContextForNames_url = "{{=getContextForNames_url}}";
     var render_markdown_url = "{{=render_markdown_url}}";
+    var getTreesQueuedForSynthesis_url ="{{=getTreesQueuedForSynthesis_url}}";
 
     var getDraftTreeMRCAForNodes_url = "{{=getDraftTreeMRCAForNodes_url}}";
     var getTaxonomicMRCAForNodes_url = "{{=getTaxonomicMRCAForNodes_url}}";
@@ -2340,9 +2346,15 @@ body {
             </div>
             <div class="pull-right" style="position: relative; margin: 9px 2px;"
                  data-bind="visible: (viewOrEdit == 'EDIT')">
-              <a class="btn btn-success row-controls-ghosted" onclick="return false;"><strong>Include</strong> this tree in synthesis</a>
+              <a class="btn btn-success row-controls-ghosted"
+                 data-bind="attr: {disabled: !(testForPossibleTreeInclusion($root))},
+                            click: function() {tryToIncludeTreeInSynth($root)}">
+                <strong>Include</strong> this tree in synthesis</a>
               &nbsp;
-              <a class="btn btn-danger row-controls-ghosted" onclick="return false;"><strong>Exclude</strong> this tree from synthesis</a>
+              <a class="btn btn-danger row-controls-ghosted"
+                 data-bind="attr: {disabled: !(testForPossibleTreeExclusion($root))},
+                            click: function() {tryToExcludeTreeFromSynth($root)}">
+                <strong>Exclude</strong> this tree from synthesis</a>
             </div>
             <div class="pull-right" style="position: relative; margin: 9px 2px;"
                  data-bind="visible: (viewOrEdit == 'VIEW')">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -787,10 +787,11 @@ body {
               </p>
         {{ if viewOrEdit == 'EDIT': }}
               <p>
-                See <strong>Add a tree to this study</strong>, below, to
-                add new trees from a file or pasted text. Mark the tree as
-                <strong>preferred</strong> to nominate it for inclusion in synthesis.
-                Preferred trees will undergo validation, generating warnings
+                See <strong>Add a tree to this study</strong>, below, to add
+                new trees from a file or pasted text. To nominate a tree for
+                inclusion in synthesis, choose <strong>Include this tree</strong> 
+                in the 'Ready for synthesis?' dropdown.
+                Nominated trees will undergo validation, generating warnings
                 for full OTU mapping and other quality checks.
               </p>
               <p>
@@ -799,7 +800,7 @@ body {
               </p>
         {{ else: }}
               <p>
-                Trees marked as <strong>preferred</strong> have been nominated
+                Trees marked <strong>Include this tree</strong> have been nominated
                 for inclusion in synthesis, generally because they
                 best represent the conclusions of the study. Inclusion in synthesis
                 also requires that trees be rooted correctly and have OTUs mapped.
@@ -894,8 +895,8 @@ body {
 -->
 
                   <label class="checkbox">
-                      <input name="newTreesPreferred" type="checkbox" value="true">
-                      Mark this tree as preferred for synthesis
+                      <input name="includeNewTreesInSynthesis" type="checkbox" value="true">
+                      Include uploaded tree(s) in synthesis
                   </label>
 
                   <div Xclass="form-actions" style="margin-top: 1em;">
@@ -1169,7 +1170,7 @@ body {
                             <span data-bind="text: viewModel.listFilters.OTUS.scope">SCOPE</span>
                             <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" data-bind="foreach: ['In all trees', 'In preferred trees', 'In non-preferred trees']">
+                        <ul class="dropdown-menu" data-bind="foreach: ['In all trees', 'In trees nominated for synthesis', 'In trees not yet nominated']">
                             <li data-bind="css: {'disabled': viewModel.listFilters.OTUS.scope() == $data }">
                                 <a href="#" data-bind="text: $data, click: function () { viewModel.listFilters.OTUS.scope($data); }">SCOPE</a>
                             </li>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -697,9 +697,11 @@ body {
                             <div style="white-space: nowrap;">
                               <a class="btn btn-mini btn-success row-controls-ghosted"
                                  data-bind="attr: {disabled: !(testForPossibleTreeInclusion($data))},
+                                            css: viewModel.ticklers.TREES,
                                             click: tryToIncludeTreeInSynth">Include</a>
                               <a class="btn btn-mini btn-danger row-controls-ghosted"
                                  data-bind="attr: {disabled: !(testForPossibleTreeExclusion($data))},
+                                            css: viewModel.ticklers.TREES,
                                             click: tryToExcludeTreeFromSynth">Exclude</a>
                               <a class="badge" href="#" style="padding: 2px 6px;"
                                  title="Click to see details about this tree in synthesis"
@@ -2022,6 +2024,8 @@ body {
     var getContextForNames_url = "{{=getContextForNames_url}}";
     var render_markdown_url = "{{=render_markdown_url}}";
     var getTreesQueuedForSynthesis_url ="{{=getTreesQueuedForSynthesis_url}}";
+    var includeTreeInSynthesis_url ="{{=includeTreeInSynthesis_url}}";
+    var excludeTreeFromSynthesis_url ="{{=excludeTreeFromSynthesis_url}}";
 
     var getDraftTreeMRCAForNodes_url = "{{=getDraftTreeMRCAForNodes_url}}";
     var getTaxonomicMRCAForNodes_url = "{{=getTaxonomicMRCAForNodes_url}}";

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -726,7 +726,8 @@ body {
                             <button data-bind="click: removeTree,
                                                visible: true"
                                 class="pull-right btn btn-mini btn-danger row-controls-ghosted"
-                                style="display: none;">
+                                title="Click to delete this tree from the study"
+                                style="display: none; margin-left: 5px;">
                                 <i class="icon-remove icon-white"></i>
                             </button>
                         </td>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -789,8 +789,8 @@ body {
               <p>
                 See <strong>Add a tree to this study</strong>, below, to add
                 new trees from a file or pasted text. To nominate a tree for
-                inclusion in synthesis, choose <strong>Include this tree</strong> 
-                in the 'Ready for synthesis?' dropdown.
+                inclusion in synthesis, click its <strong>Include</strong> 
+                button after clearing (or acknowledging) any objections.
                 Nominated trees will undergo validation, generating warnings
                 for full OTU mapping and other quality checks.
               </p>
@@ -800,10 +800,11 @@ body {
               </p>
         {{ else: }}
               <p>
-                Trees marked <strong>Include this tree</strong> have been nominated
-                for inclusion in synthesis, generally because they
-                best represent the conclusions of the study. Inclusion in synthesis
-                also requires that trees be rooted correctly and have OTUs mapped.
+                Trees with a synthesis status of <strong>Included</strong>
+                or <strong>Queued</strong> have been nominated for inclusion
+                in synthesis, generally because they best represent the
+                conclusions of the study. Inclusion in synthesis also requires
+                that trees be rooted correctly and have OTUs mapped.
               </p>
               <p>
                 Click on a tree name to view the tree and get more information.

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -895,11 +895,6 @@ body {
                   <input type="text" id="new-tree-URL" class="input-block-level" value="" placeholder="Paste URL here">
 -->
 
-                  <label class="checkbox">
-                      <input name="includeNewTreesInSynthesis" type="checkbox" value="true">
-                      Include uploaded tree(s) in synthesis
-                  </label>
-
                   <div Xclass="form-actions" style="margin-top: 1em;">
                       <button name="new-tree-submit" type="submit"
                           class="btn btn-info btn-info-disabled"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -646,10 +646,11 @@ body {
                         <th>Ingroup clade</th>
                         <th>Tree root</th>
                         <th>OTUs mapped</th>
-                        <th>Synthesis status</th>
                       {{ if viewOrEdit == 'EDIT': }}
-                        <th>Include in synthesis?</th>
+                        <th colspan="2">Included in synthesis?</th>
                         <th>&nbsp;</th>
+                      {{ else: }}
+                        <th>Synthesis status</th>
                       {{ pass }}
                     </tr>
                   </thead>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -256,7 +256,7 @@ body {
       <li><a href="#History" data-toggle="tab">History <span class="badge badge-important" style="display: none;">?</span></a></li>
     </ul>
 
-    <div class="span4 Xbtn-group" style="float: right; margin-top: -56px;">
+    <div class="span4" style="float: right; margin-top: -56px;">
         {{ if viewOrEdit == 'EDIT': }}
           <button id="save-study-button" class="btn">Save Study</button>
           <input type="hidden" id="return-to-study-list"
@@ -655,8 +655,9 @@ body {
                         <th>Ingroup clade</th>
                         <th>Tree root</th>
                         <th>OTUs mapped</th>
-                        <th>Preferred</th>
+                        <th>Synthesis status</th>
                       {{ if viewOrEdit == 'EDIT': }}
+                        <th>Include in synthesis?</th>
                         <th>&nbsp;</th>
                       {{ pass }}
                     </tr>
@@ -699,12 +700,27 @@ body {
                                 css: viewModel.ticklers.TREES">&nbsp;</td>
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
-                            <input type="checkbox" style="margin: 0px 20px; display: none;"
-            data-bind="attr: {'checked': jQuery.inArray(tree['@id'], getPreferredTreeIDs()) !== -1},
-                       click: togglePreferredTree,
-                       visible: true" /></td>
+                            <span data-bind="text: getSynthStatusDescriptionForTree($data)"></span>
+                        </td>
+                        <td>
+                            <div style="white-space: nowrap;">
+                              <a class="btn btn-mini btn-success row-controls-ghosted">Include</a>
+                              <a class="btn btn-mini btn-danger row-controls-ghosted" disabled="disabled">Exclude</a>
+                              <a class="badge badge-info" href="#" style="padding: 2px 6px;"
+                                 title="Click to see details about this tree in synthesis"
+                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'])? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
+                                            css: {'class': (tree['^ot:reasonsToExcludeFromSynthesis'])? 'badge badge-warning' : 'badge badge-info'}">?</a>
+                            </div>
+                        </td>
                       {{ else: }}
-                        <td data-bind="text: (jQuery.inArray(tree['@id'], getPreferredTreeIDs()) !== -1) ? 'YES' : 'NO'">&nbsp;</td>
+                        <td>
+                          <div style="white-space: nowrap;">
+                              <span data-bind="text: getSynthStatusDescriptionForTree($data)"></span>
+                              <a class="badge badge-info" href="#" style="padding: 2px 6px;"
+                                 data-bind="text: (tree['^ot:reasonsToExcludeFromSynthesis'])? (tree['^ot:reasonsToExcludeFromSynthesis'].length) : '?',
+                                            css: {'class': (tree['^ot:reasonsToExcludeFromSynthesis'])? 'badge badge-warning' : 'badge badge-info'}">?</a>
+                          </div>
+                        </td>
                       {{ pass }}
                       {{ if viewOrEdit == 'EDIT': }}
                         <td>
@@ -1940,6 +1956,7 @@ body {
 <script type='text/javascript'>
     var studyID = '{{= studyID }}';
     var latestSynthesisSHA = '{{= latestSynthesisSHA }}';
+    var latestSynthesisTreeIDs = {{= XML( json.dumps(latestSynthesisTreeIDs) ) }};
     var viewOrEdit = '{{= viewOrEdit }}';
 
     var API_load_study_GET_url = '{{=API_load_study_GET_url}}';

--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -333,6 +333,12 @@ def source_link(source_id):
                 # https://github.com/OpenTreeOfLife/peyotl/blob/3c32582e16be9dcf1029ce3d6481cdb09444890a/peyotl/amendments/amendments_umbrella.py#L33-L34
                 if (len(id_parts) > 1) and id_parts[0] in ('additions', 'changes', 'deletions',):
                     url = _AMENDMENT_REPO_URL_TEMPLATE.format(possible_amendment_id)
+                    # we use a special displayed format for amendments
+                    type_to_singular_prefix = {'additions':'addition' , 'changes':'change', 'deletions':'deletion'}
+                    prefix = type_to_singular_prefix.get(id_parts[0])
+                    node_id = parts[1]
+                    formatted_id = '%s:%s' % (prefix, node_id)
+                    return '<a href="%s">%s</a>' % (cgi.escape(url), cgi.escape(formatted_id))
 
     if url != None:
         return '<a href="%s">%s</a>' % (cgi.escape(url), cgi.escape(source_id))

--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -333,12 +333,6 @@ def source_link(source_id):
                 # https://github.com/OpenTreeOfLife/peyotl/blob/3c32582e16be9dcf1029ce3d6481cdb09444890a/peyotl/amendments/amendments_umbrella.py#L33-L34
                 if (len(id_parts) > 1) and id_parts[0] in ('additions', 'changes', 'deletions',):
                     url = _AMENDMENT_REPO_URL_TEMPLATE.format(possible_amendment_id)
-                    # we use a special displayed format for amendments
-                    type_to_singular_prefix = {'additions':'addition' , 'changes':'change', 'deletions':'deletion'}
-                    prefix = type_to_singular_prefix.get(id_parts[0])
-                    node_id = parts[1]
-                    formatted_id = '%s:%s' % (prefix, node_id)
-                    return '<a href="%s">%s</a>' % (cgi.escape(url), cgi.escape(formatted_id))
 
     if url != None:
         return '<a href="%s">%s</a>' % (cgi.escape(url), cgi.escape(source_id))

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -236,6 +236,31 @@ def fetch_current_TNRS_context_names(request):
         # throw 403 or 500 or just leave it
         return ('ERROR', e.message)
 
+def fetch_trees_queued_for_synthesis(request):
+    try:
+        # fetch all current synth-input collections (as JSON) from remote site
+        # N.B. that this service "concatenates" all synth-input collections
+        # into a single, artificial "collection" with contributors and
+        # decisions/trees, but no name or description, see
+        # <https://github.com/OpenTreeOfLife/peyotl/blob/33b493e84558ffef381d841986281be352f3da53/peyotl/collections_store/__init__.py#L46>
+        from gluon.tools import fetch
+
+        method_dict = get_opentree_services_method_urls(request)
+        fetch_url = method_dict['getTreesQueuedForSynthesis_url']
+        if fetch_url.startswith('//'):
+            # Prepend scheme to a scheme-relative URL
+            fetch_url = "https:%s" % fetch_url
+
+        queued_trees_response = fetch(fetch_url)
+        #queued_trees_response = queued_trees_response.encode('utf-8')  # OK TO SKIP THIS?
+        queued_trees_json = json.loads( queued_trees_response )
+        # this should be a dictionary rendering of the artificial collection
+        return queued_trees_json
+
+    except Exception, e:
+        # throw 403 or 500 or just leave it
+        return ('ERROR', e.message)
+
 def unique_ordered_list(seq):
     seen = set()
     seen_add = seen.add


### PR DESCRIPTION
Add client-side logic and UI to manage (include/exclude) trees queued for synthesis. Addresses #1068 and other related issues. This builds on related PRs https://github.com/OpenTreeOfLife/peyotl/pull/171 and https://github.com/OpenTreeOfLife/phylesystem-api/pull/213.

These features are available for review on **devtree** (for example, [this study with several trees](https://devtree.opentreeoflife.org/curator/study/edit/pg_2606?tab=trees)).