### PR TITLE
Ignore tips when looking for ambiguous node labels

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8722,6 +8722,12 @@ function getAmbiguousLabelsInTree(tree) {
     }
 
     $.each( tree.node, function(i, node) {
+        if (node['^ot:isLeaf'] === true) {
+            /* We sometimes save a misspelled taxon name as `node[@label]` so
+             * we can show it later, but tip labels aren't really ambiguous here.
+             */
+            return true;  // skip to next node
+        }
         if ('@label' in node) {
             var nodeID = node['@id'];
             labelData[ nodeID ] = node['@label'];


### PR DESCRIPTION
These labels are not really ambiguous! If found, a leaf node with a `@label` attribute seems only to indicate a misspelled taxon name that was entered elsewhere (i.e. imported from TreeBASE).

By reporting them here, we present the user with a confusing instruction to disambiguate labels, but nothing they can see and respond to.

This fix is running now on **devtree**. You can see the effect by (for example) importing study 'TB2:S17496' from TreeBASE. On **production**, this study's trees almost all report ambiguous labels, since one or a few tips retain their original/misspelled taxon names; on **devtree**, all of them should display normally.