### PR TITLE
Improved HTML bleaching

### DIFF
--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -4,6 +4,24 @@ from datetime import datetime
 from opentreewebapputil import (get_opentree_services_method_urls, 
                                 fetch_current_TNRS_context_names,
                                 get_data_deposit_message,)
+import bleach
+from bleach.sanitizer import Cleaner
+
+# Define a consistent cleaner to sanitize user input. We need a few
+# elements that are common in our markdown but missing from the Bleach
+# whitelist.
+# N.B. HTML comments are stripped by default. Non-allowed tags will appear
+# "naked" in output, so we can identify any bad actors.
+common_version_notes_tags = [u'p', u'br',
+                             u'h1', u'h2', u'h3', u'h4', u'h5', u'h6',
+                             u'table', u'tbody', u'tr', u'td', u'th',
+                             ]
+ot_markdown_tags = list(set( bleach.sanitizer.ALLOWED_TAGS + common_version_notes_tags))
+common_version_notes_attributes={u'table': [u'class'],
+                                 }
+ot_markdown_attributes = bleach.sanitizer.ALLOWED_ATTRIBUTES.copy()
+ot_markdown_attributes.update(common_version_notes_attributes)
+ot_cleaner = Cleaner(tags=ot_markdown_tags, attributes=ot_markdown_attributes)
 
 ### required - do no delete
 def user(): return dict(form=auth())
@@ -290,7 +308,8 @@ def synthesis_release():
         version_notes_response = requests.get(url=fetch_url).text
         # N.B. We assume here that any hyperlinks have the usual Markdown braces!
         version_notes_html = markdown(version_notes_response).encode('utf-8')
-        # TODO: scrub HTML output with bleach?
+        # scrub HTML output with bleach
+        version_notes_html = ot_cleaner.clean(version_notes_html)
     except:
         version_notes_html = None
     view_dict['synthesis_release_notes'] = version_notes_html
@@ -329,7 +348,8 @@ def taxonomy_version():
         version_notes_response = requests.get(url=fetch_url).text
         # N.B. We assume here that any hyperlinks have the usual Markdown braces!
         version_notes_html = markdown(version_notes_response).encode('utf-8')
-        # TODO: scrub HTML output with bleach?
+        # scrub HTML output with bleach
+        version_notes_html = ot_cleaner.clean(version_notes_html)
     except:
         version_notes_html = None
     view_dict['taxonomy_version_notes'] = version_notes_html

--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -290,6 +290,7 @@ def synthesis_release():
         version_notes_response = requests.get(url=fetch_url).text
         # N.B. We assume here that any hyperlinks have the usual Markdown braces!
         version_notes_html = markdown(version_notes_response).encode('utf-8')
+        # TODO: scrub HTML output with bleach?
     except:
         version_notes_html = None
     view_dict['synthesis_release_notes'] = version_notes_html
@@ -328,6 +329,7 @@ def taxonomy_version():
         version_notes_response = requests.get(url=fetch_url).text
         # N.B. We assume here that any hyperlinks have the usual Markdown braces!
         version_notes_html = markdown(version_notes_response).encode('utf-8')
+        # TODO: scrub HTML output with bleach?
     except:
         version_notes_html = None
     view_dict['taxonomy_version_notes'] = version_notes_html

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -5,6 +5,7 @@ from gluon.contrib.markdown.markdown2 import markdown
 import requests
 import os.path
 import urllib
+import bleach
 from bleach.sanitizer import Cleaner
 from datetime import datetime
 import json

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -433,7 +433,9 @@ def index():
         # whitelist.
         # N.B. HTML comments are stripped by default. Non-allowed tags will appear
         # "naked" in output, so we can identify any bad actors.
-        common_feedback_tags = [u'p', u'br']  # any others? h1, h2, etc?
+        common_feedback_tags = [u'p', u'br',
+                                u'h1', u'h2', u'h3', u'h4', u'h5', u'h6',
+                                ]
         ot_markdown_tags = list(set( bleach.sanitizer.ALLOWED_TAGS + common_feedback_tags))
         ot_cleaner = Cleaner(tags=ot_markdown_tags)
 
@@ -441,11 +443,19 @@ def index():
             # N.B. some missing information (e.g. supporting URL) will appear here as a string like "None"
             supporting_reference_url = metadata.get('Supporting reference', None)
             has_supporting_reference_url = supporting_reference_url and (supporting_reference_url != u'None')
+            # Prepare a sanitized rendering of this user-submitted markup
+            rendered_comment_markdown = markdown(
+                get_visible_comment_body(comment['body'] or ''),
+                extras={'link-patterns':None},
+                link_patterns=[(link_regex, link_replace)]).encode('utf-8')
+            safe_comment_markup = XML(
+                ot_cleaner.clean(rendered_comment_markdown),
+                sanitize=False)
             markup = LI(
                     DIV(##T('posted by %(first_name)s %(last_name)s',comment.created_by),
                     # not sure why this doesn't work... db.auth record is not a mapping!?
                     ('title' in comment) and DIV( comment['title'], A(T('on GitHub'), _href=comment['html_url'], _target='_blank'), _class='topic-title') or '',
-                    DIV( ot_cleaner.clean(str(XML(markdown(get_visible_comment_body(comment['body'] or ''), extras={'link-patterns':None}, link_patterns=[(link_regex, link_replace)]).encode('utf-8'), sanitize=False))),_class=(issue_node and 'body issue-body' or 'body comment-body')),
+                    DIV( safe_comment_markup, _class=(issue_node and 'body issue-body' or 'body comment-body')),
                     DIV( A(T('Supporting reference (opens in a new window)'), _href=supporting_reference_url, _target='_blank'), _class='body issue-supporting-reference' ) if has_supporting_reference_url else '',
                     DIV(
                         A(T(author_display_name), _href=author_link, _target='_blank'),

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -450,7 +450,7 @@ def index():
                 link_patterns=[(link_regex, link_replace)]).encode('utf-8')
             safe_comment_markup = XML(
                 ot_cleaner.clean(rendered_comment_markdown),
-                sanitize=False)
+                sanitize=True)
             markup = LI(
                     DIV(##T('posted by %(first_name)s %(last_name)s',comment.created_by),
                     # not sure why this doesn't work... db.auth record is not a mapping!?

--- a/webapp/views/about/synthesis_release.html
+++ b/webapp/views/about/synthesis_release.html
@@ -109,7 +109,7 @@ circle.taxo-release-marker {
             {{ if synthesis_release_notes: }}
               <div id="taxonomy-version-notes"
                    style="background-color: #f5f5f5; padding: 1em; border-radius: 6px;">
-                  {{= XML(synthesis_release_notes) }}
+                  {{= XML(synthesis_release_notes, sanitize=True) }}
               </div>
             {{ else: }}
               <div class="alert alert-error">

--- a/webapp/views/about/taxonomy_version.html
+++ b/webapp/views/about/taxonomy_version.html
@@ -56,7 +56,7 @@
             {{ if taxonomy_version_notes: }}
               <div id="taxonomy-version-notes"
                    style="background-color: #f5f5f5; padding: 1em; border-radius: 6px;">
-                  {{= XML(taxonomy_version_notes) }}
+                  {{= XML(taxonomy_version_notes, sanitize=True) }}
               </div>
             {{ else: }}
               <div class="alert alert-error">


### PR DESCRIPTION
Use custom tag and attribute whitelists to allow selected markup in feedback/comments and in version notes for synthesis and taxonomy. We also re-enable the `sanitize=True` option for web2py's `XML` helper, for extra protection; this is overkill, but it doesn't cause any visible harm.