### PR TITLE
use parens in taxo browser to distinguish merged from aligned qids

### DIFF
--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -296,7 +296,11 @@ def display_basic_info(info, output):
     # Sources
     start_el(output, 'span', 'sources')
     if u'tax_sources' in info:
-        output.write(' %s ' % ', '.join(map(source_link, info[u'tax_sources'])))
+        sources = info[u'tax_sources']
+        if len(sources) > 0:
+            output.write(' %s ' % source_link(sources[0]))
+            if len(sources) > 1:
+                output.write('(%s) ' % (', '.join(map(source_link, sources[1:])),))
     end_el(output, 'span')
 
     # Flags


### PR DESCRIPTION
This just tweaks the formatting of the source id list. Instead of

>ncbi:8397, worms:448307, gbif:6746, irmng:103657

it now shows

>ncbi:8397 (worms:448307, gbif:6746, irmng:103657)

which I hope is suggestive of the fact that the taxon comes from the non-parenthesized source. The others are just alignments.

See https://devtree.opentreeoflife.org/taxonomy/browse?id=364560 . Attempts to address https://github.com/OpenTreeOfLife/reference-taxonomy/issues/328