### PR TITLE
Fix missing progress chart (and possibly others)

### DIFF
--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -96,6 +96,9 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
       {{ if 'showLegendOnLoad' in locals(): }}
         // support the option to show the synth-tree view's legend when the page is fully loaded
         var showLegendOnLoad = {{=showLegendOnLoad and 'true' or 'false'}};
+      {{ else: }}
+        // harmless default value (for About and other unrelated pages)
+        var showLegendOnLoad = false;
       {{ pass }}
     </script>
     {{pass}}


### PR DESCRIPTION
Failing to initialize this JS var is causing other client-side code to fail. This set a harmless default value on all pages. 

This fix is [working now on **devtree**](https://devtree.opentreeoflife.org/about/progress).

Thanks to @kcranston for the heads-up!