### PR TITLE
Improved banner for development sites.

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -773,9 +773,17 @@ body.printing-tree-view #tree-title * {
     color: #888;
 }
 /* Warning banners appear when using DEVELOPMENT, STAGING servers */
+.ribbon-banner, .ribbon-banner-details {
+    position: absolute;
+    -webkit-transform: rotate(-45deg);
+    -moz-transform:    rotate(-45deg);
+    -ms-transform:     rotate(-45deg);
+    transform:         rotate(-45deg);
+    z-index: 500;
+    cursor: pointer;
+}
 .ribbon-banner {
     display: block;
-    position: absolute;
     top: 40px;
     left: -90px;
     width: 300px;
@@ -783,18 +791,27 @@ body.printing-tree-view #tree-title * {
     line-height: 30px;
     text-align: center;
     opacity: 0.7;
-    -webkit-transform: rotate(-45deg);
-    -moz-transform:    rotate(-45deg);
-    -ms-transform:     rotate(-45deg);
-    transform:         rotate(-45deg);
     font-size: 18px;
     font-weight: 900;
     color: #fff;
     background-color: #c00;
     border: 1px solid white;
-    z-index: 500;
-    cursor: pointer;
 }
+.ribbon-banner-details {
+    display: none;
+    top: 58px;
+    left: -100px;
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.25em;
+    color: #600;
+    background-color: white;
+    width: 400px;
+    padding: 2px 0 4px;
+    border-bottom: 1px solid #ddd;
+    margin: 0px auto;
+}
+
 .needs-attention {
     background-color: #fdd;
     padding: 4px;

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -243,6 +243,16 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
             },
             50  // runs 20 times/sec until it finds its backdrop or dies
         );
+
+        // toggle behavior for dev-site banner
+        $('.ribbon-banner, .ribbon-banner-details').hover(
+            function() {
+                $('.ribbon-banner-details').show();
+            },
+            function() {
+                $('.ribbon-banner-details').hide();
+            }
+        );
     });
     $('body').on('hidden', '.modal', function (evt) {
         if (evt.target !== this) {
@@ -322,7 +332,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
   <!--[if (gt IE 9)|!(IE)]><!--> <body> <!--<![endif]-->
 
 {{ if get_domain_banner_text(request): }}
-  <div class="ribbon-banner" title="{{= get_domain_banner_hovertext(request) }}">{{= get_domain_banner_text(request) }}</div>
+  <div class="ribbon-banner">{{= get_domain_banner_text(request) }}</div>
+  <p class="ribbon-banner-details">{{= XML(get_domain_banner_hovertext(request)) }}</p>
 {{ pass }}
   <div class="navbar navbar-inverse navbar-static-top">
     <div class="navbar-inner">

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -164,20 +164,24 @@ def get_user_login():
 def get_domain_banner_text(request):
     # Add an optional CSS banner to indicate a test domain, or none if
     # we're on a production server.
-    if request.env.http_host == 'devtree.opentreeoflife.org':
-        return 'DEVELOPMENT'
-    elif request.env.http_host == 'stagingtree.opentreeoflife.org':
-        return 'STAGING'
-    return ''
+    if request.env.http_host == 'tree.opentreeoflife.org':
+        return ''
+    # all other domains (including 'devtree.opentreeoflife.org') should present as dev servers
+    return 'DEVELOPMENT'
 
 def get_domain_banner_hovertext(request):
-    # Return optional hover-text for test domains, or none if
+    # Return optional hover-text for dev+test domains, or none if
     # we're on a production server.
-    if request.env.http_host == 'devtree.opentreeoflife.org':
-        return 'This is the development site for Open Tree of Life. Data and services may not be up to date, or may be untested. Production version at tree.opentreeoflife.org'
-    elif request.env.http_host == 'stagingtree.opentreeoflife.org':
-        return 'This is the staging site for Open Tree of Life. Data and services may not be up to date, or may be untested. Production version at tree.opentreeoflife.org'
-    return ''
+    if request.env.http_host == 'tree.opentreeoflife.org':
+        return ""
+    # all other domains (including 'devtree.opentreeoflife.org') should present as dev servers
+    # N.B. Line lengths gradually change, since this text fits diagonally in the page corner.
+    # Be sure to test any changes!
+    return '<br/>'.join(["This is a development version",
+                         "of the Open Tree of Life website!",
+                         "Data and services may be out of date or",
+                         "untested. The production site (the place to",
+                         "do real work) is <a href='https://tree.opentreeoflife.org/'>tree.opentreeoflife.org</a>."])
 
 
 treebase_deposit_doi = re.compile('//purl.org/phylo/treebase/phylows/study/TB2:S(?P<treebase_id>\d+)')

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -442,9 +442,17 @@ div#r0 {
     color: white;
 }
 /* Warning banners appear when using DEVELOPMENT, STAGING servers */
+.ribbon-banner, .ribbon-banner-details {
+    position: absolute;
+    -webkit-transform: rotate(-45deg);
+    -moz-transform:    rotate(-45deg);
+    -ms-transform:     rotate(-45deg);
+    transform:         rotate(-45deg);
+    z-index: 500;
+    cursor: pointer;
+}
 .ribbon-banner {
     display: block;
-    position: absolute;
     top: 40px;
     left: -90px;
     width: 300px;
@@ -452,17 +460,25 @@ div#r0 {
     line-height: 30px;
     text-align: center;
     opacity: 0.7;
-    -webkit-transform: rotate(-45deg);
-    -moz-transform:    rotate(-45deg);
-    -ms-transform:     rotate(-45deg);
-    transform:         rotate(-45deg);
     font-size: 18px;
     font-weight: 900;
     color: #fff;
     background-color: #c00;
     border: 1px solid white;
-    z-index: 500;
-    cursor: pointer;
+}
+.ribbon-banner-details {
+    display: none;
+    top: 58px;
+    left: -100px;
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.25em;
+    color: #600;
+    background-color: white;
+    width: 400px;
+    padding: 2px 0 4px;
+    border-bottom: 1px solid #ddd;
+    margin: 0px auto;
 }
 
 /* Adjusting "inverse" colors in header search */

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -349,6 +349,16 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
                 searchForMatchingTaxa();
                 return false;
             });
+
+            // toggle behavior for dev-site banner
+            $('.ribbon-banner, .ribbon-banner-details').hover(
+                function() {
+                    $('.ribbon-banner-details').show();
+                },
+                function() {
+                    $('.ribbon-banner-details').hide();
+                }
+            );
         });
 
     </script>
@@ -372,7 +382,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
 
 <body>
 {{ if get_domain_banner_text(request): }}
-  <div class="ribbon-banner" title="{{= get_domain_banner_hovertext(request) }}">{{= get_domain_banner_text(request) }}</div>
+  <div class="ribbon-banner">{{= get_domain_banner_text(request) }}</div>
+  <p class="ribbon-banner-details">{{= XML(get_domain_banner_hovertext(request)) }}</p>
 {{ pass }}
   <div class="navbar navbar-inverse navbar-static-top" role="navigation">
     <div class="navbar-inner">


### PR DESCRIPTION
The "DEVELOPMENT" banner will now appear in **any** domain other than **tree.opentreeoflife.org**, instead of just **devtree**. This should cut down on confusion when users stumble into other dev systems like **ot123.opentreeoflife.org**.

Another enhancement: Instead of simple rollover text, we expand the entire banner on mouseover. This gives more room for explanation, plus a live (clickable) link to the production website:

![Screen Shot 2019-04-16 at 8 00 13 PM](https://user-images.githubusercontent.com/446375/56252351-67ce4900-6085-11e9-8886-5911717b217b.png)

This addresses a recent issue or discussion... that I can't seem to find now. (Link welcome, if anyone spots it!).