### PR TITLE
Ff treeview history bug

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2175,13 +2175,12 @@ function checkForInterestingStudies(a,b) {
     if ($.inArray( b['ot:studyId'], interestingIDs ) === -1) return false;
     return true;
     */
-
+    /*
     // match just one study
     var interestingIDs = ['tt_95'];
     if ($.inArray( a['ot:studyId'], interestingIDs ) !== -1) return true;
     if ($.inArray( b['ot:studyId'], interestingIDs ) !== -1) return true;
     return false;
-    /*
     */
 }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4669,7 +4669,16 @@ function drawTree( treeOrID, options ) {
 
     // Finalize SVG height/width/scale/left/top to match rendered labels
     // (prevents cropping when some labels exceed our estimated `labelWidth` above)
-    var renderedBounds = vizInfo.vis.node().getBBox();
+    var renderedBounds;
+    try {
+        renderedBounds = vizInfo.vis.node().getBBox();
+    } catch(e) {
+        /* FF fails with NS_ERROR_FAILURE if this SVG element is not currently rendered! See
+         *  https://bugzilla.mozilla.org/show_bug.cgi?id=528969
+         */
+        //console.error('>>> UNABLE TO MEASURE BOUNDING BOX ('+ e +'):');
+        renderedBounds = { x:0, y:0, width:0, height:0 };
+    }
     var svgNode = d3.select( vizInfo.vis.node().parentNode );
     // match SVG size to the rendered bounds incl. all labels
     if (renderedBounds.height > 0) {


### PR DESCRIPTION
This fixes issue #1123, problems with browser history and navigation when using the tree viewer in Firefox. See the issue for discussion and example URLs. This is working now on **devtree**.