### PR TITLE
stringify post payload for find_studies

### DIFF
--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -879,11 +879,11 @@ function showObjectProperties( objInfo, options ) {
                     ///console.warn('>>>>>>>>>>>>>>> sourceDetails NOT FOUND for sourceID '+ sourceID +', FETCHING NOW...');
                     $.post(
                         singlePropertySearchForStudies_url, // JSONP fetch URL
-                        {   // POSTed data
+                        JSON.stringify({   // POSTed data
                             "property": "ot:studyId",
                             "value": (sourceMetadata).study_id,
                             verbose: true
-                        },
+                        }),
                         function(data) {    // JSONP callback
                             // reset this locally, to MAKE SURE we've got the right box
                             ///console.warn('<<<<<<<<<<<<<<< BACK FROM FETCH for sourceID '+ sourceID);


### PR DESCRIPTION
Find_studies post data was getting read as:
    ```property=ot%3AstudyId&value=pg_2542&verbose=true```
instead of 
  ```"property":"ot:studyId","value":"ot_1164","verbose":true, "exact":true}```
resulting in every find studies call from the treeviewer returning every study.

Stringifying data fixes this. 