### PR TITLE
Consistent tree ordering across browsers.

### DIFF
--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -212,7 +212,24 @@ if (!d3) { throw "d3 wasn't included!"};
         h = parseInt(h);
     var tree = options.tree || d3.layout.cluster()
       .size([h, w])
-      .sort(function(node) { return node.children ? node.children.length : -1; })
+      .sort(function(a,b,c) {
+          // use basic laddering with more children first
+          var aCount = a.children ? a.children.length : 0;
+          var bCount = b.children ? b.children.length : 0;
+          if (aCount > bCount) {
+              return 1;
+          } else if (aCount < bCount) {
+              return -1;
+          } else {
+              // final sort by name/label, if any
+              var aName = $.trim(a.name);
+              var bName = $.trim(b.name);
+              if (aName.localeCompare) {
+                  return aName.localeCompare(bName);
+              }
+              return (aName < bName) ? 1 : -1;
+          }
+      })
       .children(options.children || function(node) {
         return node.branchset
       });


### PR DESCRIPTION
Addresses #1106. We now have standard cross-browser node order (and laddering) for curated trees, with alpha-sort of node labels as the tie-breaker between siblings with the same number of children. 

I've set up a common sort-and-ladderize function that works consistently across browsers. This now applies to both the standard and radial (circular) tree layouts, since the latter was subject to arbitrary rotation as well as inconsistent node order across browsers.

See the results on **devtree**, [for example this tree](https://devtree.opentreeoflife.org/curator/study/view/ot_535/?tab=trees&tree=tree1).