### PR TITLE
Suppress bogus error message on main root node

### DIFF
--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -782,7 +782,8 @@ function showObjectProperties( objInfo, options ) {
         if (fullNodeSupporters) {
             if (edgeSection) {
                 edgeSection.displayedProperties['Supporting trees'] = fullNodeSupporters;
-            } else {
+            } else if (parentNode) {
+                // ignore OTT support on 'cellular organisms' (main root of synth tree)
                 console.log('>>> No edgeSection found for this node:');
                 console.log(fullNode);
             }


### PR DESCRIPTION
This appears because we now include OTT support for the main root node,
but we have no easy place to show it since there's no "edge to parent".
Check for this and suppress the error message in JS console.