### PR TITLE
Highlight extinct nodes in synth view

### DIFF
--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -154,6 +154,9 @@ function createArgus(spec) {
         "pathColor": "#999",
         "strongPathColor": "#000",
         "labelColor": "#000",
+        "extinctNodeColor": "#c96",  // or maybe #963
+        "extinctPathColor": "#c96",
+        "extinctLabelColor": "#a74",
         "provenanceHighlightColor": "#3333ff",
         "provenanceHighlightLabelColor": "#3333ff",
         "provenanceHighlightLabelBackgroundColor": "#ffffff",
@@ -163,7 +166,9 @@ function createArgus(spec) {
         "backStack": [], // args to previous displayNode calls
         "forwardStack": [], // args to displayNode calls after the back button has been clicked
         "currDisplayContext": undefined, //arg to most recent displayNode call
-
+        // add dagger † before (or after) extinct node labels
+        "leadingDagger": "\u2020 ",
+        "trailingDagger": " \u2020",
         clusters: {},      // a registry of clustered child-nodes, keyed to the parent-node's ID
         maxClusterSize: 100,   // try to bundle sets of n children
         minClusterSize: 10, // add fewer to the previous cluster (or unclustered children) instead
@@ -1240,11 +1245,11 @@ function createArgus(spec) {
         } else {
             node.r = this.minTipRadius + this.nodeDiamScalar * Math.log(node.num_tips);
         }
-        var nodeFill = this.nodeColor;
-        var nodeStroke = this.pathColor;
+        var nodeFill = node.isExtinct() ? this.extinctNodeColor : this.nodeColor;
+        var nodeStroke = node.isExtinct() ? this.extinctPathColor : this.pathColor;
         // override for special cases
         if (node.isActualLeafNode()) {
-            nodeFill = this.actualLeafColor;
+            nodeFill = node.isExtinct() ? this.extinctNodeColor : this.actualLeafColor;
             nodeStroke = this.bgColor;
         } else if (node.isVisibleLeafNode()) {
             nodeFill = this.visibleLeafColor;
@@ -1327,10 +1332,17 @@ function createArgus(spec) {
                                           (node.name.indexOf(compoundNodeNameSuffix) === (node.name.length -1)));
                 displayLabel = (isCompoundNodeName ? '' : node.name || '');
             }
+            if (node.isExtinct()) {
+                if (labelAnchor === 'start') {
+                    displayLabel = this.markLabelAsExtinct(displayLabel, 'LEADING');
+                } else {
+                    displayLabel = this.markLabelAsExtinct(displayLabel, 'TRAILING');
+                }
+            }
             label = paper.text(labelX, labelY, displayLabel).attr({
                 'text-anchor': labelAnchor,
                 "title": displayLabel,
-                "fill": this.labelColor,
+                "fill": node.isExtinct() ? this.extinctLabelColor : this.labelColor,
                 "font-size": fontSize
             }).insertBefore(dividerBeforeHighlights);
             label.id = (nodeLabelElementID);
@@ -1349,7 +1361,7 @@ function createArgus(spec) {
             } else {
                 // create the new spine
                 spine = paper.path(spineSt).toBack().attr({
-                    "stroke": this.pathColor,
+                    "stroke": node.isExtinct() ? this.extinctPathColor : this.pathColor,
                     "stroke-linecap": 'round'
                 }).insertBefore(dividerBeforeLabels)
                   .id = (nodeSpineElementID);
@@ -1368,13 +1380,13 @@ function createArgus(spec) {
             if (supportedByTaxonomy && supportedByPhylogeny) {
                 //lineDashes = '--..';
                 lineDashes = '';
-                lineColor = this.strongPathColor;
+                lineColor = node.isExtinct() ? this.extinctPathColor : this.strongPathColor;
             } else if (supportedByPhylogeny){
                 lineDashes = '';
-                lineColor = this.strongPathColor;
+                lineColor = node.isExtinct() ? this.extinctPathColor : this.strongPathColor;
             } else if (supportedByTaxonomy){
                 lineDashes = '- ';
-                lineColor = this.pathColor;
+                lineColor = node.isExtinct() ? this.extinctPathColor : this.pathColor;
             } else {
                 lineDashes = '--..';
                 lineColor = 'orange';
@@ -1405,7 +1417,7 @@ function createArgus(spec) {
                     "stroke-width": 1,
                     "stroke-linecap": (lineDashes === '.') || (lineDashes === '--..') || (lineDashes === '--.') ? 'butt' : 'round',      // avoids Chrome bug with dotted lines + round caps
                     "stroke-dasharray": lineDashes,
-                    "stroke": lineColor          // this.pathColor
+                    "stroke": node.isExtinct() ? this.extinctPathColor : this.pathColor
                 }).insertBefore(dividerBeforeLabels);
                 visibleBranch.id = (nodeVisibleBranchElementID);
 
@@ -1455,7 +1467,7 @@ function createArgus(spec) {
                     } else {
                         // create the new branch
                         branch = paper.path(upwardSt).toBack().attr({
-                            "stroke": this.pathColor,
+                            "stroke": node.isExtinct() ? this.extinctPathColor : this.pathColor,
                             "stroke-linecap": 'butt', // REQUIRED if stroke-dasharray is '.'
                             "stroke-dasharray": '. ',
                             "opacity": pathOpacity
@@ -1481,16 +1493,19 @@ function createArgus(spec) {
                         } else {
                             // create the new circle and label
                             circle = paper.circle(endX, endY, this.minTipRadius).attr({
-                                "fill": this.nodeColor,
+                                "fill": ancestorNode.isExtinct() ? this.extinctNodeColor : this.nodeColor,
                                 "title": "Click to move to this node",
-                                "stroke": this.pathColor
+                                "stroke": ancestorNode.isExtinct() ? this.extinctPathColor : this.pathColor
                             }).insertBefore(dividerBeforeAnchoredUI);
                             circle.id = (nodeCircleElementID);
-
-                            label = paper.text(labelX, labelY, ancestorNode.name || "").attr({
+                            var displayLabel = (ancestorNode.name || "");
+                            if (ancestorNode.isExtinct()) {
+                                displayLabel = this.markLabelAsExtinct(displayLabel, 'TRAILING');
+                            }
+                            label = paper.text(labelX, labelY, displayLabel).attr({
                                 'text-anchor': 'end',
-                                "title": (ancestorNode.name || ""),
-                                "fill": this.labelColor,
+                                "title": displayLabel,
+                                "fill": ancestorNode.isExtinct() ? this.extinctLabelColor :this.labelColor,
                                 "font-size": fontSize
                             }).insertBefore(dividerBeforeHighlights);
                             label.id = (nodeLabelElementID);
@@ -1506,7 +1521,7 @@ function createArgus(spec) {
                             circle.hover(getHoverHandlerNodeAndEdge('OVER', circle, {
                                 "fill": this.nodeHoverColor
                             }), getHoverHandlerNodeAndEdge('OUT', circle, {
-                                "fill": this.nodeColor
+                                "fill": ancestorNode.isExtinct() ? this.extinctNodeColor : this.nodeColor
                             }));
                         }
 
@@ -1520,6 +1535,18 @@ function createArgus(spec) {
             }
         }
     }
+
+    // add dagger † before (or after) the label of an extinct node
+    argusObj.markLabelAsExtinct = function(label, leadingOrTrailing) {
+        if ($.trim(label) === "") {
+            return "";
+        }
+        if (leadingOrTrailing === 'TRAILING') {
+            return (label + this.trailingDagger);
+        } else {
+            return (this.leadingDagger + label);
+        }
+    };
 
     argusObj.drawCluster = function (obj) {
         var cluster = obj.cluster;
@@ -1556,7 +1583,7 @@ function createArgus(spec) {
                 "stroke-width": 1,
                 "stroke-linecap": 'butt', // REQUIRED if stroke-dasharray is '.'
                 "stroke-dasharray": '. ',
-                "stroke": this.pathColor
+                "stroke": node.isExtinct() ? this.extinctPathColor : this.pathColor
             }).insertBefore(dividerBeforeLabels);
             branch.id = (clusterBranchElementID);
         }
@@ -2026,6 +2053,12 @@ ArgusNode.prototype.isLocalLeafNode = function() {
 };
 ArgusNode.prototype.isActualLeafNode = function() {
     return this.num_tips === 0;
+};
+ArgusNode.prototype.isExtinct = function() {
+    if (typeof this.extinct === 'undefined') {
+        return false;  // allow parsimony (omit property for non-extinct nodes)
+    }
+    return (this.extinct === true);
 };
 ArgusNode.prototype.isVisibleLeafNode = function() {
     return this.hasChildren === false || this.num_tips_in_view === 0;

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1610,7 +1610,7 @@ function createArgus(spec) {
             label = paper.text(clusterLeftEdge + 8, cluster.y - (this.nodeHeight * 0.0), clusterLabel).attr({
                 'text-anchor': 'start',
                 "title": clusterLabel,
-                "fill": this.labelColor,
+                "fill": parentNodeExtinct ? this.extinctLabelColor : this.labelColor,
                 "font-size": fontSize,
                 "cursor": "pointer"
             });

--- a/webapp/static/js/argus/drawtree.js
+++ b/webapp/static/js/argus/drawtree.js
@@ -1215,6 +1215,7 @@ function createArgus(spec) {
                     "clusterPosition": $.inArray(dlChild, node.getClusters()), // returns index
                     "domSource": domSource,
                     "parentNodeX": node.x,
+                    "parentNodeExtinct": node.isExtinct(),
                     "currentYoffset": currentYoffset,
                     "depthFromTargetNode": depthFromTargetNode
                 });
@@ -1552,6 +1553,7 @@ function createArgus(spec) {
         var cluster = obj.cluster;
         var parentNodeID = cluster.parentNodeID;
         var parentNodeX = obj.parentNodeX;
+        var parentNodeExtinct = obj.parentNodeExtinct;
         var depthFromTargetNode = obj.depthFromTargetNode;
         var currentYoffset = obj.currentYoffset;
         var clusterPosition = obj.clusterPosition;
@@ -1583,7 +1585,7 @@ function createArgus(spec) {
                 "stroke-width": 1,
                 "stroke-linecap": 'butt', // REQUIRED if stroke-dasharray is '.'
                 "stroke-dasharray": '. ',
-                "stroke": node.isExtinct() ? this.extinctPathColor : this.pathColor
+                "stroke": parentNodeExtinct ? this.extinctPathColor : this.pathColor
             }).insertBefore(dividerBeforeLabels);
             branch.id = (clusterBranchElementID);
         }

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -844,6 +844,9 @@ function showObjectProperties( objInfo, options ) {
     // start filling in the panel from the top
 
     displayName = (objName) ? objName : ("Unnamed "+ objType);
+    if (fullNode.isExtinct()) {
+        displayName = argus.leadingDagger + displayName;
+    }
     jQuery('#provenance-panel .provenance-title').html( displayName );
 
     /* Clear and rebuild collection of detailed properties, adapting to special

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1300,6 +1300,7 @@ function showObjectProperties( objInfo, options ) {
         // for proper taxon names (not nodes like '[Canis + Felis]'), link to EOL
         if ((displayName.indexOf('Unnamed ') !== 0) &&
             (displayName.indexOf('(unnamed ') !== 0) &&
+            (displayName.indexOf(argus.leadingDagger +'[') !== 0) &&
             (displayName.indexOf('[') !== 0)) {
             // Attempt to find a page for this taxon in the Encyclopedia of Life website
             // N.B. This 'external-links' list can hold similar entries.


### PR DESCRIPTION
This reflects our recent discussions about how to display extinct nodes in the synthetic tree. Nodes and "rootward" paths are colored differently for these, and their labels are decorated with the conventional "dagger" (†). This character leads or follows the name, based on layout rules for best legibility. Generally speaking, visible leaf nodes always use the leading format, while internal nodes and those "upward" of the current target node use the following format.

The dagger is also shown for an extinct node in the right-hand property inspector, always before the name.