### PR TITLE
Simplified curation tabs

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -914,6 +914,11 @@ tr.after-shims th {
 		margin-left: 4em;
 }
 
+#study-metadata-popup {
+    width: 80%;
+    margin: auto -40%;
+}
+
 #new-taxa-popup {
     width: 80%;
     margin: auto -40%;

--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -930,6 +930,13 @@ tr.after-shims th {
     margin-bottom: 10px;
 }
 
+#new-taxa-popup .form-horizontal .control-label {
+    width: 148px;
+}
+#new-taxa-popup .form-horizontal .controls {
+    margin-left: 140px;
+}
+
 .required-field {
  /* border-color: red !important; */
 }

--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -468,12 +468,14 @@ div.flash #closeflash{color:inherit; float:right; margin-left:15px; cursor:point
     padding: 0.25em 0;
 }
 
-.suggestion-list {
-    /* list-style-type: none; */
-}
 .suggestion-list li {
     padding-bottom: 0.2em;
     color: #b94a48;
+    list-style-position: inside;
+}
+.suggestion-list li.edit-prompt {
+    list-style: none;
+    list-style-position: outside;
 }
 .suggestion-list span.label {
     padding: 0.3em 0.7em 0.4em;
@@ -875,6 +877,7 @@ tr.after-shims th {
   border-radius: 5px;
   border: 1px #ddd solid;
   overflow: hidden;
+  margin-bottom: 14px;
   padding: 12px 18px;
   box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.5);
 }

--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -488,7 +488,7 @@ div.flash #closeflash{color:inherit; float:right; margin-left:15px; cursor:point
     font-weight: bold;
 }
 .rendered-comment {
-    background-color: #f5f5f5;
+    background-color: #eee;
     border: none;
     border-radius: 4px;
     padding: 5px;
@@ -870,6 +870,13 @@ tr.after-shims th {
 
 .form-horizontal.metadata-readonly .control-group {
   margin-bottom: 12px;
+}
+#core-metadata-pane {
+  border-radius: 5px;
+  border: 1px #ddd solid;
+  overflow: hidden;
+  padding: 12px 18px;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .profile-header .control-group > .control-label,

--- a/curator/static/js/curation-dashboard.js
+++ b/curator/static/js/curation-dashboard.js
@@ -100,7 +100,7 @@ function updateListFiltersWithHistory() {
         var oldState = History.getState().data;
 
         // Determine which list filter is active (currently based on tab)
-        // N.B. There's currently just one filter per tab (Trees, Files, OTU Mapping).
+        // N.B. There's currently just one filter per tab (Home, Files, OTU Mapping).
         var activeFilter = viewModel.listFilters.STUDIES;
         var filterDefaults = listFilterDefaults.STUDIES;
         var newState = { };

--- a/curator/static/js/curator-profile.js
+++ b/curator/static/js/curator-profile.js
@@ -102,7 +102,7 @@ function updateListFiltersWithHistory() {
         var oldState = History.getState().data;
 
         // Determine which list filter is active (currently based on tab)
-        // N.B. There's currently just one filter per tab (Trees, Files, OTU Mapping).
+        // N.B. There's currently just one filter per tab (Home, Files, OTU Mapping).
         var activeFilter = viewModel.listFilters.COLLECTIONS;
         var filterDefaults = listFilterDefaults.COLLECTIONS;
         var newState = { };

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9173,6 +9173,11 @@ function getDataDepositMessage() {
     return url;
 }
 
+function showStudyMetadata() {
+  // show details in a popup (already bound)
+  $('#study-metadata-popup').modal('show');
+}
+
 function showDownloadFormatDetails() {
   // show details in a popup (already bound)
   $('#download-formats-popup').modal('show');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -3555,8 +3555,8 @@ var roughDOIpattern = new RegExp('(doi|DOI)[\\s\\.\\:]{0,2}\\b10[.\\d]{2,}\\b');
 // runs various tests on a study; used for building the scoreInfo var
 // tests divided into Metadata, Files, Trees and OTU mapping
 var studyScoringRules = {
-    'Metadata': [
-        // problems with study metadata, DOIs, etc
+    'Home': [  // combines former Metadata and Trees tabs
+        // problems with study metadata, DOIs, etc. AND TREES
         {
             description: "The study should have all metadata fields complete.",
             test: function(studyData) {
@@ -3697,9 +3697,7 @@ var studyScoringRules = {
             failureMessage: "This study has no license or waiver.",
             suggestedAction: "A study author should add an appropriate license or waiver."
             // TODO: add hint/URL/fragment for when curator clicks on suggested action?
-        }
-    ],
-    'Trees': [
+        },
         {
             description: "The study should contain at least one tree.",
             test: function(studyData) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -145,7 +145,7 @@ if ( History && History.enabled ) {
         if (currentTab) {
             goToTab( currentTab );
             switch(slugify(currentTab)) {
-                case 'trees':
+                case 'home':
                     activeFilter = viewModel.listFilters.TREES;
                     filterDefaults = listFilterDefaults.TREES;
                     break;
@@ -270,11 +270,11 @@ function showTreeWithHistory(tree) {
         var newState = $.extend(
             cloneFromSimpleObject( oldState ),
             {
-                'tab': 'Trees',
+                'tab': 'Home',
                 'tree': tree['@id']
             }
         );
-        History.pushState( newState, (window.document.title), ('?tab=trees&tree='+ newState.tree) );
+        History.pushState( newState, (window.document.title), ('?tab=home&tree='+ newState.tree) );
     } else {
         // show tree normally (ignore browser history)
         showTreeViewer(tree);
@@ -293,12 +293,12 @@ function hideTreeWithHistory() {
         var newState = $.extend(
             cloneFromSimpleObject( oldState ),
             {
-                'tab': 'Trees',
+                'tab': 'Home',
                 'tree': null,
                 'conflict': null
             }
         );
-        History.pushState( newState, (window.document.title), '?tab=trees' );
+        History.pushState( newState, (window.document.title), '?tab=home' );
     }
     fixLoginLinks();
 }
@@ -318,11 +318,11 @@ function updateListFiltersWithHistory() {
         var oldState = History.getState().data;
 
         // Determine which list filter is active (currently based on tab)
-        // N.B. There's currently just one filter per tab (Trees, Files, OTU Mapping).
+        // N.B. There's currently just one filter per tab (Home, Files, OTU Mapping).
         var activeFilter;
         var filterDefaults;
         switch(slugify(oldState.tab)) {
-            case 'trees':
+            case 'home':
                 activeFilter = viewModel.listFilters.TREES;
                 filterDefaults = listFilterDefaults.TREES;
                 break;
@@ -612,6 +612,11 @@ function goToTab( tabName ) {
         }
         return false;
     })
+    if ($matchingTab.length === 0) {
+        console.warn("No such tab, going to Home...");
+        goToTab('home');
+        return;
+    }
     $matchingTab.tab('show');
 }
 
@@ -1814,7 +1819,7 @@ function displayConflictSummary(conflictInfo) {
     var $reportArea = $('#analysis-results');
     var targetTree = $('#reference-select').val();
     var referenceTreeID = $('#tree-select').val();
-    var treeURL = getViewURLFromStudyID(studyID) +"?tab=trees&tree="+ referenceTreeID;
+    var treeURL = getViewURLFromStudyID(studyID) +"?tab=home&tree="+ referenceTreeID;
       +"&conflict="+ targetTree;
     $reportArea.empty()
            .append('<h4>Conflict summary</h4>')
@@ -2211,12 +2216,12 @@ function showConflictDetailsWithHistory(tree, referenceTreeID) {
         var newState = $.extend(
             cloneFromSimpleObject( oldState ),
             {
-                'tab': 'Trees',
+                'tab': 'Home',
                 'tree': tree['@id'],
                 'conflict': referenceTreeID
             }
         );
-        History.pushState( newState, (window.document.title), ('?tab=trees&tree='+ newState.tree +'&conflict='+ newState.conflict) );
+        History.pushState( newState, (window.document.title), ('?tab=home&tree='+ newState.tree +'&conflict='+ newState.conflict) );
     } else {
         // show conflict normally (ignore browser history)
         showTreeConflictDetailsFromPopup(tree);
@@ -2230,12 +2235,12 @@ function hideConflictDetailsWithHistory(tree) {
         var newState = $.extend(
             cloneFromSimpleObject( oldState ),
             {
-                'tab': 'Trees',
+                'tab': 'Home',
                 'tree': tree['@id'],
                 'conflict': null
             }
         );
-        History.pushState( newState, (window.document.title), '?tab=trees&tree='+ newState.tree );
+        History.pushState( newState, (window.document.title), '?tab=home&tree='+ newState.tree );
     } else {
         // hide conflict normally (ignore browser history)
         hideTreeConflictDetails(tree);
@@ -2363,7 +2368,7 @@ function validateFormData() {
     // check for a study year (non-empty integer)
     var studyYear = Number(viewModel.nexml["^ot:studyYear"]);
     if (isNaN(studyYear) || studyYear === 0) {
-        showErrorMessage('Please enter an non-zero integer for the Study Year (in Metadata tab).');
+        showErrorMessage("Please enter an non-zero integer for the Study Year (in Home tab's metadata editor).");
         return false;
     }
     // TODO: Add other validation logic to match changes on the server side.
@@ -3546,14 +3551,14 @@ function TreeNode() {
  *
  * validity? or should we make it "impossible" to build invalid data here?
  *
- * Let's try again, organizing by tab (Metadata, Trees, etc)
+ * Let's try again, organizing by tab (Home, Files, etc)
  */
 
 var roughDOIpattern = new RegExp('(doi|DOI)[\\s\\.\\:]{0,2}\\b10[.\\d]{2,}\\b');
 // this checks for *attempts* to include a DOI, not necessarily valid
 
 // runs various tests on a study; used for building the scoreInfo var
-// tests divided into Metadata, Files, Trees and OTU mapping
+// tests divided into Home, Files, and OTU mapping
 var studyScoringRules = {
     'Home': [  // combines former Metadata and Trees tabs
         // problems with study metadata, DOIs, etc. AND TREES
@@ -6954,7 +6959,7 @@ function showNodeOptionsMenu( tree, node, nodePageOffset, importantNodeIDs ) {
     }
     nodeInfoBox.append('<span class="node-name">'+ nodeOptionsLabel +'</span>');
 
-    var nodeURL = getViewURLFromStudyID(studyID) +"?tab=trees&tree="+ tree['@id'] +"&node="+ node['@id'];
+    var nodeURL = getViewURLFromStudyID(studyID) +"?tab=home&tree="+ tree['@id'] +"&node="+ node['@id'];
     nodeInfoBox.append('<a class="node-direct-link" title="Link directly to this node (opens in new window)" target="_blank" href="'+ 
                        nodeURL +'"><i class="icon-share-alt"></i></a>');
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1600,6 +1600,19 @@ function updateQualityDisplay () {
         if (suggestionCount === 0) {
             $cTabTally.hide();
         } else {
+            // if read-only, prompot the user to login and fix things
+            if (viewOrEdit == 'VIEW') {
+                var editPromptHTML;
+                // show appropriate text for logged-in vs anonymous user
+                var $loginToEditLink = $('a.sticky-login').eq(0);
+                editPromptHTML = 'If you want to improve this study, click <a href="#">'+ $loginToEditLink.text() +'</a> to begin.'
+                $cTabSugestionList.append('<li class="edit-prompt">'+ editPromptHTML +'</li>');
+                // clicking the new link should click our smart login link
+                $cTabSugestionList.find('li.edit-prompt').unbind('click').click(function(evt) {
+                    $loginToEditLink[0].click();  // call the bare DOM element for full support of onclick AND href
+                    return false;
+                });
+            }
             $cTabTally.text(suggestionCount).show();
         }
 

--- a/curator/static/js/tree-collection-dashboard.js
+++ b/curator/static/js/tree-collection-dashboard.js
@@ -99,7 +99,6 @@ function updateListFiltersWithHistory() {
         var oldState = History.getState().data;
 
         // Determine which list filter is active (currently based on tab)
-        // N.B. There's currently just one filter per tab (Trees, Files, OTU Mapping).
         var activeFilter = viewModel.listFilters.COLLECTIONS;
         var filterDefaults = listFilterDefaults.COLLECTIONS;
         var newState = { };

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -368,7 +368,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                 <li><a href="/curator/default/quickstart">Instructions</a></li>
                 -->
                 <li class="dropdown">
-                    <a href="/curator/study" class="dropdown-toggle" data-toggle="dropdown">Studies  <b class="caret"></b></a>
+                    <a href="/curator" class="dropdown-toggle" data-toggle="dropdown">Studies  <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="/curator">Browse all studies</a></li><!-- TODO: point to /curator/study once we have a full list -->
                         <li><a href="/curator/study/create">Add new study</a></li>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3051,9 +3051,9 @@ body {
                                     event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: formatDataDepositDOIAsURL },
                                     css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyDataDeposit" class="input-xlarge" placeholder="">
                 {{ else: }}
-                  <p>
+                  <p class="static-form-value">
                   <!-- ko if: getDataDepositMessage() !== '' -->
-                      <span class="static-form-value" data-bind="html: getDataDepositMessage()">&nbsp;</span>
+                      <span data-bind="html: getDataDepositMessage()">&nbsp;</span>
                  <!-- /ko -->
                  <!-- ko if: getDataDepositMessage() === '' -->
                       <em>None</em>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -259,7 +259,9 @@ body {
       <li><a href="#">Import</a></li>
     -->
       <li><a href="#Trees" data-toggle="tab">Home <span class="badge badge-important" style="display: none;">?</span></a></li>
-      <li><a href="#Metadata" data-toggle="tab">XXX-Metadata <span class="badge badge-important" style="display: none;">?</span></a></li>
+    <!--
+    -->
+      <li><a href="#Metadata" data-toggle="tab">Metadata <span class="badge badge-important" style="display: none;">?</span></a></li>
       <li><a href="#Files" data-toggle="tab">Files <span class="badge badge-important" style="display: none;">?</span></a></li>
       <li><a href="#OTU-Mapping" data-toggle="tab">OTU Mapping <span class="badge badge-important" style="display: none;">?</span></a></li>
     <!--
@@ -311,273 +313,11 @@ body {
 
 <div class="row">
     <div class="tab-content">
+          <div class="tab-pane" id="Metadata">
 
-          <div class="tab-pane" id="XXX-Metadata">
            <div class="span8"><!-- main column... -->
             <ul class="suggestion-list"></ul>
-            <form class="form-horizontal wider-fields{{= (viewOrEdit == 'VIEW') and ' metadata-readonly' or '' }}">
-              <div class="control-group">
-                <label class="control-label" for="ot_studyPublicationReference">Publication reference</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                  <textarea data-bind="value: nexml['^ot:studyPublicationReference'], valueUpdate: ['afterkeydown', 'input'], event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }, css: viewModel.ticklers.GENERAL_METADATA" id="ot_studyPublicationReference" class="input-xlarge" style="height: 160px;" placeholder=""></textarea>
-                {{ else: }}
-                  <p class="static-form-value" data-bind="text: nexml['^ot:studyPublicationReference']"></p>
-                {{ pass }}
-                </div>
-              </div>
-              <div class="control-group">
-                <label class="control-label" for="ot_studyPublication">Publication DOI (or URL)</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                  <input data-bind="value: nexml['^ot:studyPublication']['@href'],
-                                    valueUpdate: ['afterkeydown', 'input'],
-                                    event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: validateAndTestDOI },
-                                    css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyPublication" class="input-xlarge" placeholder="">
-                  <button type="button" class="btn btn-info" onclick="lookUpDOI(); return false;">Look up DOI...</button>
-                {{ else: }}
-                  <p>
-                 <!-- ko if: getStudyPublicationLink() !== '' -->
-                      <span class="static-form-value" data-bind="html: getStudyPublicationLink()">&nbsp;</span>
-                 <!-- /ko -->
-                 <!-- ko if: getStudyPublicationLink() === '' -->
-                      <em>None</em>
-                 <!-- /ko -->
-                  </p>
-                {{ pass }}
-                </div>
-                <div class="controls" data-bind="if: viewModel.duplicateStudyIDs().length > 0">
-                    <p class="static-form-value interesting-value">
-                        There are other studies in Open Tree database with this DOI. Click the links below to see each one in a new browser window.
-                    </p>
-                    <ul class="static-form-value interesting-value" data-bind="foreach: viewModel.duplicateStudyIDs">
-                        <li><a href="#" target="_blank"
-                            data-bind="text: getViewURLFromStudyID($data), attr: {'href': getViewURLFromStudyID($data)}">&nbsp</a></li>
-                    </ul>
-                </div>
-              </div>
-              <div class="control-group">
-                <label class="control-label" for="ot_studyDataDeposit">Data deposit DOI/URL</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                  <input data-bind="value: nexml['^ot:dataDeposit']['@href'],
-                                    valueUpdate: ['afterkeydown', 'input'],
-                                    event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: formatDataDepositDOIAsURL },
-                                    css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyDataDeposit" class="input-xlarge" placeholder="">
-                {{ else: }}
-                  <p>
-                  <!-- ko if: getDataDepositMessage() !== '' -->
-                      <span class="static-form-value" data-bind="html: getDataDepositMessage()">&nbsp;</span>
-                 <!-- /ko -->
-                 <!-- ko if: getDataDepositMessage() === '' -->
-                      <em>None</em>
-                 <!-- /ko -->
-                  </p>
-                {{ pass }}
-                </div>
-              </div>
-              <div class="control-group">
-                <label class="control-label" for="ot_studyYear">Study Year</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                  <input data-bind="value: nexml['^ot:studyYear'], valueUpdate: ['afterkeydown', 'input'], event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }" type="text" id="ot_studyYear" class="input-mini" placeholder="">
-                {{ else: }}
-                  <p class="static-form-value" data-bind="text: nexml['^ot:studyYear']"></p>
-                {{ pass }}
-                </div>
-              </div>
-              <div class="control-group">
-                <label class="control-label" for="ot_focalClade">Focal clade</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                  <div class="static-form-value"
-                       data-bind="text: nexml['^ot:focalCladeOTTTaxonName'] || 'None', attr:{'title': ('ottid:'+ nexml['^ot:focalClade'])}, css: viewModel.ticklers.GENERAL_METADATA">
-                    &nbsp;
-                  </div>
-            <!-- reuse some (not all) style and behavior for taxon search in synth-tree viewer -->
-            <div id="taxon-search-form" class="Xnavbar-search Xpull-right" autocomplete="off" style="Xdisplay: inline-block; position: relative;">
-                <input type="text" name="taxon-search" class="" style="width: 365px;"
-                    placeholder="Choose the smallest taxon that contains the ingroup..." autocomplete="off">
-                <!-- <input type="submit" style="" name="taxon-search-go" value="Go" onclick="return false;"/> -->
-                <!-- then show dropdown when results are ready... -->
-                <span style="color: #999; padding: 0 2px; font-size: 14px;">in</span>
-                <select style="margin-bottom: 0; width: auto;" name="taxon-search-context">
-                    {{ # generate our contextNames list based on newly fetched names
-                      try:
-                       for context_name in taxonSearchContextNames:
-                          if context_name == 'All life': }}
-                            <option selected="selected" value="{{= context_name }}">{{= context_name }}</option>
-                       {{ else: }}
-                            <option value="{{= context_name }}">{{= context_name }}</option>
-                       {{ pass }}
-                    {{ pass }}
-                    {{ except: }}
-                            <option selected="selected">ERROR loading context values</option>
-                       {{ pass }}
-                <!--
-                NOTE that the displayed OPTION values (confirmed as current via AJAX) are accepted
-                by the server, ie, there's no distinction between visible and occult values.
-                -->
-                </select>
-                <div class="">
-                    <ul id="search-results" class="dropdown-menu" role="menu">
-                        ...
-                    </ul>
-                </div>
-            </div>
-                  <input data-bind="value: nexml['^ot:focalClade'], event: { change: nudge.GENERAL_METADATA }, css: viewModel.ticklers.GENERAL_METADATA" type="hidden" id="ot_focalClade" placeholder="">
-                {{ else: }}
-                  <p class="static-form-value">
-                    <span data-bind="text: nexml['^ot:focalCladeOTTTaxonName'], attr:{'title': ('ottid:'+ nexml['^ot:focalClade'])}, css: viewModel.ticklers.GENERAL_METADATA">&nbsp;</span>
-                  </p>
-                {{ pass }}
-                </div>
-              </div>
-              <div class="control-group">
-                <label class="control-label">Tags</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                    <select id="study-tags" multiple="multiple" placeholder="Add tags"
-                            onchange="updateElementTags(this); nudge.GENERAL_METADATA();">
-                    </select>
-                {{ else: }}
-                    <!-- TODO: make all tags clickable (search in new window?) -->
-                    <div class="bootstrap-tagsinput"
-                         style="border: none; margin-bottom: 0; padding: 4px 0; display: none;"
-                         data-bind="visible: getTags(viewModel.nexml).length > 0">
-                    <!-- ko foreach: getTags( viewModel.nexml ) -->
-                        <span class="tag label label-info" data-bind="text:
-                            $data"></span>
-                    <!-- /ko -->
-                    </div>
-                    <p class="static-form-value" style="display: none;"
-                       data-bind="visible: getTags(viewModel.nexml).length === 0">
-                       <em>None</em>
-                    </p>
-                {{ pass }}
-
-                </div>
-              </div>
-
-              <div class="control-group">
-                <label class="control-label" for="ot_curatorName">Submitted by</label>
-                <div class="controls">
-                  <p class="static-form-value" data-bind="text: nexml['^ot:curatorName'].join(', ')"></p>
-                </div>
-              </div>
-
-              <div class="control-group">
-                <label class="control-label">Waiver or license</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT':
-                   # treat this as read-only once it's been chosen! }}
-                 <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && studyHasCC0Waiver( nexml ) -->
-                 <p class="static-form-value" data-bind="css:viewModel.ticklers.GENERAL_METADATA">
-                  <a target="_blank" href="http://creativecommons.org/publicdomain/zero/1.0/">
-                      <img alt="CC0 (opens a new window)" src="{{=URL('static','images/cc-zero.png')}}">
-                  </a>
-                 </p>
-                 <!-- /ko -->
-                 <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && !studyHasCC0Waiver( nexml ) -->
-                 <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && getStudyLicenseInfo( nexml ) -->
-                     <p class="static-form-value">
-                      <a target="_blank" href="#"
-                         data-bind="text: getStudyLicenseInfo( nexml )['@name'] || '???',
-                                    attr: {'href': getStudyLicenseInfo( nexml )['@href'] || '#'}">&nbsp;</a>
-                     </p>
-                     <!-- /ko -->
-                     <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && !getStudyLicenseInfo( nexml ) -->
-                     <p class="static-form-value">
-                      <em>None</em>
-                     </p>
-                     <div id="applying-cc0-details" Xclass="featured-label-child">
-                            <label for="agreed-to-CC0" class="featured-label" style="margin-top: 0px; padding-left: 20px; text-indent: -20px; width: 60%;">
-                                <input type="checkbox" id="agreed-to-CC0" name="cc0_agreement"
-                                       style="width: 20px;"
-                                       onclick="applyCC0Waiver(); return false;"/>I am an author, or can act on behalf of the authors, to apply a CC0 waiver to these data. By clicking this checkbox, I hereby release these data under the terms of the <a href="http://creativecommons.org/publicdomain/zero/1.0/" target="_blank">Creative Commons Zero (CC0) waiver</a>.
-                            </label>
-                     </div>
-                     <!-- /ko -->
-                 <!-- /ko -->
-                {{ else: }}
-                 <!-- ko if: studyHasCC0Waiver( nexml ) -->
-                 <p class="static-form-value">
-                  <a target="_blank" href="http://creativecommons.org/publicdomain/zero/1.0/">
-                      <img alt="CC0 (opens a new window)" src="{{=URL('static','images/cc-zero.png')}}">
-                  </a>
-                 </p>
-                 <!-- /ko -->
-                 <!-- ko if: !studyHasCC0Waiver( nexml ) -->
-                 <p class="static-form-value">
-                     <!-- ko if: getStudyLicenseInfo( nexml ) -->
-                      <a target="_blank" href="#"
-                         data-bind="text: getStudyLicenseInfo( nexml )['@name'] || '???',
-                                    attr: {'href': getStudyLicenseInfo( nexml )['@href'] || '#'}">&nbsp;</a>
-                     <!-- /ko -->
-                     <!-- ko if: !getStudyLicenseInfo( nexml ) -->
-                      <em>None</em>
-                     <!-- /ko -->
-                 </p>
-                 <!-- /ko -->
-                {{ pass }}
-                </div>
-              </div>
-
-              <div class="control-group">
-                <label class="control-label" for="ot_curatorName">Study ID</label>
-                <div class="controls">
-                  <p class="static-form-value" data-bind="text: nexml['^ot:studyId']"></p>
-                </div>
-              </div>
-
-              <!-- <div class="control-group">
-                <div class="controls">
-
-                  <p class="static-form-value interesting-value" data-bind="text: studyContributedToLatestSynthesis() ? (currentStudyVersionContributedToLatestSynthesis() ? 'This version was used to build the latest synthetic tree' : 'This study has changed since building the last synthetic tree.') : 'This study was not used in the latest synthesis.'"></p>
-
-                </div>
-
-              </div> -->
-
-              <div class="control-group">
-                <label class="control-label">Curator notes</label>
-                <div class="controls">
-                {{ if viewOrEdit == 'EDIT': }}
-                  <!-- markdown editor w/ preview option -->
-                    <ul class="nav nav-pills pull-right" style="margin-bottom: 4px;">
-                        <li><a target="_blank" href="https://help.github.com/articles/basic-writing-and-formatting-syntax/">Markdown help</a></li>
-                    </ul>
-                    <div class="btn-group" style="margin-bottom: 8px;">
-                      <button id="edit-comment-button" class="btn active" onclick="showStudyCommentEditor(); return false;">&nbsp; Edit (as Markdown) &nbsp;</button>
-                      <button id="preview-comment-button" class="btn" onclick="showStudyCommentPreview(); return false;">&nbsp; Preview (as HTML) &nbsp;</button>
-                    </div>
-<!--
-                    <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
--->
-                    <div id="comment-editor"><textarea data-bind="value: viewModel.nexml['^ot:comment'],
-                                                                  valueUpdate: ['afterkeydown', 'input'],
-                                                                  event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }"
-                                                       placeholder="Enter notes for viewers and other curators here (as markdown)."
-                                                       rows="8"
-                                                       class="input-block-level">?</textarea></div>
-                    <div id="comment-preview" class="rendered-comment" style="display: none;">
-                    </div>
-                {{ else: }}
-                  <!-- render existing comment as markdown -->
-                    <div class="rendered-comment" style="display: none;"
-                         data-bind="visible: $.trim(viewModel.nexml['^ot:comment']) !== '', html: viewModel['commentHTML']" >
-                       {comments appear here}
-                    </div>
-                    <p class="static-form-value" style="display: none;"
-                       data-bind="visible: $.trim(viewModel.nexml['^ot:comment']) === ''">
-                       <em>None</em>
-                    </p>
-                {{ pass }}
-
-                </div>
-              </div>
-
-            </form>
+            {MOVED TO POPUP}
 
            </div><!-- end of main column... -->
            <div class="span4"><!-- right col -->
@@ -637,9 +377,11 @@ body {
               <p data-bind="text: nexml['^ot:studyPublicationReference']"></p>
               <div class="control-group">
                  {{ if viewOrEdit == 'EDIT': }}
-                  <button id="full-metadata-button" class="btn btn-small pull-right">Edit study metadata</button>
+                  <button id="full-metadata-button" class="btn btn-small pull-right"
+                          onclick="showStudyMetadata(); return false;">Edit study metadata</button>
                  {{ else: }}
-                  <button id="full-metadata-button" class="btn btn-small pull-right">See all study metadata</button>
+                  <button id="full-metadata-button" class="btn btn-small pull-right"
+                          onclick="showStudyMetadata(); return false;">See all study metadata</button>
                  {{ pass }}
                <!-- ko if: getNormalizedStudyPublicationURL() !== '' -->
                 <a href="" target="_blank"
@@ -3268,3 +3010,287 @@ body {
     </div>
   </div><!-- /#full-screen-area -->
 </div>
+
+<!-- hidden template for gathering comments when saving the study -->
+<div class="modal hide fade modal-save-comments" id="study-metadata-popup" style="display: none;">
+    <div class="modal-header">
+      <a data-dismiss="modal" class="close">×</a>
+      <h3 id='dialog-heading'>
+          Study metadata <span style="color: #ccc;">& curator notes</span>
+      </h3>
+    </div>
+    <div class="modal-body">
+      <div class="row">
+
+           <div class="span"><!-- main column... -->
+            <ul class="suggestion-list"></ul>
+            <form class="form-horizontal wider-fields{{= (viewOrEdit == 'VIEW') and ' metadata-readonly' or '' }}">
+              <div class="control-group">
+                <label class="control-label" for="ot_studyPublicationReference">Publication reference</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                  <textarea data-bind="value: nexml['^ot:studyPublicationReference'], valueUpdate: ['afterkeydown', 'input'], event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }, css: viewModel.ticklers.GENERAL_METADATA" id="ot_studyPublicationReference" class="input-xlarge" style="height: 160px;" placeholder=""></textarea>
+                {{ else: }}
+                  <p class="static-form-value" data-bind="text: nexml['^ot:studyPublicationReference']"></p>
+                {{ pass }}
+                </div>
+              </div>
+              <div class="control-group">
+                <label class="control-label" for="ot_studyPublication">Publication DOI (or URL)</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                  <input data-bind="value: nexml['^ot:studyPublication']['@href'],
+                                    valueUpdate: ['afterkeydown', 'input'],
+                                    event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: validateAndTestDOI },
+                                    css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyPublication" class="input-xlarge" placeholder="">
+                  <button type="button" class="btn btn-info" onclick="lookUpDOI(); return false;">Look up DOI...</button>
+                {{ else: }}
+                  <p>
+                 <!-- ko if: getStudyPublicationLink() !== '' -->
+                      <span class="static-form-value" data-bind="html: getStudyPublicationLink()">&nbsp;</span>
+                 <!-- /ko -->
+                 <!-- ko if: getStudyPublicationLink() === '' -->
+                      <em>None</em>
+                 <!-- /ko -->
+                  </p>
+                {{ pass }}
+                </div>
+                <div class="controls" data-bind="if: viewModel.duplicateStudyIDs().length > 0">
+                    <p class="static-form-value interesting-value">
+                        There are other studies in Open Tree database with this DOI. Click the links below to see each one in a new browser window.
+                    </p>
+                    <ul class="static-form-value interesting-value" data-bind="foreach: viewModel.duplicateStudyIDs">
+                        <li><a href="#" target="_blank"
+                            data-bind="text: getViewURLFromStudyID($data), attr: {'href': getViewURLFromStudyID($data)}">&nbsp</a></li>
+                    </ul>
+                </div>
+              </div>
+              <div class="control-group">
+                <label class="control-label" for="ot_studyDataDeposit">Data deposit DOI/URL</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                  <input data-bind="value: nexml['^ot:dataDeposit']['@href'],
+                                    valueUpdate: ['afterkeydown', 'input'],
+                                    event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: formatDataDepositDOIAsURL },
+                                    css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyDataDeposit" class="input-xlarge" placeholder="">
+                {{ else: }}
+                  <p>
+                  <!-- ko if: getDataDepositMessage() !== '' -->
+                      <span class="static-form-value" data-bind="html: getDataDepositMessage()">&nbsp;</span>
+                 <!-- /ko -->
+                 <!-- ko if: getDataDepositMessage() === '' -->
+                      <em>None</em>
+                 <!-- /ko -->
+                  </p>
+                {{ pass }}
+                </div>
+              </div>
+              <div class="control-group">
+                <label class="control-label" for="ot_studyYear">Study Year</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                  <input data-bind="value: nexml['^ot:studyYear'], valueUpdate: ['afterkeydown', 'input'], event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }" type="text" id="ot_studyYear" class="input-mini" placeholder="">
+                {{ else: }}
+                  <p class="static-form-value" data-bind="text: nexml['^ot:studyYear']"></p>
+                {{ pass }}
+                </div>
+              </div>
+              <div class="control-group">
+                <label class="control-label" for="ot_focalClade">Focal clade</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                  <div class="static-form-value"
+                       data-bind="text: nexml['^ot:focalCladeOTTTaxonName'] || 'None', attr:{'title': ('ottid:'+ nexml['^ot:focalClade'])}, css: viewModel.ticklers.GENERAL_METADATA">
+                    &nbsp;
+                  </div>
+            <!-- reuse some (not all) style and behavior for taxon search in synth-tree viewer -->
+            <div id="taxon-search-form" class="Xnavbar-search Xpull-right" autocomplete="off" style="Xdisplay: inline-block; position: relative;">
+                <input type="text" name="taxon-search" class="" style="width: 365px;"
+                    placeholder="Choose the smallest taxon that contains the ingroup..." autocomplete="off">
+                <!-- <input type="submit" style="" name="taxon-search-go" value="Go" onclick="return false;"/> -->
+                <!-- then show dropdown when results are ready... -->
+                <span style="color: #999; padding: 0 2px; font-size: 14px;">in</span>
+                <select style="margin-bottom: 0; width: auto;" name="taxon-search-context">
+                    {{ # generate our contextNames list based on newly fetched names
+                      try:
+                       for context_name in taxonSearchContextNames:
+                          if context_name == 'All life': }}
+                            <option selected="selected" value="{{= context_name }}">{{= context_name }}</option>
+                       {{ else: }}
+                            <option value="{{= context_name }}">{{= context_name }}</option>
+                       {{ pass }}
+                    {{ pass }}
+                    {{ except: }}
+                            <option selected="selected">ERROR loading context values</option>
+                       {{ pass }}
+                <!--
+                NOTE that the displayed OPTION values (confirmed as current via AJAX) are accepted
+                by the server, ie, there's no distinction between visible and occult values.
+                -->
+                </select>
+                <div class="">
+                    <ul id="search-results" class="dropdown-menu" role="menu">
+                        ...
+                    </ul>
+                </div>
+            </div>
+                  <input data-bind="value: nexml['^ot:focalClade'], event: { change: nudge.GENERAL_METADATA }, css: viewModel.ticklers.GENERAL_METADATA" type="hidden" id="ot_focalClade" placeholder="">
+                {{ else: }}
+                  <p class="static-form-value">
+                    <span data-bind="text: nexml['^ot:focalCladeOTTTaxonName'], attr:{'title': ('ottid:'+ nexml['^ot:focalClade'])}, css: viewModel.ticklers.GENERAL_METADATA">&nbsp;</span>
+                  </p>
+                {{ pass }}
+                </div>
+              </div>
+              <div class="control-group">
+                <label class="control-label">Tags</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                    <select id="study-tags" multiple="multiple" placeholder="Add tags"
+                            onchange="updateElementTags(this); nudge.GENERAL_METADATA();">
+                    </select>
+                {{ else: }}
+                    <!-- TODO: make all tags clickable (search in new window?) -->
+                    <div class="bootstrap-tagsinput"
+                         style="border: none; margin-bottom: 0; padding: 4px 0; display: none;"
+                         data-bind="visible: getTags(viewModel.nexml).length > 0">
+                    <!-- ko foreach: getTags( viewModel.nexml ) -->
+                        <span class="tag label label-info" data-bind="text:
+                            $data"></span>
+                    <!-- /ko -->
+                    </div>
+                    <p class="static-form-value" style="display: none;"
+                       data-bind="visible: getTags(viewModel.nexml).length === 0">
+                       <em>None</em>
+                    </p>
+                {{ pass }}
+
+                </div>
+              </div>
+
+              <div class="control-group">
+                <label class="control-label" for="ot_curatorName">Submitted by</label>
+                <div class="controls">
+                  <p class="static-form-value" data-bind="text: nexml['^ot:curatorName'].join(', ')"></p>
+                </div>
+              </div>
+
+              <div class="control-group">
+                <label class="control-label">Waiver or license</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT':
+                   # treat this as read-only once it's been chosen! }}
+                 <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && studyHasCC0Waiver( nexml ) -->
+                 <p class="static-form-value" data-bind="css:viewModel.ticklers.GENERAL_METADATA">
+                  <a target="_blank" href="http://creativecommons.org/publicdomain/zero/1.0/">
+                      <img alt="CC0 (opens a new window)" src="{{=URL('static','images/cc-zero.png')}}">
+                  </a>
+                 </p>
+                 <!-- /ko -->
+                 <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && !studyHasCC0Waiver( nexml ) -->
+                 <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && getStudyLicenseInfo( nexml ) -->
+                     <p class="static-form-value">
+                      <a target="_blank" href="#"
+                         data-bind="text: getStudyLicenseInfo( nexml )['@name'] || '???',
+                                    attr: {'href': getStudyLicenseInfo( nexml )['@href'] || '#'}">&nbsp;</a>
+                     </p>
+                     <!-- /ko -->
+                     <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && !getStudyLicenseInfo( nexml ) -->
+                     <p class="static-form-value">
+                      <em>None</em>
+                     </p>
+                     <div id="applying-cc0-details" Xclass="featured-label-child">
+                            <label for="agreed-to-CC0" class="featured-label" style="margin-top: 0px; padding-left: 20px; text-indent: -20px; width: 60%;">
+                                <input type="checkbox" id="agreed-to-CC0" name="cc0_agreement"
+                                       style="width: 20px;"
+                                       onclick="applyCC0Waiver(); return false;"/>I am an author, or can act on behalf of the authors, to apply a CC0 waiver to these data. By clicking this checkbox, I hereby release these data under the terms of the <a href="http://creativecommons.org/publicdomain/zero/1.0/" target="_blank">Creative Commons Zero (CC0) waiver</a>.
+                            </label>
+                     </div>
+                     <!-- /ko -->
+                 <!-- /ko -->
+                {{ else: }}
+                 <!-- ko if: studyHasCC0Waiver( nexml ) -->
+                 <p class="static-form-value">
+                  <a target="_blank" href="http://creativecommons.org/publicdomain/zero/1.0/">
+                      <img alt="CC0 (opens a new window)" src="{{=URL('static','images/cc-zero.png')}}">
+                  </a>
+                 </p>
+                 <!-- /ko -->
+                 <!-- ko if: !studyHasCC0Waiver( nexml ) -->
+                 <p class="static-form-value">
+                     <!-- ko if: getStudyLicenseInfo( nexml ) -->
+                      <a target="_blank" href="#"
+                         data-bind="text: getStudyLicenseInfo( nexml )['@name'] || '???',
+                                    attr: {'href': getStudyLicenseInfo( nexml )['@href'] || '#'}">&nbsp;</a>
+                     <!-- /ko -->
+                     <!-- ko if: !getStudyLicenseInfo( nexml ) -->
+                      <em>None</em>
+                     <!-- /ko -->
+                 </p>
+                 <!-- /ko -->
+                {{ pass }}
+                </div>
+              </div>
+
+              <div class="control-group">
+                <label class="control-label" for="ot_curatorName">Study ID</label>
+                <div class="controls">
+                  <p class="static-form-value" data-bind="text: nexml['^ot:studyId']"></p>
+                </div>
+              </div>
+
+              <!-- <div class="control-group">
+                <div class="controls">
+
+                  <p class="static-form-value interesting-value" data-bind="text: studyContributedToLatestSynthesis() ? (currentStudyVersionContributedToLatestSynthesis() ? 'This version was used to build the latest synthetic tree' : 'This study has changed since building the last synthetic tree.') : 'This study was not used in the latest synthesis.'"></p>
+
+                </div>
+
+              </div> -->
+
+              <div class="control-group">
+                <label class="control-label">Curator notes</label>
+                <div class="controls">
+                {{ if viewOrEdit == 'EDIT': }}
+                  <!-- markdown editor w/ preview option -->
+                    <ul class="nav nav-pills pull-right" style="margin-bottom: 4px;">
+                        <li><a target="_blank" href="https://help.github.com/articles/basic-writing-and-formatting-syntax/">Markdown help</a></li>
+                    </ul>
+                    <div class="btn-group" style="margin-bottom: 8px;">
+                      <button id="edit-comment-button" class="btn active" onclick="showStudyCommentEditor(); return false;">&nbsp; Edit (as Markdown) &nbsp;</button>
+                      <button id="preview-comment-button" class="btn" onclick="showStudyCommentPreview(); return false;">&nbsp; Preview (as HTML) &nbsp;</button>
+                    </div>
+<!--
+                    <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>
+-->
+                    <div id="comment-editor"><textarea data-bind="value: viewModel.nexml['^ot:comment'],
+                                                                  valueUpdate: ['afterkeydown', 'input'],
+                                                                  event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA }"
+                                                       placeholder="Enter notes for viewers and other curators here (as markdown)."
+                                                       rows="8"
+                                                       class="input-block-level">?</textarea></div>
+                    <div id="comment-preview" class="rendered-comment" style="display: none;">
+                    </div>
+                {{ else: }}
+                  <!-- render existing comment as markdown -->
+                    <div class="rendered-comment" style="display: none;"
+                         data-bind="visible: $.trim(viewModel.nexml['^ot:comment']) !== '', html: viewModel['commentHTML']" >
+                       {comments appear here}
+                    </div>
+                    <p class="static-form-value" style="display: none;"
+                       data-bind="visible: $.trim(viewModel.nexml['^ot:comment']) === ''">
+                       <em>None</em>
+                    </p>
+                {{ pass }}
+
+                </div>
+              </div>
+
+            </form>
+
+           </div><!-- end of main column... -->
+
+      </div><!-- div.row -->
+    </div><!-- div.modal-body -->
+</div><!-- div.modal -->
+

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -313,7 +313,6 @@ body {
 
           <div class="tab-pane" id="Home">
            <div class="span8"><!-- main column -->
-            <ul class="suggestion-list"></ul>
 
             <!-- read-only display of core metadata -->
             <div id="core-metadata-pane">
@@ -361,6 +360,8 @@ body {
                 </div>
               </div>
             </div>
+
+            <ul class="suggestion-list" style="margin-bottom: -2px;"></ul>
 
             <div style="margin-bottom: 100px; clear: right; padding-top: 1em;">
               <div class="navbar">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3022,9 +3022,9 @@ body {
                                     css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyPublication" class="input-xlarge" placeholder="">
                   <button type="button" class="btn btn-info" onclick="lookUpDOI(); return false;">Look up DOI...</button>
                 {{ else: }}
-                  <p>
+                  <p class="static-form-value">
                  <!-- ko if: getStudyPublicationLink() !== '' -->
-                      <span class="static-form-value" data-bind="html: getStudyPublicationLink()">&nbsp;</span>
+                      <span data-bind="html: getStudyPublicationLink()">&nbsp;</span>
                  <!-- /ko -->
                  <!-- ko if: getStudyPublicationLink() === '' -->
                       <em>None</em>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -258,8 +258,8 @@ body {
     <!-- Appears only during creation..? then replaced by status
       <li><a href="#">Import</a></li>
     -->
-      <li><a href="#Metadata" data-toggle="tab">Metadata <span class="badge badge-important" style="display: none;">?</span></a></li>
-      <li><a href="#Trees" data-toggle="tab">Trees <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Trees" data-toggle="tab">Home <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Metadata" data-toggle="tab">XXX-Metadata <span class="badge badge-important" style="display: none;">?</span></a></li>
       <li><a href="#Files" data-toggle="tab">Files <span class="badge badge-important" style="display: none;">?</span></a></li>
       <li><a href="#OTU-Mapping" data-toggle="tab">OTU Mapping <span class="badge badge-important" style="display: none;">?</span></a></li>
     <!--
@@ -312,7 +312,7 @@ body {
 <div class="row">
     <div class="tab-content">
 
-          <div class="tab-pane" id="Metadata">
+          <div class="tab-pane" id="XXX-Metadata">
            <div class="span8"><!-- main column... -->
             <ul class="suggestion-list"></ul>
             <form class="form-horizontal wider-fields{{= (viewOrEdit == 'VIEW') and ' metadata-readonly' or '' }}">
@@ -336,9 +336,9 @@ body {
                                     css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyPublication" class="input-xlarge" placeholder="">
                   <button type="button" class="btn btn-info" onclick="lookUpDOI(); return false;">Look up DOI...</button>
                 {{ else: }}
-                  <p class="static-form-value">
+                  <p>
                  <!-- ko if: getStudyPublicationLink() !== '' -->
-                      <span data-bind="html: getStudyPublicationLink()">&nbsp;</span>
+                      <span class="static-form-value" data-bind="html: getStudyPublicationLink()">&nbsp;</span>
                  <!-- /ko -->
                  <!-- ko if: getStudyPublicationLink() === '' -->
                       <em>None</em>
@@ -365,9 +365,9 @@ body {
                                     event: { keyup: nudge.GENERAL_METADATA, change: nudge.GENERAL_METADATA, blur: formatDataDepositDOIAsURL },
                                     css: viewModel.ticklers.GENERAL_METADATA" type="text" id="ot_studyDataDeposit" class="input-xlarge" placeholder="">
                 {{ else: }}
-                  <p class="static-form-value">
+                  <p>
                   <!-- ko if: getDataDepositMessage() !== '' -->
-                      <span data-bind="html: getDataDepositMessage()">&nbsp;</span>
+                      <span class="static-form-value" data-bind="html: getDataDepositMessage()">&nbsp;</span>
                  <!-- /ko -->
                  <!-- ko if: getDataDepositMessage() === '' -->
                       <em>None</em>
@@ -631,10 +631,57 @@ body {
           <div class="tab-pane" id="Trees">
            <div class="span8"><!-- main column -->
             <ul class="suggestion-list"></ul>
-            <div style="margin-bottom: 100px;">
+
+            <!-- read-only display of core metadata -->
+            <div id="core-metadata-pane">
+              <p data-bind="text: nexml['^ot:studyPublicationReference']"></p>
+              <div class="control-group">
+                 {{ if viewOrEdit == 'EDIT': }}
+                  <button id="full-metadata-button" class="btn btn-small pull-right">Edit study metadata</button>
+                 {{ else: }}
+                  <button id="full-metadata-button" class="btn btn-small pull-right">See all study metadata</button>
+                 {{ pass }}
+               <!-- ko if: getNormalizedStudyPublicationURL() !== '' -->
+                <a href="" target="_blank"
+                   data-bind="attr: {'href': getNormalizedStudyPublicationURL()}">Link to publication</a>
+               <!-- /ko -->
+               <!-- ko if: getNormalizedStudyPublicationURL() === '' -->
+                <span style="color: #999; text-decoration: line-through;">No link to publication</span>
+               <!-- /ko -->
+               |
+               <!-- ko if: getNormalizedDataDepositURL() !== '' -->
+                <a href="" target="_blank"
+                   data-bind="attr: {'href': getNormalizedDataDepositURL()}">Link to data package</a>
+               <!-- /ko -->
+               <!-- ko if: getNormalizedDataDepositURL() === '' -->
+                <span style="color: #999; text-decoration: line-through;">No link to data package</span>
+               <!-- /ko -->
+
+                <div class="controls" data-bind="if: viewModel.duplicateStudyIDs().length > 0">
+                    <p class="static-form-value interesting-value">
+                        There are other studies in Open Tree database with this DOI. Click the links below to see each one in a new browser window.
+                    </p>
+                    <ul class="static-form-value interesting-value" data-bind="foreach: viewModel.duplicateStudyIDs">
+                        <li><a href="#" target="_blank"
+                            data-bind="text: getViewURLFromStudyID($data), attr: {'href': getViewURLFromStudyID($data)}">&nbsp</a></li>
+                    </ul>
+                </div>
+              </div>
+              <!-- render any existing curator notes as HTML (else hide)-->
+              <div data-bind="visible: $.trim(viewModel.nexml['^ot:comment']) !== ''">
+                <strong>Curator notes: </strong>
+                <div class="rendered-comment"
+                     data-bind="html: viewModel['commentHTML']" >
+                   {comments appear here}
+                </div>
+              </div>
+            </div>
+
+            <div style="margin-bottom: 100px; clear: right; padding-top: 1em;">
               <div class="navbar">
                <div class="navbar-inner">
                 <form class="navbar-search pull-left">
+                    <h4 class="pull-left" style="margin: 5px 1em 0 0">Trees in this study</h4>
                     <input type="text" id="tree-list-filter" class="search-query" placeholder="Filter by name or ingroup clade"
                            data-bind="value: viewModel.listFilters.TREES.match, valueUpdate: ['afterkeydown', 'input']">
                 </form>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -258,10 +258,7 @@ body {
     <!-- Appears only during creation..? then replaced by status
       <li><a href="#">Import</a></li>
     -->
-      <li><a href="#Trees" data-toggle="tab">Home <span class="badge badge-important" style="display: none;">?</span></a></li>
-    <!--
-    -->
-      <li><a href="#Metadata" data-toggle="tab">Metadata <span class="badge badge-important" style="display: none;">?</span></a></li>
+      <li><a href="#Home" data-toggle="tab">Home <span class="badge badge-important" style="display: none;">?</span></a></li>
       <li><a href="#Files" data-toggle="tab">Files <span class="badge badge-important" style="display: none;">?</span></a></li>
       <li><a href="#OTU-Mapping" data-toggle="tab">OTU Mapping <span class="badge badge-important" style="display: none;">?</span></a></li>
     <!--
@@ -313,50 +310,8 @@ body {
 
 <div class="row">
     <div class="tab-content">
-          <div class="tab-pane" id="Metadata">
 
-           <div class="span8"><!-- main column... -->
-            <ul class="suggestion-list"></ul>
-            {MOVED TO POPUP}
-
-           </div><!-- end of main column... -->
-           <div class="span4"><!-- right col -->
-
-            <button class="help-toggle" style="display: none;">
-                Show help for this tab <i class="icon-chevron-down Xicon-white"></i>
-            </button>
-            <div class="help-box">
-              <button class="help-toggle">
-                  Hide <i class="icon-chevron-up Xicon-white"></i>
-              </button>
-            </div>
-            <div class="well" style="clear: right;">
-                <h4 style="margin-top: 0;">Download</h4>
-
-                <p>
-                You can download this study in
-                <a href="#" onclick="showDownloadFormatDetails(); return false;"
-                   title="Click for details on how these differ">
-                    several formats</a>:
-                </p>
-                <div class="btn-group" style="position: relative; top: -5px; margin-bottom: 10px;">
-                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '?output_nexml2json=1.2' }}" target="_blank">NexSON</a>
-                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '.nexml' }}" target="_blank">NeXML</a>
-                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '.nex' }}" target="_blank">NEXUS</a>
-                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '.tre' }}" target="_blank">Newick</a>
-                </div>
-
-                <p>
-                You can also use the <strong>
-                <a href="https://github.com/OpenTreeOfLife/germinator/wiki/Open-Tree-of-Life-Web-APIs" target="_blank">Open Tree API</a></strong> to retrieve study data.
-                </p>
-
-            </div>
-
-           </div><!-- end of right col -->
-          </div><!-- /.tab-pane -->
-
-          <div class="tab-pane" id="Trees">
+          <div class="tab-pane" id="Home">
            <div class="span8"><!-- main column -->
             <ul class="suggestion-list"></ul>
 
@@ -623,6 +578,29 @@ body {
         {{ pass }}
             </div>
 
+            <div class="well" style="clear: right;">
+                <h4 style="margin-top: 0;">Download</h4>
+
+                <p>
+                You can download this study in
+                <a href="#" onclick="showDownloadFormatDetails(); return false;"
+                   title="Click for details on how these differ">
+                    several formats</a>:
+                </p>
+                <div class="btn-group" style="position: relative; top: -5px; margin-bottom: 10px;">
+                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '?output_nexml2json=1.2' }}" target="_blank">NexSON</a>
+                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '.nexml' }}" target="_blank">NeXML</a>
+                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '.nex' }}" target="_blank">NEXUS</a>
+                    <a class="btn btn-small" href="{{= API_load_study_GET_url.replace('{STUDY_ID}', studyID) + '.tre' }}" target="_blank">Newick</a>
+                </div>
+
+                <p>
+                You can also use the <strong>
+                <a href="https://github.com/OpenTreeOfLife/germinator/wiki/Open-Tree-of-Life-Web-APIs" target="_blank">Open Tree API</a></strong> to retrieve study data.
+                </p>
+
+            </div>
+
         {{ if viewOrEdit == 'EDIT': }}
             <div class="well" style="clear: right;">
                 <h4 style="margin-top: 0;">Add a tree to this study</h4>
@@ -719,6 +697,7 @@ body {
                 </form>
             </div>
         {{ pass }}
+
 
            </div><!-- end of right col -->
           </div><!-- /.tab-pane -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -329,18 +329,6 @@ body {
               <button class="help-toggle">
                   Hide <i class="icon-chevron-up Xicon-white"></i>
               </button>
-              <p>
-                Each tab in this tool manages a different aspect of the
-                study data. Prompts&mdash;they look like
-                <span class="badge badge-important" style="">2</span>&mdash;identify
-                aspects that are incomplete.
-              </p>
-              <p>
-                <strong>Metadata</strong> holds information that
-                identifies this study and makes it easy to find, such as
-                standard publication references, DOIs, and
-                free-form tags.
-              </p>
             </div>
             <div class="well" style="clear: right;">
                 <h4 style="margin-top: 0;">Download</h4>
@@ -374,7 +362,7 @@ body {
 
             <!-- read-only display of core metadata -->
             <div id="core-metadata-pane">
-              <p data-bind="text: nexml['^ot:studyPublicationReference']"></p>
+              <p data-bind="visible: viewModel.ticklers.GENERAL_METADATA(), text: nexml['^ot:studyPublicationReference']"></p>
               <div class="control-group">
                  {{ if viewOrEdit == 'EDIT': }}
                   <button id="full-metadata-button" class="btn btn-small pull-right"
@@ -383,19 +371,19 @@ body {
                   <button id="full-metadata-button" class="btn btn-small pull-right"
                           onclick="showStudyMetadata(); return false;">See all study metadata</button>
                  {{ pass }}
-               <!-- ko if: getNormalizedStudyPublicationURL() !== '' -->
+               <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && getNormalizedStudyPublicationURL() !== '' -->
                 <a href="" target="_blank"
-                   data-bind="attr: {'href': getNormalizedStudyPublicationURL()}">Link to publication</a>
+                   data-bind="visible: viewModel.ticklers.GENERAL_METADATA(), attr: {'href': getNormalizedStudyPublicationURL()}">Link to publication</a>
                <!-- /ko -->
-               <!-- ko if: getNormalizedStudyPublicationURL() === '' -->
+               <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && getNormalizedStudyPublicationURL() === '' -->
                 <span style="color: #999; text-decoration: line-through;">No link to publication</span>
                <!-- /ko -->
                |
-               <!-- ko if: getNormalizedDataDepositURL() !== '' -->
+               <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && getNormalizedDataDepositURL() !== '' -->
                 <a href="" target="_blank"
-                   data-bind="attr: {'href': getNormalizedDataDepositURL()}">Link to data package</a>
+                   data-bind="visible: viewModel.ticklers.GENERAL_METADATA(), attr: {'href': getNormalizedDataDepositURL()}">Link to data package</a>
                <!-- /ko -->
-               <!-- ko if: getNormalizedDataDepositURL() === '' -->
+               <!-- ko if: viewModel.ticklers.GENERAL_METADATA() && getNormalizedDataDepositURL() === '' -->
                 <span style="color: #999; text-decoration: line-through;">No link to data package</span>
                <!-- /ko -->
 
@@ -410,10 +398,10 @@ body {
                 </div>
               </div>
               <!-- render any existing curator notes as HTML (else hide)-->
-              <div data-bind="visible: $.trim(viewModel.nexml['^ot:comment']) !== ''">
+              <div data-bind="visible: viewModel.ticklers.GENERAL_METADATA() && $.trim(viewModel.nexml['^ot:comment']) !== ''">
                 <strong>Curator notes: </strong>
                 <div class="rendered-comment"
-                     data-bind="html: viewModel['commentHTML']" >
+                     data-bind="visible: viewModel.ticklers.GENERAL_METADATA(), html: viewModel['commentHTML']" >
                    {comments appear here}
                 </div>
               </div>
@@ -595,8 +583,18 @@ body {
                   Hide <i class="icon-chevron-up Xicon-white"></i>
               </button>
               <p>
-                <strong>Trees</strong> lists the phylogenetic
-                trees in the current study.
+                Each tab in this tool manages a different aspect of the
+                study data. Prompts&mdash;they look like
+                <span class="badge badge-important" style="">2</span>&mdash;identify
+                aspects that are incomplete.
+              </p>
+              <p>
+                The <strong>Home</strong> tab shows metadata and lists the
+                phylogenetic trees in the current study. Metadata is
+                information that identifies this study and makes it easy to
+                find, such as standard publication references, DOIs, and
+                free-form tags. You can also add curator notes that will appear
+                on this tab.
               </p>
         {{ if viewOrEdit == 'EDIT': }}
               <p>
@@ -3036,7 +3034,7 @@ body {
                 </div>
               </div>
               <div class="control-group">
-                <label class="control-label" for="ot_studyPublication">Publication DOI (or URL)</label>
+                <label class="control-label" for="ot_studyPublication">Publication DOI/URL</label>
                 <div class="controls">
                 {{ if viewOrEdit == 'EDIT': }}
                   <input data-bind="value: nexml['^ot:studyPublication']['@href'],
@@ -3257,8 +3255,8 @@ body {
                         <li><a target="_blank" href="https://help.github.com/articles/basic-writing-and-formatting-syntax/">Markdown help</a></li>
                     </ul>
                     <div class="btn-group" style="margin-bottom: 8px;">
-                      <button id="edit-comment-button" class="btn active" onclick="showStudyCommentEditor(); return false;">&nbsp; Edit (as Markdown) &nbsp;</button>
-                      <button id="preview-comment-button" class="btn" onclick="showStudyCommentPreview(); return false;">&nbsp; Preview (as HTML) &nbsp;</button>
+                      <button id="edit-comment-button" class="btn active" onclick="showStudyCommentEditor(); return false;">&nbsp; Edit (Markdown) &nbsp;</button>
+                      <button id="preview-comment-button" class="btn" onclick="showStudyCommentPreview(); return false;">&nbsp; Preview (HTML) &nbsp;</button>
                     </div>
 <!--
                     <textarea id="save-comment-more-lines" class="input-block-level" rows="4" placeholder="Add more details and background as needed."></textarea>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -857,8 +857,7 @@ body {
                 <strong>Files</strong> is a list of optional supporting files.
                 These  might include alignments, files used for inference (e.g.
                 a BEAST XML file or MrBayes block), or lists of bootstrap trees.
-                Tree
-                data imported in the <strong>Trees</strong> tab also appears
+                Tree data imported in the <strong>Home</strong> tab also appears
                 here in its original form.
               </p>
               <p>
@@ -874,7 +873,7 @@ body {
                 These  might include alignments, files used for inference (e.g.
                 a BEAST XML file or MrBayes block), or lists of bootstrap trees.
                 Tree data imported in the
-                <strong>Trees</strong> tab also appears here in its original
+                <strong>Home</strong> tab also appears here in its original
                 form.
               </p>
               <p>


### PR DESCRIPTION
This branch addresses #1063 :
 - consolidates Metadata and Trees tabs into a new Home tab; 
 - moves Metadata viewing/editing to a new popup;
 - shows validation warnings in their best new context; and
 - updates all tab-navigation and browser-history logic to match.

This is [working now on **devtree**](https://devtree.opentreeoflife.org/curator/study/view/ot_1164), please take a look and comment here.