### PR TITLE
Allow more recent stevedore.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 nose==1.2.1
 ipython==0.13.1
 wsgiref==0.1.2
-stevedore==0.8
+stevedore>=0.8
 pyparsing==1.5.7
 requests==1.2.0
 virtualenv==1.9.1


### PR DESCRIPTION
Not sure how to test if this change works. I see no
obvious problems with it. I don't even see where we
use this package within our webapps, so we can probably
get rid of it.

The version 0.8 that we were previously pinned to does
not install cleanly on any modern Python version that I've seen.