### PR TITLE
Show contesting trees

### DIFF
--- a/webapp/private/config.example
+++ b/webapp/private/config.example
@@ -50,6 +50,7 @@ getContextsJSON_url = {CACHED_taxomachine_domain}/v3/tnrs/contexts
 getSynthesisSourceList_url = {CACHED_treemachine_domain}/v3/tree_of_life/about
 findAllStudies_url = {CACHED_oti_domain}/v3/studies/find_studies
 singlePropertySearchForStudies_url = {oti_domain}/v3/studies/find_studies
+singlePropertySearchForTrees_url = {oti_domain}/v3/studies/find_trees
 getTaxonInfo_url = {taxomachine_domain}/v3/taxonomy/taxon_info
 # Include one phylesystem-api method to download NexSON from Bibliographic References page
 API_load_study_GET_url = {opentree_api_domain}/v3/study/{STUDY_ID}

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -747,10 +747,11 @@ function createArgus(spec) {
                                 errMsg +='<p class="action-item"><a href="' + mrcaSynthViewURL
                                         +'">View the MRCA of the members of this taxon in the synthetic tree</a></p>';
                             }
-                            if (mainFetchJSON.broken.contesting_trees) {
+                            var contestingTreeJSON = mainFetchJSON.broken.contesting_trees;
+                            if (contestingTreeJSON) {
                                 errMsg +='<p class="action-item">Input phylogenies that conflict with this taxon: &nbsp; <a class="conflicting-tree-toggle" style="font-weight: normal; display: none;" href="#">[show tree and study details]</a></p>';
                                 errMsg +='<ul class="action-item conflicting-trees">';
-                                Object.keys(mainFetchJSON.broken.contesting_trees).forEach(function(treeAndStudyID) {
+                                Object.keys(contestingTreeJSON).forEach(function(treeAndStudyID) {
 
                                     var parts = treeAndStudyID.split('@');
                                     var studyID = parts[0];
@@ -758,20 +759,20 @@ function createArgus(spec) {
                                     var conflictURL = '/curator/study/view/{STUDY_ID}/?tab=trees&tree={TREE_ID}&conflict=ott'
                                         .replace('{STUDY_ID}', studyID)
                                         .replace('{TREE_ID}', treeID);
-
-                                    errMsg +='<li><a target="_blank" href="'+ conflictURL +'"><b>' + treeAndStudyID +'</b> (show this tree in a new window)';
+                                    var conflictDetailsPanelID = 'conflicting-tree-details-'+ studyID +'-'+ treeID;
+                                    errMsg +='<li><a target="_blank" href="'+ conflictURL +'"><b>' + treeAndStudyID +'</b> (show this tree in a new window)</a><div id="'+ conflictDetailsPanelID +'" class="conflicting-tree-details"><em>...loading details..</em></div></li>';
                                   /* TODO: One or more AJAX fetches to retrieve study and tree names?
                                     var treeName = "TODO";
                                     var compactRef = "TODO";
                                     errMsg +=' &nbsp; ('+ "tree <b>'+ treeName +'</b> in study <b>'+ compactRef +'</b>" +')<//a></li>';
                                   */
+                                    /* Fetch more information about conflicting trees and
+                                     * studies; update the UI once we have the data.
+                                     */
+                                    loadConflictingTreeDetails(contestingTreeJSON, conflictDetailsPanelID);
                                 });
                                 errMsg +='</ul>';
 
-                                /* Fetch more information about conflicting trees and
-                                 * studies; update the UI once we have the data.
-                                 */
-                                loadConflictingTreeDetails(mainFetchJSON.broken.contesting_trees);
                             }
                         } else {
                             errMsg = '<p>This taxon is in our taxonomy but does not appear in the latest synthetic tree. This can happen for a variety of reasons,'
@@ -2088,11 +2089,48 @@ ArgusCluster.prototype.updateDisplayBounds = function() {
     return this.displayBounds;
 };
 
-function loadConflictingTreeDetails( contestingTreeJSON ) {
+function loadConflictingTreeDetails(contestingTreeJSON, conflictDetailsPanelID) {
     /* Fetch details (esp. names) about conflicting trees and
      * studies; update the UI once we have the data.
      */
-    console.log('Now I\'d load some details!');
+    //var conflictingStudyInfo = { };  // display conflicts by study, with any trees listed beneath each?
+    Object.keys(contestingTreeJSON).forEach(function(treeAndStudyID) {
+        // extract study & tree IDs from each property, e.g. "pg_1940@tree3943"
+        var parts = treeAndStudyID.split('@');
+        var studyID = parts[0];
+        var treeID = parts[1];
+        var studyURL = '/curator/study/view/{STUDY_ID}/'.replace('{STUDY_ID}', studyID);
+        var conflictURL = studyURL + '?tab=trees&tree={TREE_ID}&conflict=ott'.replace('{TREE_ID}', treeID);
+        // One AJAX fetch per tree
+        $.post(
+            singlePropertySearchForTrees_url, // JSON fetch URL
+            JSON.stringify({   // POSTed data
+                "property": "ot:studyId",
+                "value": studyID,
+                verbose: true
+            }),
+            function(data) {    // JSONP callback
+                var $detailsPanel = $('#'+ conflictDetailsPanelID);
+                try {
+                    var studyInfo = data.matched_studies[0];
+                    var treeInfo = $.grep(studyInfo.matched_trees, function(treeInfo) {
+                        return (treeInfo['ot:treeId'] === treeID);
+                    })[0];
+                    detailsPanelHTML = 'Conflicting tree \'<strong>'+ treeInfo['@label'] +'</strong>\'<br/>'
+                      + '<a target="_blank" href="'+ conflictURL +'">Show this tree\'s conflicts in the study curation tool</a><br/>'
+                      + '<pre>'+ studyInfo['ot:studyPublicationReference']
+                      + ' <a target="_blank" href="'+ studyInfo['ot:studyPublication'] +'">'+ studyInfo['ot:studyPublication'] +'</a></pre>';
+                      //+ '<a target="_blank" href="'+ studyURL +'">Show this study (all trees) in a new window</a><br/>';
+                    $detailsPanel.html(detailsPanelHTML);
+                    // clobber the initial raw link, since we have somethign nicer
+                    $detailsPanel.prev().remove();
+                } catch(e) {
+                    $detailsPanel.html('<strong>ERROR loading details for this conflicting tree!</strong>');
+                }
+            }
+        );
+    });
+    console.warn("ALL DONE?");
 }
 
 function getClientBoundingBox( elementSet ) {

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -747,6 +747,14 @@ function createArgus(spec) {
                                 errMsg +='<p class="action-item"><a href="' + mrcaSynthViewURL
                                         +'">View the MRCA of the members of this taxon in the synthetic tree</a></p>';
                             }
+                            if (mainFetchJSON.broken.contesting_trees) {
+                                errMsg +='<p>Input phylogenies that conflict with this taxon:</p>';
+                                errMsg +='<ul>';
+                                Object.keys(mainFetchJSON.broken.contesting_trees).forEach(function(tree) {
+                                    errMsg +='<li>' + tree + '</li>';
+                                });
+                                errMsg +='</ul>';
+                            }
                         } else {
                             errMsg = '<p>This taxon is in our taxonomy but does not appear in the latest synthetic tree. This can happen for a variety of reasons,'
                                 +' but the most probable is that is has a taxon flag (e.g. <em>incertae sedis</em>) that'

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -748,10 +748,23 @@ function createArgus(spec) {
                                         +'">View the MRCA of the members of this taxon in the synthetic tree</a></p>';
                             }
                             if (mainFetchJSON.broken.contesting_trees) {
-                                errMsg +='<p>Input phylogenies that conflict with this taxon:</p>';
-                                errMsg +='<ul>';
-                                Object.keys(mainFetchJSON.broken.contesting_trees).forEach(function(tree) {
-                                    errMsg +='<li>' + tree + '</li>';
+                                errMsg +='<p class="action-item">Input phylogenies that conflict with this taxon (click to see each conflicting tree in a new window):</p>';
+                                errMsg +='<ul class="action-item">';
+                                Object.keys(mainFetchJSON.broken.contesting_trees).forEach(function(treeAndStudyID) {
+
+                                    var parts = treeAndStudyID.split('@');
+                                    var studyID = parts[0];
+                                    var treeID = parts[1];
+                                    var conflictURL = '/curator/study/view/{STUDY_ID}/?tab=trees&tree={TREE_ID}&conflict=ott'
+                                        .replace('{STUDY_ID}', studyID)
+                                        .replace('{TREE_ID}', treeID);
+
+                                    errMsg +='<li><a target="_blank" href="'+ conflictURL +'"><b>' + treeAndStudyID +'</b>';
+                                  /* TODO: One or more AJAX fetches to retrieve study and tree names?
+                                    var treeName = "TODO";
+                                    var compactRef = "TODO";
+                                    errMsg +=' &nbsp; ('+ "tree <b>'+ treeName +'</b> in study <b>'+ compactRef +'</b>" +')<//a></li>';
+                                  */
                                 });
                                 errMsg +='</ul>';
                             }

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -748,8 +748,8 @@ function createArgus(spec) {
                                         +'">View the MRCA of the members of this taxon in the synthetic tree</a></p>';
                             }
                             if (mainFetchJSON.broken.contesting_trees) {
-                                errMsg +='<p class="action-item">Input phylogenies that conflict with this taxon (click to see each conflicting tree in a new window):</p>';
-                                errMsg +='<ul class="action-item">';
+                                errMsg +='<p class="action-item">Input phylogenies that conflict with this taxon: &nbsp; <a class="conflicting-tree-toggle" style="font-weight: normal; display: none;" href="#">[show tree and study details]</a></p>';
+                                errMsg +='<ul class="action-item conflicting-trees">';
                                 Object.keys(mainFetchJSON.broken.contesting_trees).forEach(function(treeAndStudyID) {
 
                                     var parts = treeAndStudyID.split('@');
@@ -759,7 +759,7 @@ function createArgus(spec) {
                                         .replace('{STUDY_ID}', studyID)
                                         .replace('{TREE_ID}', treeID);
 
-                                    errMsg +='<li><a target="_blank" href="'+ conflictURL +'"><b>' + treeAndStudyID +'</b>';
+                                    errMsg +='<li><a target="_blank" href="'+ conflictURL +'"><b>' + treeAndStudyID +'</b> (show this tree in a new window)';
                                   /* TODO: One or more AJAX fetches to retrieve study and tree names?
                                     var treeName = "TODO";
                                     var compactRef = "TODO";
@@ -767,6 +767,11 @@ function createArgus(spec) {
                                   */
                                 });
                                 errMsg +='</ul>';
+
+                                /* Fetch more information about conflicting trees and
+                                 * studies; update the UI once we have the data.
+                                 */
+                                loadConflictingTreeDetails(mainFetchJSON.broken.contesting_trees);
                             }
                         } else {
                             errMsg = '<p>This taxon is in our taxonomy but does not appear in the latest synthetic tree. This can happen for a variety of reasons,'
@@ -2082,6 +2087,13 @@ ArgusCluster.prototype.updateDisplayBounds = function() {
     };
     return this.displayBounds;
 };
+
+function loadConflictingTreeDetails( contestingTreeJSON ) {
+    /* Fetch details (esp. names) about conflicting trees and
+     * studies; update the UI once we have the data.
+     */
+    console.log('Now I\'d load some details!');
+}
 
 function getClientBoundingBox( elementSet ) {
     // Takes a RaphaelJS element set, reckons its full bounding box in

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1450,7 +1450,8 @@ function showErrorInArgusViewer( msg, details ) {
         + '<a href="#" onclick="$(\'#error-details\').show(); return false;">Show details</a></div>'
         + '<p id="error-details" style="margin: 8px 12px; font-style: italic; display: none;">'+ details +'</p>';
     }
-    $('#argusCanvasContainer').css('height','500px').html( errorHTML );
+    // allow full height (with scrollbars) for long messages
+    $('#argusCanvasContainer').css('height','').html( errorHTML );
 }
 
 function toggleTreeViewLegend() {

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -535,6 +535,7 @@ div#r0 {
 .argus-error {
     margin: 30px 40px; 
     font-size: 120%;
+    max-width: 40em;
 }
 .argus-error p {
     font-weight: bold; 

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -540,6 +540,9 @@ div#r0 {
     font-weight: bold; 
     color: #777;
 }
-.argus-error p.action-item {
+.argus-error .action-item {
     padding-left: 3em;
+}
+.argus-error .action-item li {
+    list-style: circle;
 }

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -88,6 +88,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         var getTaxonInfo_url = "{{=getTaxonInfo_url}}";
         var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
         var singlePropertySearchForStudies_url = "{{=singlePropertySearchForStudies_url}}";
+        var singlePropertySearchForTrees_url = "{{=singlePropertySearchForTrees_url}}";
       {{ if 'nudgingToLatestSyntheticTree' in locals(): }}
         // notify the user if we've nudged an old synth-tree URL to the latest (in synth-tree view only)
         // N.B. This JS variable is currently unused! See static alert '#nudged-to-latest-synthetic-tree' below.


### PR DESCRIPTION
I believe the detailed display of conflicting trees (when searching for a broken taxon) is ready for release. These changes are live on **devtree.opentree.org**, see for example these test taxa:

[Drosophila](https://devtree.opentreeoflife.org/opentree/argus/ottol@34907/Drosophila) has a single conflicting tree.

[Canis](https://devtree.opentreeoflife.org/opentree/argus/ottol@372706/Canis) has two.
_Odd, I see that one of these trees shows multiple study references. I'll review and report my findings below..._

[Typhlopoidea](https://devtree.opentreeoflife.org/opentree/argus/ottol@100035/Typhlopoidea) has five conflict trees. _NOTE that we can't currently return details for one of these (ot_1042@tree1), apparently because this study is not in the index used by our AJAX call to `find_trees`._
