### PR TITLE
Fix broken error page in curation app.

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -47,7 +47,8 @@ def collections():
     return view_dict
     
 def error():
-    return dict()
+    view_dict = get_opentree_services_method_urls(request)
+    return view_dict
 
 @auth.requires_login()
 def dashboard():


### PR DESCRIPTION
This view uses the 'layout.html' template, which expects to find method URLs as in other common views. I've added these to its view dictionary, so we should now see the error page rather than masking the original error.