### PR TITLE
Support repeated search string for collections.

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -826,12 +826,6 @@ function searchForMatchingStudy() {
         return false;
     }
 
-    // is this unchanged from last time? no need to search again..
-    if ((searchText == showingResultsForStudyLookupText)) {
-        //console.log("Study-lookup text UNCHANGED!");
-        return false;
-    }
-
     // stash the search-text used to generate these results
     showingResultsForStudyLookupText = searchText;
     $('#study-lookup-results').html('<li class="disabled"><a><span class="text-warning">Search in progress...</span></a></li>');


### PR DESCRIPTION
Remove an "optimization" that would abort study search, if the search
string exactly matches the previous search. This would "kill" the search
feature if someone tried to find another study with, e.g., an author's
last name. Fixes #1029.