### PR TITLE
Sync requirements.txt with current peyotl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==1.2.0
+requests==2.2.1
 python-dateutil==2.2
 locket==0.1.1


### PR DESCRIPTION
One more minor change here, to match the reported requirements for peyotl. (This was caught and reported by `pip install -r requirements.txt`.) Combination tested on my local dev setup.