### PR TITLE
Collection management UI - fixes and refresh feature

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -932,3 +932,7 @@ a.node-direct-link {
     margin-right: -16px;
     border-radius: 4px;
 }
+.tree-status-marker {
+    font-weight: bold;
+    margin: 4px 0 0 2px;
+}

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -213,8 +213,9 @@ function loadStudyList() {
                         var pubReference = study['ot:studyPublicationReference'];
                         var pubURL = study['ot:studyPublication'];
                         var pubYear = study['ot:studyYear'];
+                        // NB playing it safe here, since JS regex isn't guaranteed to match against array values
                         var tags = $.isArray(study['ot:tag']) ? study['ot:tag'].join('|') : study['ot:tag'];
-                        var curator = study['ot:curatorName'];
+                        var curator = $.isArray(study['ot:curatorName']) ? study['ot:curatorName'].join('|') : study['ot:curatorName'];
                         var clade = ('ot:focalCladeOTTTaxonName' in study && 
                                      ($.trim(study['ot:focalCladeOTTTaxonName']) !== "")) ?
                                         study['ot:focalCladeOTTTaxonName'] :  // use mapped name if found

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -665,14 +665,21 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                 title="Cancel your changes to this collection"
                 class="pull-right btn btn-warning btn-mini row-controls-ghosted"
                 style="margin-left: 4px;">
-                Cancel</i>
+                Cancel
             </button>
             <button data-bind="click: promptForSaveCollectionComments,
                                visible: userIsEditingCollection($data)"
                 title="Save your changes to this collection"
                 class="pull-right btn btn-info btn-mini row-controls-ghosted"
                 style="margin-left: 4px;">
-                Save Changes</i>
+                Save Changes
+            </button>
+            <button data-bind="click: updateCollectionTrees,
+                               visible: userIsEditingCollection($data)"
+                title="Use latest tree labels, detect removed trees"
+                class="pull-right btn btn-mini row-controls-ghosted"
+                style="margin-left: 4px;">
+                Update trees <i class="icon-refresh"></i>
             </button>
 
            </div>
@@ -756,8 +763,13 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                     </tr>
                   </thead>
                   <tbody id="tree-collection-decisions"
-                         data-bind="foreach: { data: $data.data.decisions, as: 'decision' }">
-                      <tr class="single-tree-row">
+                         data-bind="foreach: { data: $data.data.decisions }">
+                      <tr data-bind="attr: { class: (userIsEditingCollection($parent) && $data['status'] == 'REMOVED') ?
+                                                      'single-tree-row error' :
+                                                      (userIsEditingCollection($parent) && $data['status'] == 'RENAMED' ?
+                                                        'single-tree-row warning' :
+                                                        'single-tree-row-'+ $data['status'] )
+                                            }">
                           <td>
                           <!-- ko if: userIsEditingCollection($parent) -->
                             <input type="text"
@@ -801,6 +813,12 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                                title="Move this tree down in the list"
                                class="icon-chevron-down">
                             </a>
+                           <!-- /ko -->
+                           <!-- ko if: $data['status'] == 'REMOVED' -->
+                             <div class="tree-status-marker text-error">REMOVED</div>
+                           <!-- /ko -->
+                           <!-- ko if: $data['status'] == 'RENAMED' -->
+                             <div class="tree-status-marker text-warning">RENAMED</div>
                            <!-- /ko -->
 
                           <!-- /ko --><!-- END of editing widgets -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -2354,7 +2354,7 @@ body {
                     <tr class="single-tree-row">
                       <td>
                         <button data-bind="click: function() {removeReasonToExcludeTree($index(), $root); return false;},
-                                           visible: (viewOrEdit == 'EDIT')" title="Remove this tree from the collection" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
+                                           visible: (viewOrEdit == 'EDIT')" title="Remove this reason to exclude" class="pull-right btn btn-mini btn-danger row-controls-ghosted" style="margin-left: 4px;">
                           <i class="icon-trash icon-white"></i>
                         </button>
                         <textarea class="input-block-level"

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1173,6 +1173,9 @@ function showObjectProperties( objInfo, options ) {
 
                             pCurator = studyInfo['ot:curatorName'];
                             if (pCurator) {
+                                if ($.isArray(pCurator)) {
+                                    pCurator = pCurator.join(", ");
+                                }
                                 displayVal += ('<div>Curated by: '+ pCurator +'</div>');
                             }
                             displayVal += '</div>';  // end of .full-study-details


### PR DESCRIPTION
This fixes some serious bugs in the current collections editor, and adds the ability to update trees from phylesystem. 

Specifically, this will adopt any new tree labels and mark them for review. Same for trees (or studies) that have since been removed from phylesystem -- these are marked for likely removal from the collection, but also as hints that a replacement tree might be needed here.

Here's the resulting display after a "boring" update with no changes to tree labels or status:
<img width="890" alt="Screen Shot 2020-01-31 at 7 55 15 PM" src="https://user-images.githubusercontent.com/446375/73584509-f2dacd00-4466-11ea-8cde-37600abf4d07.png">

This one has more interesting changes to review:
<img width="903" alt="Screen Shot 2020-01-31 at 7 42 28 PM" src="https://user-images.githubusercontent.com/446375/73584525-0ab25100-4467-11ea-8b59-f65d0c2f0149.png">

Note that we don't currently flag changes to _tree topology_, which might be very useful. We could approximate this by storing and updating a SHA for each tree, but this would mean that _any_ changes in the study would prompt for a review, so maybe not a good idea.

Anyway, this is deployed now on **devtree**. Please take a look and see how it behaves for you. [The example collection above](https://devtree.opentreeoflife.org/curator/collections/jimallman/new-test) is a good one to test, but please don't save your changes until others have had a little time to try it. The big input-to-synthesis collections are also interesting to look at. Generally their trees have not been removed, but tons of new+improved tree names can be incorporated easily now.