### PR TITLE
Fix broken study list w/ multiple curators

### DIFF
--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -416,7 +416,16 @@ function getViewOrEditLinks(study) {
     return html;
 }
 function getCuratorLink(study) {
-    return '<a href="#" onclick="filterByCurator(\''+ study['ot:curatorName'] +'\'); return false;"'+'>'+ study['ot:curatorName'] +'</a'+'>';
+    var linkList = [];
+    var nameList = study['ot:curatorName'];
+    if (! $.isArray(nameList)) {
+        // wrap single curator name in the expected list
+        nameList = [nameList];
+    }
+    $.each(nameList , function(i, name) {
+        linkList.push('<a href="#" onclick="filterByCurator(\''+ name +'\'); return false;"'+'>'+ name +'</a'+'>');
+    });
+    return linkList.join(', ');
 }
 function getFocalCladeLink(study) {
     var ottIdNotFound = false;


### PR DESCRIPTION
We now cleanly split multiple curator names, and each becomes a separate
link to filter for that person's studies.