### PR TITLE
Fix entities in SVG download

### DIFF
--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -496,9 +496,11 @@ if (!d3) { throw "d3 wasn't included!"};
                       return '<a xlink:href="'+ link +'" target="_blank" xlink:title="'+ title +'">'+ d.name +'</a>';
                   case ('empty'):
                       /* N.B. empty label should hide, but still have layout to
-                       * support a legible highlight.
+                       * support a legible highlight. NOTE that we use the
+                       * numeric entity '#160' here, instead of 'nbsp', so we
+                       * can safely download the resulting tree view as SVG/XML!
                        */
-                      return '&nbsp; &nbsp; &nbsp; &nbsp;';
+                      return '&#160; &#160; &#160; &#160;';
                   default:
                       console.error('Unknown label type! ['+ d.labelType +']');;
                       return "???";

--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -500,7 +500,7 @@ if (!d3) { throw "d3 wasn't included!"};
                        * numeric entity '#160' here, instead of 'nbsp', so we
                        * can safely download the resulting tree view as SVG/XML!
                        */
-                      return '&#160; &#160; &#160; &#160;';
+                      return '&#160; &#160; TEST &#160; &#160;';
                   default:
                       console.error('Unknown label type! ['+ d.labelType +']');;
                       return "???";

--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -496,11 +496,9 @@ if (!d3) { throw "d3 wasn't included!"};
                       return '<a xlink:href="'+ link +'" target="_blank" xlink:title="'+ title +'">'+ d.name +'</a>';
                   case ('empty'):
                       /* N.B. empty label should hide, but still have layout to
-                       * support a legible highlight. NOTE that we use the
-                       * numeric entity '#160' here, instead of 'nbsp', so we
-                       * can safely download the resulting tree view as SVG/XML!
+                       * support a legible highlight.
                        */
-                      return '&#160; &#160; &#160; &#160;';
+                      return '&nbsp; &nbsp; &nbsp; &nbsp;';
                   default:
                       console.error('Unknown label type! ['+ d.labelType +']');;
                       return "???";

--- a/curator/static/js/d3.phylogram.js
+++ b/curator/static/js/d3.phylogram.js
@@ -500,7 +500,7 @@ if (!d3) { throw "d3 wasn't included!"};
                        * numeric entity '#160' here, instead of 'nbsp', so we
                        * can safely download the resulting tree view as SVG/XML!
                        */
-                      return '&#160; &#160; TEST &#160; &#160;';
+                      return '&#160; &#160; &#160; &#160;';
                   default:
                       console.error('Unknown label type! ['+ d.labelType +']');;
                       return "???";

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10502,10 +10502,11 @@ function updateSaveTreeViewLink() {
         null    // desired doctype, or null
     )
     // replace its boring top-level element with our SVG
-    var htmlNode = $treeSVG[0];
-    tempXMLDoc.documentElement.replaceWith(htmlNode)
-    xmlNode = tempXMLDoc.documentElement
-    var svgString = serializer.serializeToString(node);
+    // (cloned from the original, else it disappears!)
+    var htmlNode = $treeSVG.clone()[0];
+    tempXMLDoc.documentElement.replaceWith(htmlNode);
+    var xmlNode = tempXMLDoc.documentElement;
+    var svgString = serializer.serializeToString(xmlNode);
 
     /* Alternate implmentation (fails in Safari)
     var serializer = new XMLSerializer();

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10493,10 +10493,28 @@ function updateSaveTreeViewLink() {
         $treeSVG.prepend( $treeStylesheet[0].outerHTML );
     }
 
-    // serialize the main SVG node (convert HTML entities to Unicode)
+    // Serialize the main SVG node (converting HTML entities to Unicode); first, we
+    // create a temporary XML document
+    var serializer = new XMLSerializer();
+    var tempXMLDoc = document.implementation.createDocument(
+        null,   // desired namespace, or null
+        "svg",  // name of top-level element
+        null    // desired doctype, or null
+    )
+    // replace its boring top-level element with our SVG
+    var htmlNode = $treeSVG[0];
+    tempXMLDoc.documentElement.replaceWith(htmlNode)
+    xmlNode = tempXMLDoc.documentElement
+    var svgString = serializer.serializeToString(node);
+
+    /* Alternate implmentation (fails in Safari)
     var serializer = new XMLSerializer();
     var node = $treeSVG[0];
     var svgString = serializer.serializeToString(node);
+    // Safari may still fail to convert HTML entities :-/
+    svgString = svgString.replace(/&nbsp;/gi,'&#160;');
+    */
+
     // encode it for safe use in a data URI
     var base64src = b64EncodeUnicode(svgString);
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10493,8 +10493,12 @@ function updateSaveTreeViewLink() {
         $treeSVG.prepend( $treeStylesheet[0].outerHTML );
     }
 
-    // encode the current SVG
-    var base64src = b64EncodeUnicode( $treeSVG[0].outerHTML );
+    // serialize the main SVG node (convert HTML entities to Unicode)
+    var serializer = new XMLSerializer();
+    var node = $treeSVG[0];
+    var svgString = serializer.serializeToString(node);
+    // encode it for safe use in a data URI
+    var base64src = b64EncodeUnicode(svgString);
 
     var $saveLink = $('#save-tree-view');
     $saveLink.attr('href', 'data:image/svg+xml;base64,\n'+ base64src);


### PR DESCRIPTION
We've had some problems with unsupported HTML entities (typically `&nbsp;`) in our SVG output. See this [related Gitter chat](https://gitter.im/OpenTreeOfLife/public?at=5925a2059f4f4ab05bf8002f) for details. 

This change serializes the main SVG node to Unicode, which removes all entities entirely, then relies on Base64 to encode all characters in the data URI. This is working and tested on **devtree**, see for example [this tree](https://devtree.opentreeoflife.org/curator/study/edit/tt_103?tab=trees&tree=tree3) with unlabeled internal nodes. This should download and print with no problems. Also note that I've added some diacritical marks and challenging punctuation in the topmost tip's label `Mycôsphærëlla "zoomer" >!;`. The new solution seems to handle these characters just fine.