### PR TITLE
Argus view fixes

### DIFF
--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1207,6 +1207,7 @@ function createArgus(spec) {
             }
             label = paper.text(labelX, labelY, displayLabel).attr({
                 'text-anchor': labelAnchor,
+                "title": displayLabel,
                 "fill": this.labelColor,
                 "font-size": fontSize
             }).insertBefore(dividerBeforeHighlights);
@@ -1366,6 +1367,7 @@ function createArgus(spec) {
 
                             label = paper.text(labelX, labelY, ancestorNode.name || "").attr({
                                 'text-anchor': 'end',
+                                "title": (ancestorNode.name || ""),
                                 "fill": this.labelColor,
                                 "font-size": fontSize
                             }).insertBefore(dividerBeforeHighlights);
@@ -1456,6 +1458,7 @@ function createArgus(spec) {
             var clusterLabel = "more... ("+ cluster.firstName +" - "+ cluster.lastName +")";
             label = paper.text(clusterLeftEdge + 8, cluster.y - (this.nodeHeight * 0.0), clusterLabel).attr({
                 'text-anchor': 'start',
+                "title": clusterLabel,
                 "fill": this.labelColor,
                 "font-size": fontSize,
                 "cursor": "pointer"

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -522,6 +522,7 @@ function createArgus(spec) {
 
             pwidth = argusObjRef.nodesWidth * (node.max_node_depth + 1);
             pwidth += 1.5 * argusObjRef.tipOffset + argusObjRef.xLabelMargin;
+            // NOTE that this might still clip super-wide labels, e.g. for a cluster
 
             argusObjRef.xOffset = pwidth - argusObjRef.nodesWidth - argusObjRef.tipOffset;
 


### PR DESCRIPTION
These fixes address #1138, and a related bug I found when clusters have a very wide label (text was being "cropped" on mouseover).