### PR TITLE
Support URL option to show synth-tree legend automatically.

### DIFF
--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -33,6 +33,7 @@ def index():
     treeview_dict['viewport'] = ''
     treeview_dict['nudgingToLatestSyntheticTree'] = False
     treeview_dict['incomingDomSource'] = 'none'
+    treeview_dict['showLegendOnLoad'] = request.vars.get('show-legend') or False
 
     # add a flag to determine whether to force the viewer to this node (vs. using the
     # browser's stored state for this URL, or a default starting node)

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -84,6 +84,10 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         // N.B. This JS variable is currently unused! See static alert '#nudged-to-latest-synthetic-tree' below.
         var nudgingToLatestSyntheticTree = {{=nudgingToLatestSyntheticTree and 'true' or 'false'}};
       {{ pass }}
+      {{ if 'showLegendOnLoad' in locals(): }}
+        // support the option to show the synth-tree view's legend when the page is fully loaded
+        var showLegendOnLoad = {{=showLegendOnLoad and 'true' or 'false'}};
+      {{ pass }}
     </script>
     {{pass}}
 
@@ -349,6 +353,9 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                 searchForMatchingTaxa();
                 return false;
             });
+            if (showLegendOnLoad) {
+                toggleTreeViewLegend();
+            }
         });
 
     </script>


### PR DESCRIPTION
If someone adds `?show-legend=true` to any synth-tree viewer URL, the legend popup will appear automatically when the page loads. Addresses #1186.

![Screen Shot 2019-04-12 at 1 36 19 PM](https://user-images.githubusercontent.com/446375/56055650-00806400-5d28-11e9-8e9a-5ce56920b92b.png)

Note that synth-tree URLs typically go through a redirect to match the latest synthesis, so this addition to the query-string will be recognized, but won't be in the final URL displayed in the browser.