### PR TITLE
Fix link to OTT info

### DIFF
--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -165,7 +165,7 @@ def display_taxon_info(info, limit, output, api_base):
 
         start_el(output, 'p', 'legend')
         version = get_taxonomy_version(api_base)
-        output.write('The current taxonomy version is <a target="_blank" href="https://devtree.opentreeoflife.org/about/taxonomy-version/%s">%s (click for more information)</a>. ' % (version, version,))
+        output.write('The current taxonomy version is <a target="_blank" href="https://tree.opentreeoflife.org/about/taxonomy-version/%s">%s (click for more information)</a>. ' % (version, version,))
         output.write('See the OTT wiki for <a href="https://github.com/OpenTreeOfLife/reference-taxonomy/wiki/Taxon-flags">an explanation of the taxon flags used</a> below, e.g., <span class="flag">extinct</span>\n')
         end_el(output, 'p')
 


### PR DESCRIPTION
This was a static link pointing to the OTT version page on **devtree** (now points to production **tree**)