### PR TITLE
Careful branch length detection

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1632,27 +1632,57 @@ function toggleRadialTreeLayoutInViewer(cb) {
     /* N.B. This logic is replicated in Knockout bindings to handle the 
      * initial display for each tree!
      */
-    if (usingRadialTreeLayout || !allBranchLengthsFoundInTree(currentTree)) {
+    if isBranchLengthToggleEnabled(currentTree) {
         $branchLengthCheckbox.attr('disabled', 'disabled');
-        $branchLengthLabel.css('color', '#999');
-        if (noBranchLengthsFoundInTree(currentTree)) {
-            $branchLengthLabel.attr('title', 'No branch lengths found in this tree');
-        } else if (!allBranchLengthsFoundInTree(currentTree)) {
-            $branchLengthLabel.attr('title', 'Not all edges of this tree have branch lengths');
-        } else {
-            $branchLengthLabel.attr('title', 'Branch lengths cannot be shown in the radial layout');
-        }
     } else {
         $branchLengthCheckbox.removeAttr('disabled')
-        $branchLengthLabel.css('color', null).attr('title', '');
     }
+    $branchLengthLabel.css( getBranchLengthToggleStyle(currentTree) );
+    $branchLengthLabel.attr( getBranchLengthToggleAttributes(currentTree) );
+
     if (currentTreeID) {
         drawTree(currentTreeID)
     } else {
         console.warn("No tree in vizInfo!");
     }
 }
-
+/* These awkward support functions isolate the logic used to assign inline CSS
+ * and attributes for the toggling checkbox and its surrounding label. This
+ * makes it possible to build Knockout bindings and JS functions that draw
+ * from common logic and values. The previous duplication was error-prone and
+ * unwieldy, esp. for KO bindings.
+ */
+function isBranchLengthToggleEnabled(tree) {
+    viewModel.ticklers.TREES();
+    if (usingRadialTreeLayout) return false;
+    if (allBranchLengthsFoundInTree(tree)) return true;
+    return false;  // i.e., some branches have no length
+}
+function getBranchLengthToggleAttributes(tree) {
+    viewModel.ticklers.TREES();
+    // return a set of properties/values suitable for HTML attributes
+    var title;
+    if (isBranchLengthToggleEnabled(tree)) {
+        title = '';
+    } else {
+        if (noBranchLengthsFoundInTree(tree)) {
+            title = 'No branch lengths found in this tree';
+        } else if (!allBranchLengthsFoundInTree(tree)) {
+            title = 'Not all edges of this tree have branch lengths';
+        } else {
+            title = 'Branch lengths cannot be shown in the radial layout';
+        }
+    }
+    return {'title': title};
+}
+function getBranchLengthToggleStyle(tree) {
+    viewModel.ticklers.TREES();
+    // return a set of properties/values suitable for inline CSS
+    if (isBranchLengthToggleEnabled(tree)) {
+        return {'color': null};
+    }
+    return {'color': '#999'};
+}
 
 /* Support conflict display in the tree viewer */
 function getTreeConflictSummary(conflictInfo) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1629,20 +1629,22 @@ function toggleRadialTreeLayoutInViewer(cb) {
     // NOTE: We only enable this feature if ALL branches have length!
     var $branchLengthCheckbox = $('#branch-length-toggle');
     var $branchLengthLabel = $branchLengthCheckbox.parent();
+    /* N.B. This logic is replicated in Knockout bindings to handle the 
+     * initial display for each tree!
+     */
     if (usingRadialTreeLayout || !allBranchLengthsFoundInTree(currentTree)) {
         $branchLengthCheckbox.attr('disabled', 'disabled');
         $branchLengthLabel.css('color', '#999');
         if (noBranchLengthsFoundInTree(currentTree)) {
-            $('#branch-length-toggle').attr('title', 'No branch lengths found in this tree');
+            $branchLengthLabel.attr('title', 'No branch lengths found in this tree');
         } else if (!allBranchLengthsFoundInTree(currentTree)) {
-            $('#branch-length-toggle').attr('title', 'Not all edges of this tree have branch lengths');
+            $branchLengthLabel.attr('title', 'Not all edges of this tree have branch lengths');
         } else {
-            $('#branch-length-toggle').attr('title', 'Branch lengths cannot be shown in the radial layout');
+            $branchLengthLabel.attr('title', 'Branch lengths cannot be shown in the radial layout');
         }
     } else {
-        $('#branch-length-toggle').removeAttr('disabled')
-                                  .attr('title', '');
-        $branchLengthLabel.css('color', null);
+        $branchLengthCheckbox.removeAttr('disabled')
+        $branchLengthLabel.css('color', null).attr('title', '');
     }
     if (currentTreeID) {
         drawTree(currentTreeID)

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1633,9 +1633,9 @@ function toggleRadialTreeLayoutInViewer(cb) {
      * initial display for each tree.
      */
     if (isBranchLengthToggleEnabled(currentTree)) {
-        $branchLengthCheckbox.attr('disabled', 'disabled');
-    } else {
         $branchLengthCheckbox.removeAttr('disabled');
+    } else {
+        $branchLengthCheckbox.attr('disabled', 'disabled');
     }
     $branchLengthLabel.css( getBranchLengthToggleStyle(currentTree) );
     $branchLengthLabel.attr( getBranchLengthToggleAttributes(currentTree) );

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1629,19 +1629,19 @@ function toggleRadialTreeLayoutInViewer(cb) {
     // NOTE: We only enable this feature if ALL branches have length!
     var $branchLengthCheckbox = $('#branch-length-toggle');
     var $branchLengthLabel = $branchLengthCheckbox.parent();
-    /* N.B. This logic is replicated in Knockout bindings to handle the 
-     * initial display for each tree!
+    /* N.B. This logic is shared with Knockout bindings, to handle the
+     * initial display for each tree.
      */
-    if isBranchLengthToggleEnabled(currentTree) {
+    if (isBranchLengthToggleEnabled(currentTree)) {
         $branchLengthCheckbox.attr('disabled', 'disabled');
     } else {
-        $branchLengthCheckbox.removeAttr('disabled')
+        $branchLengthCheckbox.removeAttr('disabled');
     }
     $branchLengthLabel.css( getBranchLengthToggleStyle(currentTree) );
     $branchLengthLabel.attr( getBranchLengthToggleAttributes(currentTree) );
 
     if (currentTreeID) {
-        drawTree(currentTreeID)
+        drawTree(currentTreeID);
     } else {
         console.warn("No tree in vizInfo!");
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1628,7 +1628,7 @@ function toggleRadialTreeLayoutInViewer(cb) {
     // disable/enable the branch-lengths checkbox
     // NOTE: We only enable this feature if ALL branches have length!
     var $branchLengthCheckbox = $('#branch-length-toggle');
-    var $branchLengthLabel = $branchLengthToggleCB.parent();
+    var $branchLengthLabel = $branchLengthCheckbox.parent();
     if (usingRadialTreeLayout || !allBranchLengthsFoundInTree(currentTree)) {
         $branchLengthCheckbox.attr('disabled', 'disabled');
         $branchLengthLabel.css('color', '#999');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2908,19 +2908,25 @@ function getRootedStatusForTree( tree ) {
 // N.B. It's possible (but rare) that some-but-not-all edges will have length!
 // Let's check for some/all/none with separate functions.
 function anyBranchLengthsFoundInTree( tree ) {
+    var foundBranchWithLength = false;
     $.each(tree.edge, function(i, edge) {
-        if ('@length' in edge) return true;
+        if ('@length' in edge) {
+            foundBranchWithLength = true;
+            return false; // stop looking
+        }
     });
-    // no lengths found!
-    return false;
+    return foundBranchWithLength;
 }
 function allBranchLengthsFoundInTree( tree ) {
     // N.B. It's possible (but rare) that some-but-not-all edges will have length.
+    var foundBranchWithoutLength = false;
     $.each(tree.edge, function(i, edge) {
-        if (!('@length' in edge)) return false;
+        if (!('@length' in edge)) {
+            foundBranchWithoutLength = true;
+            return false; // stop looking
+        }
     });
-    // no exceptions found!
-    return true;
+    return !(foundBranchWithoutLength);
 }
 function noBranchLengthsFoundInTree( tree ) {
     return !(anyBranchLengthsFoundInTree(tree));

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1627,10 +1627,22 @@ function toggleRadialTreeLayoutInViewer(cb) {
     usingRadialTreeLayout = $(cb).is(':checked');
     // disable/enable the branch-lengths checkbox
     // NOTE: We only enable this feature if ALL branches have length!
-    if (usingRadialTreeLayout || !(allBranchLengthsFoundInTree(currentTree))) {
-        $('#branch-length-toggle').attr('disabled', 'disabled');
+    var $branchLengthCheckbox = $('#branch-length-toggle');
+    var $branchLengthLabel = $branchLengthToggleCB.parent();
+    if (usingRadialTreeLayout || !allBranchLengthsFoundInTree(currentTree)) {
+        $branchLengthCheckbox.attr('disabled', 'disabled');
+        $branchLengthLabel.css('color', '#999');
+        if (noBranchLengthsFoundInTree(currentTree)) {
+            $('#branch-length-toggle').attr('title', 'No branch lengths found in this tree');
+        } else if (!allBranchLengthsFoundInTree(currentTree)) {
+            $('#branch-length-toggle').attr('title', 'Not all edges of this tree have branch lengths');
+        } else {
+            $('#branch-length-toggle').attr('title', 'Branch lengths cannot be shown in the radial layout');
+        }
     } else {
-        $('#branch-length-toggle').removeAttr('disabled');
+        $('#branch-length-toggle').removeAttr('disabled')
+                                  .attr('title', '');
+        $branchLengthLabel.css('color', null);
     }
     if (currentTreeID) {
         drawTree(currentTreeID)

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2918,7 +2918,6 @@ function anyBranchLengthsFoundInTree( tree ) {
     return foundBranchWithLength;
 }
 function allBranchLengthsFoundInTree( tree ) {
-    // N.B. It's possible (but rare) that some-but-not-all edges will have length.
     var foundBranchWithoutLength = false;
     $.each(tree.edge, function(i, edge) {
         if (!('@length' in edge)) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1679,7 +1679,7 @@ function getBranchLengthToggleStyle(tree) {
     viewModel.ticklers.TREES();
     // return a set of properties/values suitable for inline CSS
     if (isBranchLengthToggleEnabled(tree)) {
-        return {'color': null};
+        return {'color': ''};
     }
     return {'color': '#999999'};
 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1681,7 +1681,7 @@ function getBranchLengthToggleStyle(tree) {
     if (isBranchLengthToggleEnabled(tree)) {
         return {'color': null};
     }
-    return {'color': '#999'};
+    return {'color': '#999999'};
 }
 
 /* Support conflict display in the tree viewer */

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3167,7 +3167,7 @@ body {
           <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle" 
                  data-bind="attr: {'title' : (viewModel.ticklers.TREES() &&
                                      (usingRadialTreeLayout ||
-                                      !allBranchLengthsFoundInTree($data)) ?
+                                      !allBranchLengthsFoundInTree($data))) ?
                                     noBranchLengthsFoundInTree($data) ?
                                  'No branch lengths found in this tree' :
                                     !allBranchLengthsFoundInTree($data) ?
@@ -3175,7 +3175,7 @@ body {
                                  'Branch lengths cannot be shown in the radial layout'},
                             css: {'color': (viewModel.ticklers.TREES() &&
                                             (usingRadialTreeLayout ||
-                                             !allBranchLengthsFoundInTree($data)) ?
+                                             !allBranchLengthsFoundInTree($data))) ?
                                            '#999' :
                                            null}">
               <input type="checkbox" id="branch-length-toggle"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3163,9 +3163,24 @@ body {
     </div>
     <div class="modal-footer">
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
-          <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle">
+          <!-- N.B. data bindings mimic toggleRadialTreeLayoutInViewer() -->
+          <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle" data-bind="attr: {'title' : (viewModel.ticklers.TREES() &&
+                                     (usingRadialTreeLayout ||
+                                      !allBranchLengthsFoundInTree($data)) ?
+                                    noBranchLengthsFoundInTree($data) ?
+                                 'No branch lengths found in this tree' :
+                                    !allBranchLengthsFoundInTree($data) ?
+                                 'Not all edges of this tree have branch lengths' :
+                                 'Branch lengths cannot be shown in the radial layout'},
+                   css: {'color': (viewModel.ticklers.TREES() &&
+                                   (usingRadialTreeLayout ||
+                                    !allBranchLengthsFoundInTree($data)) ?
+                                  '#999',
+                                  null}">
               <input type="checkbox" id="branch-length-toggle"
-                     data-bind="enable: viewModel.ticklers.TREES() && allBranchLengthsFoundInTree($data)"
+                     data-bind="enable: viewModel.ticklers.TREES() &&
+                                        (!usingRadialTreeLayout &&
+                                         allBranchLengthsFoundInTree($data))"
                      onclick="toggleBranchLengthsInViewer(this); return true;" />
               Cladogram (hide branch lengths)
           </label>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3165,7 +3165,7 @@ body {
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
           <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle">
               <input type="checkbox" id="branch-length-toggle"
-                     data-bind="enable: allBranchLengthsFoundInTree($data)"
+                     data-bind="enable: viewModel.ticklers.TREES() && allBranchLengthsFoundInTree($data)"
                      onclick="toggleBranchLengthsInViewer(this); return true;" />
               Cladogram (hide branch lengths)
           </label>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3164,7 +3164,8 @@ body {
     <div class="modal-footer">
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
           <!-- N.B. data bindings mimic toggleRadialTreeLayoutInViewer() -->
-          <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle" data-bind="attr: {'title' : (viewModel.ticklers.TREES() &&
+          <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle" 
+                 data-bind="attr: {'title' : (viewModel.ticklers.TREES() &&
                                      (usingRadialTreeLayout ||
                                       !allBranchLengthsFoundInTree($data)) ?
                                     noBranchLengthsFoundInTree($data) ?
@@ -3172,11 +3173,11 @@ body {
                                     !allBranchLengthsFoundInTree($data) ?
                                  'Not all edges of this tree have branch lengths' :
                                  'Branch lengths cannot be shown in the radial layout'},
-                   css: {'color': (viewModel.ticklers.TREES() &&
-                                   (usingRadialTreeLayout ||
-                                    !allBranchLengthsFoundInTree($data)) ?
-                                  '#999',
-                                  null}">
+                            css: {'color': (viewModel.ticklers.TREES() &&
+                                            (usingRadialTreeLayout ||
+                                             !allBranchLengthsFoundInTree($data)) ?
+                                           '#999' :
+                                           null}">
               <input type="checkbox" id="branch-length-toggle"
                      data-bind="enable: viewModel.ticklers.TREES() &&
                                         (!usingRadialTreeLayout &&

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3166,7 +3166,7 @@ body {
           <!-- N.B. data bindings mimic toggleRadialTreeLayoutInViewer() -->
           <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle"
                  data-bind="attr: getBranchLengthToggleAttributes($data),
-                            css: getBranchLengthToggleStyle($data)">
+                            style: getBranchLengthToggleStyle($data)">
               <input type="checkbox" id="branch-length-toggle"
                      data-bind="enable: isBranchLengthToggleEnabled($data)"
                      onclick="toggleBranchLengthsInViewer(this); return true;" />

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3164,24 +3164,11 @@ body {
     <div class="modal-footer">
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
           <!-- N.B. data bindings mimic toggleRadialTreeLayoutInViewer() -->
-          <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle" 
-                 data-bind="attr: {'title' : (viewModel.ticklers.TREES() &&
-                                     (usingRadialTreeLayout ||
-                                      !allBranchLengthsFoundInTree($data))) ?
-                                    noBranchLengthsFoundInTree($data) ?
-                                 'No branch lengths found in this tree' :
-                                    !allBranchLengthsFoundInTree($data) ?
-                                 'Not all edges of this tree have branch lengths' :
-                                 'Branch lengths cannot be shown in the radial layout'},
-                            css: {'color': (viewModel.ticklers.TREES() &&
-                                            (usingRadialTreeLayout ||
-                                             !allBranchLengthsFoundInTree($data))) ?
-                                           '#999' :
-                                           null}">
+          <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle"
+                 data-bind="attr: getBranchLengthToggleAttributes($data),
+                            css: getBranchLengthToggleStyle($data)">
               <input type="checkbox" id="branch-length-toggle"
-                     data-bind="enable: viewModel.ticklers.TREES() &&
-                                        (!usingRadialTreeLayout &&
-                                         allBranchLengthsFoundInTree($data))"
+                     data-bind="enable: isBranchLengthToggleEnabled($data)"
                      onclick="toggleBranchLengthsInViewer(this); return true;" />
               Cladogram (hide branch lengths)
           </label>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2814,7 +2814,7 @@ body {
               <br/>
                -->
 
-            <div style="margin-top: 6px;" data-bind="visible: viewModel.ticklers.TREES() && branchLengthsFoundInTree( $data )">
+            <div style="margin-top: 6px;" data-bind="visible: viewModel.ticklers.TREES() && anyBranchLengthsFoundInTree( $data )">
                 <label>Branch length mode: </label>
                 <select data-bind="options: branchLengthModeDescriptions,
                     optionsValue: function(item) {
@@ -2848,7 +2848,7 @@ body {
             </div>
 
            <!-- NOTE that a virtual element with 'ko if: ...' didn't work here! -->
-            <div style="margin-top: 6px;" data-bind="visible: viewModel.ticklers.TREES() && !branchLengthsFoundInTree( $data )">
+            <div style="margin-top: 6px;" data-bind="visible: viewModel.ticklers.TREES() && !anyBranchLengthsFoundInTree( $data )">
                 <label>Branch length mode: </label>
                 <strong data-bind="css: viewModel.ticklers.TREES(), text: getBranchLengthModeDescriptionForTree($data)"></strong>
             </div>
@@ -3165,7 +3165,7 @@ body {
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
           <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle">
               <input type="checkbox" id="branch-length-toggle"
-                     data-bind="enable: branchLengthsFoundInTree($data)"
+                     data-bind="enable: allBranchLengthsFoundInTree($data)"
                      onclick="toggleBranchLengthsInViewer(this); return true;" />
               Cladogram (hide branch lengths)
           </label>


### PR DESCRIPTION
As discussed in #1024, I've been playing too fast and loose with branch-length detection. We need to more carefully distinguish when a tree has all/some/no edges with lengths assigned, since each case has different consequences for UI and behavior in the single-tree popup.

 * If **all edges** have lengths:
    * prompt for related properties
    * enable the tree-view toggle to hide/show branch lengths

 * If **some (but not all) edges** have lengths:
    * prompt for related properties 
    * disable the tree-view toggle

 * If **no edges** in the tree have lengths:
    * don't prompt for related properties 
    * disable the tree-view toggle

Since the different cases and their effects aren't immediately obvious, I've added stronger hints to the branch-length toggle when it's disabled, for example:

<img width="387" alt="toggle-hints" src="https://user-images.githubusercontent.com/446375/26913054-77dc2eee-4be6-11e7-8f9e-8809493c6d5c.png">

These changes are live on **devtree**. You can see the effects of each case using [the specially prepared trees in this study](https://devtree.opentreeoflife.org/curator/study/edit/tt_103?tab=trees).