### PR TITLE
Fix broken curator profile page (failed to load)

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -219,7 +219,8 @@ def _get_opentree_activity( userid=None, username=None ):
     # as usual, this needs to be a POST (pass empty fetch_args)
     source_data = requests.post(
         url=fetch_url,
-        data={'include_source_list':True}
+        headers={"Content-Type": "application/json"},
+        data=json.dumps({'include_source_list':True})
     ).json()
     source_id_map = source_data.get('source_id_map')
     # N.B. We can ignore the munged ids in source_data['source_list']
@@ -239,7 +240,8 @@ def _get_opentree_activity( userid=None, username=None ):
         fetch_url = "https:%s" % fetch_url
     all_studies = requests.post(
         url=fetch_url,
-        data={'verbose': True}  # include curator list
+        headers={"Content-Type": "application/json"},
+        data=json.dumps({'verbose':True})  # include curator list
     ).json().get('matched_studies', [ ])
 
     for study in all_studies:

--- a/curator/controllers/study.py
+++ b/curator/controllers/study.py
@@ -100,7 +100,11 @@ def _get_latest_synthesis_details_for_study_id( study_id ):
             # Prepend scheme to a scheme-relative URL
             fetch_url = "https:%s" % fetch_url
         # as usual, this needs to be a POST (pass empty fetch_args)
-        source_list_response = requests.post(fetch_url, headers={"Content-Type": "application/json"},data=simplejson.dumps({'include_source_list':True})).text
+        source_list_response = requests.post(
+            fetch_url,
+            headers={"Content-Type": "application/json"},
+            data=simplejson.dumps({'include_source_list':True})
+        ).text
         source_dict = simplejson.loads( source_list_response )['source_id_map']
 
         # fetch the full source list, then look for this study and its trees

--- a/curator/views/default/profile.html
+++ b/curator/views/default/profile.html
@@ -222,34 +222,21 @@ elif active_user_found:
             </p>
             {{ pass }}
         </div>
-    </div>
-
 {{# TODO: Restore these stats once OTI has been fixed, see https://github.com/OpenTreeOfLife/oti/issues/35 }}
 {{ if False: }}
-    <div class="control-group">
-        <label class="control-label">Studies added</label>
         <div class="controls">
             <p class="static-form-value">
-                {{= len( opentree_activity.get('added_studies', []) ) }}
-                &nbsp;
-                &nbsp;
-                <span class="interesting-value" style="font-weight: normal;">
-                    N.B. Study counts here are dubious, pending
-                    <a href="https://github.com/OpenTreeOfLife/oti/issues/35" target="_blank">
-                        needed fixes to oti</a>
-                </span>
-            </p>
-            <!--  TODO: add markers for top 5%, etc. -->
-        </div>
-    </div>
-    <div class="control-group">
-        <label class="control-label">Studies curated</label>
-        <div class="controls">
-            <p class="static-form-value">
-                {{= len( opentree_activity.get('curated_studies', []) ) }}
-                &nbsp;
-                &nbsp;
-                {{ if len( opentree_activity.get('curated_studies', []) ) > 0: }}
+                {{ how_many_added = len( opentree_activity.get('added_studies', []) )
+                   how_many_curated = len( opentree_activity.get('curated_studies', []) )
+                }}
+                {{= how_many_added }}
+                <span style="font-weight: normal;">added</span>,
+                {{= how_many_curated }}
+                <span style="font-weight: normal;">curated</span>,
+                {{= len( opentree_activity.get('curated_studies_in_synthesis', []) ) }}
+                <span style="font-weight: normal;">in synthesis</span>
+                {{ if (how_many_added + how_many_curated) > 0: }}
+                <br/>
                 <a target="_blank" style="font-weight: normal;"
                    href="/curator/?match={{= user_info.get('name', user_info.get('login')) }}">
                    See these studies in the curation dashboard
@@ -258,17 +245,8 @@ elif active_user_found:
             </p>
             <!--  TODO: add markers for top 5%, etc. -->
         </div>
-    </div>
-    <div class="control-group">
-        <label class="control-label">Studies in synthesis</label>
-        <div class="controls">
-            <p class="static-form-value">
-                {{= len( opentree_activity.get('curated_studies_in_synthesis', []) ) }}
-            </p>
-            <!--  TODO: add markers for top 5%, etc. -->
-        </div>
-    </div>
 {{ pass }}
+    </div>
 
     <div class="control-group">
         <label class="control-label">Tree collections</label>


### PR DESCRIPTION
Fixes #1145. This also has a nice compact display of studies added/curated/in-synthesis, but I'm commenting out the new markup until we're using otindex (since oti still reports just one curator name per study).