### PR TITLE
Purge unused OTUs

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10720,6 +10720,6 @@ function purgeUnusedOTUs() {
     console.log("AFTER - ALL OTUs: "+ viewModel.elementTypes.otu.gatherAll(viewModel.nexml).length);
 
     // force update of curation UI in all relevant areas
-    nudgeTickler('VISIBLE_OTU_MAPPINGS');
+    nudgeTickler('OTU_MAPPING_HINTS');
     nudgeTickler('STUDY_HAS_CHANGED');
 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1174,7 +1174,7 @@ function loadSelectedStudy() {
                     var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
                     // start with all OTUs in the study, then whittle them down
                     chosenOTUIDs = viewModel.elementTypes.otu.gatherAll(viewModel.nexml);
-                    $.each( chosenTrees, function(i, tree) {
+                    $.each( allTrees, function(i, tree) {
                         // check this tree's nodes for this OTU id
                         $.each( tree.node, function( i, node ) {
                             if (node['@otu']) {
@@ -2257,7 +2257,7 @@ function updateMappingStatus() {
                             +'<span class="btn-group" style="margin: -2px 0;">'
                             +' <button class="btn btn-mini disabled"><i class="icon-remove"></i></button>'
                             +'</span> '
-                            +'button or change the filter to <strong>In all trees</strong>.<'+'/p>';
+                            +'button or change the filter to <strong>In any tree</strong>.<'+'/p>';
                     showBatchApprove = false;
                     showBatchReject = false;
                     needsAttention = true;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10675,3 +10675,7 @@ function printCurrentTreeView() {
     // restore the normal doc title
     window.document.title = oldTitle;
 }
+
+function purgeUnusedOTUs() {
+    console.warn("Now I'd do the purge!");
+}

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10704,7 +10704,6 @@ function purgeUnusedOTUs() {
     $.each( getUnusedOTUs(), function(i, otu) {
         console.log("REMOVING AN UNUSED OTU!");
         console.log(otu);
-        var otu = getOTUByID( otu );
         $.each(viewModel.nexml.otus, function(i, otusCollection) {
             if ($.inArray(otu, otusCollection.otu) !== -1) {
                 removeFromArray( otu, otusCollection.otu );

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1205,7 +1205,7 @@ body {
                     OTUs in this study.
                 </div>
                 <div class="unused-otus-prompt" style="margin-top: -6px; margin-bottom: 8px; display: none;"
-                     data-bind="visible: (viewOrEdit == 'EDIT') && (viewModel.listFilters.OTUS.scope() === 'Unused (not in any tree)') && viewModel.filteredOTUs().pagedItems().length > 0">
+                     data-bind="visible: (viewOrEdit == 'EDIT') && (viewModel.filteredOTUs().pagedItems().length > 0) && (viewModel.listFilters.OTUS.scope() === 'Unused (not in any tree)')">
                     <button class="btn pull-right btn-warning" title="Purge all OTUs listed below"
                             style="margin: 4px 0 0 18px;"
                             data-bind="click: purgeUnusedOTUs, css: viewModel.ticklers.OTU_MAPPING_HINTS">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1204,7 +1204,7 @@ body {
                     No matching OTUs found! Use the filters above to see
                     OTUs in this study.
                 </div>
-                <div class="unused-otus-prompt" style="margin-top: -6px; margin-bottom: 8px; display: none;"
+                <div class="unused-otus-prompt" style="margin-top: -6px; margin-bottom: 16px; display: none;"
                      data-bind="visible: (viewOrEdit == 'EDIT') && (viewModel.filteredOTUs().pagedItems().length > 0) && (viewModel.listFilters.OTUS.scope() === 'Unused (not in any tree)')">
                     <button class="btn pull-right btn-warning" title="Purge all OTUs listed below"
                             style="margin: 4px 0 0 18px;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1204,7 +1204,7 @@ body {
                     No matching OTUs found! Use the filters above to see
                     OTUs in this study.
                 </div>
-                <div class="unused-otus-prompt" style="margin-top: -6px; margin-bottom: 8px;"
+                <div class="unused-otus-prompt" style="margin-top: -6px; margin-bottom: 8px; display: none;"
                      data-bind="visible: (viewOrEdit == 'EDIT') && (viewModel.listFilters.OTUS.scope() === 'Unused (not in any tree)') && viewModel.filteredOTUs().pagedItems().length > 0">
                     <button class="btn pull-right btn-warning" title="Purge all OTUs listed below"
                             style="margin: 4px 0 0 18px;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1204,6 +1204,16 @@ body {
                     No matching OTUs found! Use the filters above to see
                     OTUs in this study.
                 </div>
+                <div class="unused-otus-prompt" data-bind="visible: (scope === 'Unused (not in any tree)') && viewModel.filteredOTUs().pagedItems().length > 0">
+                    The OTUs below are not currently used in any tree. If
+                    you've mapped some of these names, and you expect to
+                    (re)import trees that include them, you should keep these;
+                    otherwise you can purge them to clean up the study data.
+                    <button class="btn btn-mini pull-right" title="Purge all unused OTUs"
+                             data-bind="click: purgeUnusedOTUs, css: viewModel.ticklers.OTU_MAPPING_HINTS">
+                        <i class="icon-remove"></i>
+                    </button>
+                </div>
 
                 <table class="table table-condensed table-hover" style="table-layout: fixed;"
                        data-bind="visible: viewModel.filteredOTUs().pagedItems().length !== 0">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1204,15 +1204,17 @@ body {
                     No matching OTUs found! Use the filters above to see
                     OTUs in this study.
                 </div>
-                <div class="unused-otus-prompt" data-bind="visible: (scope === 'Unused (not in any tree)') && viewModel.filteredOTUs().pagedItems().length > 0">
+                <div class="unused-otus-prompt" style="margin-top: -6px; margin-bottom: 8px;"
+                     data-bind="visible: (viewOrEdit == 'EDIT') && (viewModel.listFilters.OTUS.scope() === 'Unused (not in any tree)') && viewModel.filteredOTUs().pagedItems().length > 0">
+                    <button class="btn pull-right btn-warning" title="Purge all OTUs listed below"
+                            style="margin: 4px 0 0 18px;"
+                            data-bind="click: purgeUnusedOTUs, css: viewModel.ticklers.OTU_MAPPING_HINTS">
+                        Purge unused OTUs &nbsp; <i class="icon-white icon-remove"></i>
+                    </button>
                     The OTUs below are not currently used in any tree. If
                     you've mapped some of these names, and you expect to
                     (re)import trees that include them, you should keep these;
                     otherwise you can purge them to clean up the study data.
-                    <button class="btn btn-mini pull-right" title="Purge all unused OTUs"
-                             data-bind="click: purgeUnusedOTUs, css: viewModel.ticklers.OTU_MAPPING_HINTS">
-                        <i class="icon-remove"></i>
-                    </button>
                 </div>
 
                 <table class="table table-condensed table-hover" style="table-layout: fixed;"

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1177,7 +1177,7 @@ body {
                             <span data-bind="text: viewModel.listFilters.OTUS.scope">SCOPE</span>
                             <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" data-bind="foreach: ['In all trees', 'In trees nominated for synthesis', 'In trees not yet nominated']">
+                        <ul class="dropdown-menu" data-bind="foreach: ['In any tree', 'In trees nominated for synthesis', 'In trees not yet nominated', 'Unused (not in any tree)']">
                             <li data-bind="css: {'disabled': viewModel.listFilters.OTUS.scope() == $data }">
                                 <a href="#" data-bind="text: $data, click: function () { viewModel.listFilters.OTUS.scope($data); }">SCOPE</a>
                             </li>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1987,7 +1987,7 @@ body {
         'OTUS': {
             // TODO: add 'pagesize'?
             'match': "",
-            'scope': "In all trees",
+            'scope': "In any tree",
             'order': "Unmapped OTUs first"
         },
         'ANNOTATIONS': {


### PR DESCRIPTION
Change the most inclusive OTU filter from **In all trees** to **In any tree** for clarity. If unused OTUs are found, allow the user to purge them from the study (but explain the consequences first!). Addresses #909. 

![purge-unused-otus-ui](https://user-images.githubusercontent.com/446375/31510116-c1c5c316-af51-11e7-8366-d7e3d63ec6d9.png)
