### PR TITLE
Support inbound link to a specific tree+node

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -908,3 +908,10 @@ tr.after-shims th {
     color: red !important;
 }
 
+a.node-direct-link {
+    float: right;
+    padding: 1px 4px !important;
+    margin-top: -4px;
+    margin-right: -16px;
+    border-radius: 4px;
+}

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -137,6 +137,7 @@ if ( History && History.enabled ) {
         // treatment of initial URLs.
         var currentTab = State.data.tab;
         var currentTree = State.data.tree;
+        var highlightNodeID = State.data.node;
         var conflictReferenceTree = State.data.conflict;
         var activeFilter = null;
         var filterDefaults = null;
@@ -174,7 +175,13 @@ if ( History && History.enabled ) {
         if (currentTree) {
             var tree = getTreeByID(currentTree);
             if (tree) {
-                showTreeViewer(tree);
+                // show inbound node, if provided
+                // N.B. this is not reflected in History state!
+                if (highlightNodeID) {
+                    showTreeViewer(tree, {HIGHLIGHT_NODE_ID: highlightNodeID });
+                } else {
+                    showTreeViewer(tree);
+                }
                 // omit conflict spinner when handling inbound URLs; it conflicts with others
                 if (conflictReferenceTree) {
                     fetchAndShowTreeConflictDetails(currentTree, conflictReferenceTree, {SHOW_SPINNER: false});
@@ -6765,6 +6772,10 @@ function showNodeOptionsMenu( tree, node, nodePageOffset, importantNodeIDs ) {
             console.error('Unknown label type! ['+ labelInfo.labelType +']');;
     }
     nodeInfoBox.append('<span class="node-name">'+ nodeOptionsLabel +'</span>');
+
+    var nodeURL = getViewURLFromStudyID(studyID) +"?tab=trees&tree="+ tree['@id'] +"&node="+ node['@id'];
+    nodeInfoBox.append('<a class="node-direct-link" title="Link directly to this node (opens in new window)" target="_blank" href="'+ 
+                       nodeURL +'"><i class="icon-share-alt"></i></a>');
 
     if ((viewOrEdit === 'EDIT') && isDuplicateNode( tree, node )) {
         if (node['^ot:isTaxonExemplar'] === true) {


### PR DESCRIPTION
We provide these links in the curation app's node-info popup. Note that these URLs won't be reflected in browser state (History.js). They're just a convenience for linking directly to a node. These changes are tested and working on **devtree**.

Fixes #914 (see this issue for related discussion and a screenshot of the proposed solution).