### PR TITLE
Follow MRCA (in synth-tree viewer) for a broken taxon

### DIFF
--- a/taxonomy/cgi-bin/browse.py
+++ b/taxonomy/cgi-bin/browse.py
@@ -166,7 +166,7 @@ def display_taxon_info(info, limit, output, api_base):
         start_el(output, 'p', 'legend')
         version = get_taxonomy_version(api_base)
         output.write('The current taxonomy version is <a target="_blank" href="https://tree.opentreeoflife.org/about/taxonomy-version/%s">%s (click for more information)</a>. ' % (version, version,))
-        output.write('See the OTT wiki for <a href="https://github.com/OpenTreeOfLife/reference-taxonomy/wiki/Taxon-flags">an explanation of the taxon flags used</a> below, e.g., <span class="flag">extinct</span>\n')
+        output.write('See the OTT documentation for <a href="https://github.com/OpenTreeOfLife/reference-taxonomy/blob/master/doc/taxon-flags.md#taxon-flags">an explanation of the taxon flags used</a> below, e.g., <span class="flag">extinct</span>\n')
         end_el(output, 'p')
 
         output.write('<h3>Taxon details</h3>')

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -723,7 +723,7 @@ function createArgus(spec) {
                     var errMsg;
                     if (textStatus !== 'success') {
                         // major server-side error, just show raw response for tech support
-                        errMsg = 'Sorry, there was an error checking for taxon status.';
+                        errMsg = '<p>Sorry, there was an error checking for taxon status.</p>';
                         showErrorInArgusViewer(errMsg);
                         return;
                     }
@@ -748,7 +748,7 @@ function createArgus(spec) {
                                         +'">View the MRCA of the members of this taxon in the synthetic tree</a></p>';
                             }
                         } else {
-                            errMsg = 'This can happen for a variety of reasons,'
+                            errMsg = '<p>This taxon is in our taxonomy but does not appear in the latest synthetic tree. This can happen for a variety of reasons,'
                                 +' but the most probable is that is has a taxon flag (e.g. <em>incertae sedis</em>) that'
                                 +' causes it to be pruned from the synthetic tree.</p>';
                         }

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -741,7 +741,8 @@ function createArgus(spec) {
                             errMsg += ' It appears to have been "broken" during the latest synthesis.';
                             if (mainFetchJSON.broken.mrca) {
                                 // this is the ottid of its MRCA, a good next step for this user
-                                var mrcaSynthViewURL = getSynthTreeViewerURLForTaxon(
+                                var mrcaSynthViewURL = getSynthTreeViewerURLForNodeID(
+                                    '',  // defaults to latest synthetic tree
                                     mainFetchJSON.broken.mrca
                                 );
                                 errMsg +=' To learn more, you can <a href="'

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -746,7 +746,7 @@ function createArgus(spec) {
                                     mainFetchJSON.broken.mrca
                                 );
                                 errMsg +=' To learn more, you can <a href="'
-                                        + getSynthTreeViewerURL
+                                        + mrcaSynthViewURL
                                         +'">review the MRCA</a> of its members.';
                             }
                         } else {

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -733,36 +733,31 @@ function createArgus(spec) {
                     if (json['ott_id'] === ottID) {
                         var taxoBrowserLink = getTaxobrowserLink('taxonomy browser', ottID)
                         // the requested taxon exists in OTT, but is not found in the target tree
-                        errMsg = '<span style="font-weight: bold; color: #777;">This taxon is in our taxonomy'
-                            +' but not in our tree synthesis database.'
+                        errMsg = '<p>This taxon is in our taxonomy but not in our tree synthesis database.</p>'
 
                         if (mainFetchJSON.broken) {
                             // parse this to learn more...
-                            errMsg += ' It appears to have been "broken" during the latest synthesis.';
+                            errMsg += '<p>It appears to be "broken" (not monophyletic) in the latest synthetic tree.</p>';
                             if (mainFetchJSON.broken.mrca) {
                                 // this is the ottid of its MRCA, a good next step for this user
                                 var mrcaSynthViewURL = getSynthTreeViewerURLForNodeID(
                                     '',  // defaults to latest synthetic tree
                                     mainFetchJSON.broken.mrca
                                 );
-                                errMsg +=' To learn more, you can <a href="'
-                                        + mrcaSynthViewURL
-                                        +'">review the MRCA</a> of its members.';
+                                errMsg +='<p class="action-item"><a href="' + mrcaSynthViewURL
+                                        +'">Review the MRCA of the members of this taxon</a></p>';
                             }
                         } else {
-                            errMsg += 'This can happen for a variety of reasons,'
+                            errMsg += '<p>This can happen for a variety of reasons,'
                                 +' but the most probable is that is has a taxon flag (e.g. <em>incertae sedis</em>) that'
-                                +' causes it to be pruned from the synthetic tree.';
+                                +' causes it to be pruned from the synthetic tree.</p>';
                         }
 
-                        errMsg +=' See the '+ taxoBrowserLink +' for more information about this taxon.'
-                                +'<br/><br/>If you think this is an error, please'
-                                +' <a href="https://github.com/OpenTreeOfLife/feedback/issues" target="_blank">'
-                                +'create an issue in our bug tracker</a>.</span>';
+                        errMsg +='<p>See the '+ taxoBrowserLink +' for more information about this taxon.</p>';
                         showErrorInArgusViewer( errMsg );
                     } else {
                         // this is not a valid taxon id! Show the *original* error response from the failed argus fetch.
-                        errMsg = 'Whoops! The call to get the tree around a node did not work out the way we were hoping it would.';
+                        errMsg = '<p>Whoops! The call to get the tree around a node did not work out the way we were hoping it would.</p>';
                         showErrorInArgusViewer( errMsg, mainFetchXHR.responseText );
                     }
                 }

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -731,13 +731,13 @@ function createArgus(spec) {
                     var json = $.parseJSON(jqXHR.responseText);
                     // if (json['ott_id'] === ottID) { TODO: use this when we switch to v3 taxonomy API!
                     if (json['ott_id'] === ottID) {
-                        var taxoBrowserLink = getTaxobrowserLink('taxonomy browser', ottID)
+                        var taxoBrowserLink = getTaxobrowserLink('View this taxon in the taxonomy browser', ottID)
                         // the requested taxon exists in OTT, but is not found in the target tree
-                        errMsg = '<p>This taxon is in our taxonomy but not in our tree synthesis database.</p>'
+                        //errMsg = '<p>This taxon is in our taxonomy but not in our tree synthesis database.</p>'
 
                         if (mainFetchJSON.broken) {
                             // parse this to learn more...
-                            errMsg += '<p>It appears to be "broken" (not monophyletic) in the latest synthetic tree.</p>';
+                            errMsg = '<p>This taxon is in our taxonomy but it\'s "broken" (not monophyletic) in the latest synthetic tree.</p>';
                             if (mainFetchJSON.broken.mrca) {
                                 // this is the ottid of its MRCA, a good next step for this user
                                 var mrcaSynthViewURL = getSynthTreeViewerURLForNodeID(
@@ -745,15 +745,15 @@ function createArgus(spec) {
                                     mainFetchJSON.broken.mrca
                                 );
                                 errMsg +='<p class="action-item"><a href="' + mrcaSynthViewURL
-                                        +'">Review the MRCA of the members of this taxon</a></p>';
+                                        +'">View the MRCA of the members of this taxon in the synthetic tree</a></p>';
                             }
                         } else {
-                            errMsg += '<p>This can happen for a variety of reasons,'
+                            errMsg = 'This can happen for a variety of reasons,'
                                 +' but the most probable is that is has a taxon flag (e.g. <em>incertae sedis</em>) that'
                                 +' causes it to be pruned from the synthetic tree.</p>';
                         }
 
-                        errMsg +='<p>See the '+ taxoBrowserLink +' for more information about this taxon.</p>';
+                        errMsg +='<p class="action-item">'+ taxoBrowserLink +'</p>';
                         showErrorInArgusViewer( errMsg );
                     } else {
                         // this is not a valid taxon id! Show the *original* error response from the failed argus fetch.

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -751,6 +751,15 @@ function createArgus(spec) {
                             errMsg = '<p>This taxon is in our taxonomy but does not appear in the latest synthetic tree. This can happen for a variety of reasons,'
                                 +' but the most probable is that is has a taxon flag (e.g. <em>incertae sedis</em>) that'
                                 +' causes it to be pruned from the synthetic tree.</p>';
+                            if (json.flags && json.flags.length > 0) {
+                                errMsg += '<p>The following flags were found on this taxon:</p>'
+                                errMsg += '<ul>';
+                                $.each(json.flags, function(i, flag) {
+                                    errMsg += '<li style="font-family: monospace; color: #999;">'+ flag +'</li>';
+                                });
+                                errMsg += '</ul>';
+                                errMsg += '<p>See our <a href="https://github.com/OpenTreeOfLife/reference-taxonomy/wiki/Taxon-flags" target="_blank">taxonomy documentation</a> for details on the meanings of each flag.</p>'
+                            }
                         }
 
                         errMsg +='<p class="action-item">'+ taxoBrowserLink +'</p>';

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -758,7 +758,7 @@ function createArgus(spec) {
                                     errMsg += '<li style="font-family: monospace; color: #999;">'+ flag +'</li>';
                                 });
                                 errMsg += '</ul>';
-                                errMsg += '<p>See our <a href="https://github.com/OpenTreeOfLife/reference-taxonomy/wiki/Taxon-flags" target="_blank">taxonomy documentation</a> for details on the meanings of each flag.</p>'
+                                errMsg += '<p>See our <a href="https://github.com/OpenTreeOfLife/reference-taxonomy/blob/master/doc/taxon-flags.md#taxon-flags" target="_blank">taxonomy documentation</a> for details on the meanings of each flag.</p>'
                             }
                         }
 

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1444,10 +1444,10 @@ if (false) {
 function showErrorInArgusViewer( msg, details ) {
     var errorHTML;
     if (!details) {
-        errorHTML = '<p style="margin: 8px 12px;">'+ msg +'</p>';
+        errorHTML = '<div class="argus-error">'+ msg +'</div>';
     } else {
-        errorHTML = '<p style="margin: 8px 12px;">'+ msg +'&nbsp; &nbsp; '
-        + '<a href="#" onclick="$(\'#error-details\').show(); return false;">Show details</a></p>'
+        errorHTML = '<div class="argus-error">'+ msg +'&nbsp; &nbsp; '
+        + '<a href="#" onclick="$(\'#error-details\').show(); return false;">Show details</a></div>'
         + '<p id="error-details" style="margin: 8px 12px; font-style: italic; display: none;">'+ details +'</p>';
     }
     $('#argusCanvasContainer').css('height','500px').html( errorHTML );

--- a/webapp/static/js/webapp-helpers.js
+++ b/webapp/static/js/webapp-helpers.js
@@ -157,7 +157,8 @@ function getSynthTreeViewerLinkForNodeID(displayName, synthID, nodeID) {
         .replace('{DISPLAY_NAME}', displayName);
 }
 function getSynthTreeViewerURLForNodeID(synthID, nodeID) {
-    if (!synthID || !nodeID) {
+    // if synthID is '', this will point to the latest synthetic tree
+    if (!nodeID) {
         return null;
     }
     var url = '/opentree/argus/{SYNTH_ID}@{NODE_ID}';

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -532,3 +532,14 @@ div#r0 {
 #tree-view-legend .legend-pane img {
     border: 1px solid #fcfcfc;
 }
+.argus-error {
+    margin: 30px 40px; 
+    font-size: 120%;
+}
+.argus-error p {
+    font-weight: bold; 
+    color: #777;
+}
+.argus-error p.action-item {
+    padding-left: 8em;
+}

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -541,5 +541,5 @@ div#r0 {
     color: #777;
 }
 .argus-error p.action-item {
-    padding-left: 8em;
+    padding-left: 3em;
 }


### PR DESCRIPTION
This also improves our messages for all taxa that don't appear in the synthetic tree.

This is working now on **devtree**, see for example these missing taxa:

- https://devtree.opentreeoflife.org/opentree/argus/ottol@372706/Canis
- https://devtree.opentreeoflife.org/opentree/argus/ottol@5265694/Xenopus-genus-in-Protostomia-
- https://devtree.opentreeoflife.org/opentree/argus/ottol@34907/Drosophila
- https://devtree.opentreeoflife.org/opentree/argus/ottol@asdfasdfasdf/not-a-real-ottid
