### PR TITLE
usage of new NCL option

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -632,6 +632,8 @@ def to_nexson():
                         if v > 0:
                             f = fa_flag[k]
                             invoc.append('-p{f}{v:d}'.format(f=f, v=v))
+                # Use new NCL option to emit only trees and taxa (not character data)
+                invoc.append('-etreenexml')
                 invoc.append('in.nex')
                 do_ext_proc_launch(request,
                                    working_dir,


### PR DESCRIPTION
this should limit memory usage for conversion of NEXUS files with huge character matrices. We discard the character data in the NeXML -> NEXSON stage, but are currently including it in the NEXUS->NeXML stage. This commit fixes that. I'm going to merge, deploy and test now....