### PR TITLE
Move labels closer, esp. to largest nodes.

### DIFF
--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1170,8 +1170,8 @@ function createArgus(spec) {
             labelY = node.y;
             labelAnchor = 'start';
         } else {
-            labelX = node.x - (node.r * 1.25);
-            labelY = node.y + (node.r * 1.25);
+            labelX = node.x - (node.r + 0.5);
+            labelY = node.y + (node.r + 0.5);
             labelAnchor = 'end';
         }
 


### PR DESCRIPTION
This replaces proportional spacing with a fixed distance beyond the
radius of the displayed node. Fixes #1102 (see that issue for before
and after screenshots).

This is available for review on **devtree**.