### PR TITLE
Enable selection of original OTU label.

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1247,9 +1247,7 @@ body {
                                                css: viewModel.ticklers.OTU_MAPPING_HINTS" />
                          </td>
                       {{ pass }}
-                        <td onmousedown="return false;"
-                            data-bind="text: otu['^ot:originalLabel'],
-                                       click: toggleMappingForOTU">&nbsp;</td>
+                        <td data-bind="text: otu['^ot:originalLabel']">&nbsp;</td>
                         <td>
                             <button class="btn btn-mini row-controls-ghosted" title="Show this OTU in all trees"
                                      data-bind="click: showOTUInContext, css: viewModel.ticklers.OTU_MAPPING_HINTS">


### PR DESCRIPTION
This makes it easy to look up a label on the web, at the (minor) cost of having a smaller target to toggle the current row's selection for mapping. Fixes #890.