### PR TITLE
Remove last few vestiges of simplejson in webapps

### DIFF
--- a/curator/controllers/study.py
+++ b/curator/controllers/study.py
@@ -89,7 +89,7 @@ def _get_latest_synthesis_details_for_study_id( study_id ):
     # treemachine. If the study is not found in contributing studies, return
     # None for both.
     try:
-        import simplejson
+        import json
         import requests
 
         method_dict = get_opentree_services_method_urls(request)
@@ -100,8 +100,8 @@ def _get_latest_synthesis_details_for_study_id( study_id ):
             # Prepend scheme to a scheme-relative URL
             fetch_url = "https:%s" % fetch_url
         # as usual, this needs to be a POST (pass empty fetch_args)
-        source_list_response = requests.post(fetch_url, headers={"Content-Type": "application/json"},data=simplejson.dumps({'include_source_list':True})).text
-        source_dict = simplejson.loads( source_list_response )['source_id_map']
+        source_list_response = requests.post(fetch_url, headers={"Content-Type": "application/json"},data=json.dumps({'include_source_list':True})).text
+        source_dict = json.loads( source_list_response )['source_id_map']
 
         # fetch the full source list, then look for this study and its trees
         commit_SHA_in_synthesis = None

--- a/curator/controllers/supporting_files.py
+++ b/curator/controllers/supporting_files.py
@@ -9,7 +9,7 @@ def upload_file():
     Return the response in JSON required by the plugin
     """
     import os
-    import gluon
+    import json
     response.view = 'generic.json'
     try:
         # Get the file from the form
@@ -33,7 +33,7 @@ def upload_file():
          
         res = dict(files=[{"name": str(f.filename), "size": size, "url": URL(f='download', args=[File['doc']]), "delete_url": URL(f='delete_file', args=[File['doc']])}])
          
-        return gluon.contrib.simplejson.dumps(res, separators=(',',':'))
+        return json.dumps(res, separators=(',',':'))
 
     except:
         return dict(message=T('Upload error'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 nose==1.2.1
 ipython==0.13.1
 wsgiref==0.1.2
-simplejson==3.2.0
 stevedore==0.8
 pyparsing==1.5.7
 requests==1.2.0


### PR DESCRIPTION
We stick to the built-in `json` module now, which has the same API. All changes tested on local dev server. Addresses comment in #1146.