### PR TITLE
Show labels from conflict

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -484,7 +484,8 @@ function getSynthTreeViewerLinkForNodeID(displayName, synthID, nodeID) {
         .replace('{DISPLAY_NAME}', displayName);
 }
 function getSynthTreeViewerURLForNodeID(synthID, nodeID) {
-    if (!synthID || !nodeID) {
+    // if synthID is empty string, will default to latest synth-tree
+    if (!nodeID) {
         return null;
     }
     var url = '/opentree/argus/{SYNTH_ID}@{NODE_ID}';

--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -424,6 +424,8 @@ if (!d3) { throw "d3 wasn't included!"};
                       return '#000';
                   case ('tip (original)'):
                       return '#888';
+                  case ('internal node (aligned)'):
+                      return '#36f';
                   case ('internal node (support)'):
                       return '#888';
                   case ('internal node (other)'):
@@ -450,6 +452,7 @@ if (!d3) { throw "d3 wasn't included!"};
               switch(d.labelType) {
                   case ('tip (mapped OTU)'):
                   case ('tip (original)'):
+                  case ('internal node (aligned)'):
                   case ('internal node (support)'):
                   case ('internal node (other)'):
                   case ('internal node (ambiguous)'):

--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -417,7 +417,14 @@ if (!d3) { throw "d3 wasn't included!"};
           .attr("dy", function(d) {return (d.labelType === 'empty') ? 3 : -6;})
           .attr("text-anchor", function(d) {return (d.labelType === 'empty') ? 'middle' : 'end';})
           .attr('font-size', '10px')
-          .attr('pointer-events', 'none')
+          .attr('pointer-events', function(d) {
+              switch(d.labelType) {
+                  case ('internal node (aligned)'):
+                      return 'all';
+                  default:
+                      return 'none';
+              }
+          })
           .attr('fill', function(d) {
               switch(d.labelType) {
                   case ('tip (mapped OTU)'):
@@ -452,11 +459,20 @@ if (!d3) { throw "d3 wasn't included!"};
               switch(d.labelType) {
                   case ('tip (mapped OTU)'):
                   case ('tip (original)'):
-                  case ('internal node (aligned)'):
                   case ('internal node (support)'):
                   case ('internal node (other)'):
                   case ('internal node (ambiguous)'):
                       return d.name;
+                  case ('internal node (aligned)'):
+                      var link, title;
+                      if (isNaN(d.conflictDetails.witness)) {
+                          link = getSynthTreeViewerURLForNodeID('', d.conflictDetails.witness);
+                          title = "Click to see this taxon in the latest synthetic tree";
+                      } else {
+                          link = getTaxobrowserURL(d.conflictDetails.witness);
+                          title = "Click to see this taxon in the latest OT taxonomy";
+                      }
+                      return '<a xlink:href="'+ link +'" target="_blank" xlink:title="'+ title +'">'+ d.name +'</a>';
                   case ('empty'):
                       /* N.B. empty label should hide, but still have layout to
                        * support a legible highlight.

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -5157,12 +5157,14 @@ function updateLeafNodeFlags(tree) {
      *  .rootDist
      */
 }
+
 function getTreeNodeLabel(tree, node, importantNodeIDs) {
     /* Return the best available label for this node, and its type:
          'tip (mapped OTU)'         mapped to OT taxonomy, preferred
          'tip (original)'           OTU is not yet mapped
          'internal node (support)'
          'internal node (other)'
+         'internal node (aligned)'  from conflict service
          'internal node (ambiguous)'
          'empty'                    no visible label
          'node id'                  a last resort, rarely useful  [DEPRECATED]
@@ -5184,6 +5186,7 @@ function getTreeNodeLabel(tree, node, importantNodeIDs) {
     */
     var itsOTU = node['@otu'];
     if (itsOTU) {
+        // use a mapped taxon name (or original for this OTU)
         var otu = getOTUByID( itsOTU );
         var itsMappedLabel = $.trim(otu['^ot:ottTaxonName']);
         if (itsMappedLabel) {
@@ -5194,33 +5197,36 @@ function getTreeNodeLabel(tree, node, importantNodeIDs) {
             labelInfo.label = otu['^ot:originalLabel'];
             labelInfo.labelType = 'tip (original)';
         }
-    } else {
-        if ('@label' in node) {
-            // TODO: What about other nodeLabelMode values!?
-            if (tree['^ot:nodeLabelMode'] === 'ot:other') {
-                // add any internal label (eg, taxon name) for display
-                labelInfo.label = node['@label'];
-                labelInfo.labelType = 'internal node (other)';
-                // include tree['^ot:nodeLabelDescription'] ?
-            } else if (tree['^ot:nodeLabelMode']) {
-                // any others are support values (1 of 2)
-                labelInfo.label = node['@label'];
-                labelInfo.labelType = 'internal node (support)';
-            } else {
-                // add any ambiguous label (unresolved type) for display
-                labelInfo.label = node['@label'];
-                labelInfo.labelType = 'internal node (ambiguous)';
-            }
-        } else if (node.adjacentEdgeLabel) {
-            // any label from the adjacent (root-ward) edge is support (2 of 2)
-            labelInfo.label = node.adjacentEdgeLabel;
+    } else if (('@label' in node) && (tree['^ot:nodeLabelMode'] === 'ot:other')) {
+        // this is probably a previously assigned taxon name
+        labelInfo.label = node['@label'];
+        labelInfo.labelType = 'internal node (other)';
+        // include tree['^ot:nodeLabelDescription'] ?
+    } else if (('conflictDetails' in node) && 
+               ($.inArray(node.conflictDetails.status, ['supported_by', 'partial_path_of', 'mapped_to_taxon']) !== -1) &&
+               node.conflictDetails.witness_name) {
+        // use any 'aligned' taxon name provided by conflict service
+        labelInfo.label = node.conflictDetails.witness_name;
+        labelInfo.labelType = 'internal node (aligned)';
+    } else if ('@label' in node) {
+        if (tree['^ot:nodeLabelMode']) {
+            // use any support values (1 of 2, see below)
+            labelInfo.label = node['@label'];
             labelInfo.labelType = 'internal node (support)';
         } else {
-            labelInfo.label = nodeID;
-            labelInfo.labelType = 'empty';
+            // use any ambiguous label (unresolved type) for display
+            labelInfo.label = node['@label'];
+            labelInfo.labelType = 'internal node (ambiguous)';
         }
+    } else if (node.adjacentEdgeLabel) {
+        // any label from the adjacent (root-ward) edge is support (2 of 2, see above)
+        labelInfo.label = node.adjacentEdgeLabel;
+        labelInfo.labelType = 'internal node (support)';
+    } else {
+        // show the bare node ID as our last resort
+        labelInfo.label = nodeID;
+        labelInfo.labelType = 'empty';
     }
-
     return labelInfo;
 }
 
@@ -6674,6 +6680,10 @@ function showNodeOptionsMenu( tree, node, nodePageOffset, importantNodeIDs ) {
         case('tip (original)'):
             nodeOptionsLabel = labelInfo.label;
             labelTypeDescription = "Original OTU label";
+            break;
+        case ('internal node (aligned)'):
+            nodeOptionsLabel = labelInfo.label;
+            labelTypeDescription = "Label provided by conflict service";
             break;
         case ('internal node (support)'):
         case ('internal node (other)'):

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -97,10 +97,6 @@ body {
   fill: steelblue;
   r: 4.5px;
 }
-.node.specifiedRoot text {
-  fill: steelblue;
-  font-size: 1.3em;
-}
 /* even more preferred ot:specifiedRoot */
 .node.inGroupClade circle {
   fill: #000;
@@ -121,6 +117,10 @@ body {
 
 .node {
   font: 10px sans-serif;
+}
+.node a, .node a:visited {
+  color: inherit;
+  fill: inherit;
 }
 
 .dropdown-menu > li.node-information {

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -80,7 +80,7 @@ def index():
         response.status = 303
 
     # when all is said and done, do we have enough information to force the location?
-    if treeview_dict['domSource'] and treeview_dict['nodeID']:
+    if incomingDomSource and treeview_dict['nodeID']:
         treeview_dict['forcedByURL'] = True
 
     treeview_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)


### PR DESCRIPTION
Addresses (parts of) #1064, by detecting taxon names in conflict-service results and showing these as labels on internal nodes. 