### PR TITLE
Add OT Taxonomy citation to About page

### DIFF
--- a/webapp/views/about/open_tree_of_life.html
+++ b/webapp/views/about/open_tree_of_life.html
@@ -17,7 +17,11 @@
               <p><strong>Contact us</strong> using one of the methods on the <a href="{{=URL('contact','index') }}">Contact page</a>.
               </p>
               <p><strong>Cite the Open Tree of Life</strong>: Hinchliff, Cody E., et al. "Synthesis of phylogeny and taxonomy into a comprehensive tree of life." Proceedings of the National Academy of Sciences 112.41 (2015): 12764-12769.
-+                    <a target="_blank" href="https://doi.org/10.1073/pnas.1423041112">https://doi.org/10.1073/pnas.1423041112</a> </p>
+                   <a target="_blank" href="https://doi.org/10.1073/pnas.1423041112">https://doi.org/10.1073/pnas.1423041112</a> </p>
+              <p><strong>Cite the Open Tree Taxonomy</strong>:
+                    Rees J, Cranston K (2017) "Automated assembly of a reference taxonomy for phylogenetic data synthesis."
+                    Biodiversity Data Journal 5: e12581.
+                   <a target="_blank" href="https://doi.org/10.3897/BDJ.5.e12581">https://doi.org/10.3897/BDJ.5.e12581</a> </p>
           </div>
       </div>
       <div class="row">


### PR DESCRIPTION
This follows the convention set by the main Open Tree of Life citation.
Addresses #1137.

This is [available for review on **devtree**](https://devtree.opentreeoflife.org/about/open-tree-of-life).

NOTE that I've added quotation marks around the title, following the example of the main OToL paper citation on this page. Is this OK?

Also, note that I've removed the `+` from the main OToL citation above, since this looks to me like a typo. Is that correct?