### PR TITLE
Migrate OAuth app to GitHub app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ smasher/feed/*/in
 smasher/feed/*/out
 *.pem
 deploy/janrain.key
-deploy/GITHUB_CLIENT_SECRET
+GITHUB_CLIENT_SECRET
+GITHUB_APP_PRIVATE_KEY_PEM
 smasher/lib/json-simple-1.1.1.jar
 deploy/setup/CONFIG

--- a/curator/private/config.example
+++ b/curator/private/config.example
@@ -21,12 +21,18 @@ maintenance_notice = Study creation and editing are disabled while we upgrade to
 ## upcoming_maintenance_notice = Note that we've scheduled an upgrade for Saturday...
 
 [apis]
-# These values can be obtained by registering your instance as an
-# application with GitHub, at https://github.com/settings/applications/new
+# Settings for a registered app on GitHub, for example on devtree:
+# <https://github.com/settings/apps/open-tree-curation-tool-dev>
+github_app_id = YOUR_APP_ID_HERE
 github_client_id = YOUR_CLIENT_ID_HERE
 github_redirect_uri = YOUR_REDIRECT_URI_HERE
 # DON'T INCLUDE 'github_client_secret' value here. For better security, this is
 # loaded from a separate file and added to config data on-the-fly.
+#
+# github_app_installation_id can be found from the installing organization's page, e.g.
+# <https://github.com/organizations/OpenTreeOfLife/settings/installations>
+# (the installation ID is in the URL of the Configure button here)
+github_app_installation_id = YOUR_APP_INSTALLATION_ID_HERE
 
 # List public-facing base URL for supporting data services
 # (NOTE that these are used by both server- and client-side code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 python-dateutil==2.2
 locket==0.1.1
 bleach
+jwcrypto
+python_jwt

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -9,7 +9,9 @@ import bleach
 from bleach.sanitizer import Cleaner
 from datetime import datetime
 import json
+from opentreewebapputil import fetch_github_app_auth_token
 from pprint import pprint
+
 
 
 def error(): raise HTTP(404)
@@ -376,7 +378,7 @@ def index():
         # Examine the comment metadata (if any) to get the best display name
         # and URL for its author. Guests should appear here as the name and
         # email address they entered when creating a comment, rather than the
-        # 'opentreeapi' bot user.
+        # GitHub app (bot).
         #
         # Default values are what we can fetch from the issues API
         author_display_name = comment['user']['login']
@@ -643,25 +645,25 @@ def index():
 # Perform basic CRUD for local comments, using GitHub Issues API
 #
 GH_BASE_URL = 'https://api.github.com'
-oauth_token_path = os.path.expanduser('~/.ssh/OPENTREEAPI_OAUTH_TOKEN')
-try:
-    OPENTREEAPI_AUTH_TOKEN = open(oauth_token_path).read().strip()
-except:
-    OPENTREEAPI_AUTH_TOKEN = ''
-    print("OAuth token (%s) not found!" % oauth_token_path)
 
 # if the current user is logged in, use their auth token instead
 USER_AUTH_TOKEN = auth.user and auth.user.github_auth_token or None
 
 # Specify the media-type from GitHub, to freeze v3 API responses and get
 # the comment body as markdown (vs. plaintext or HTML)
-PREFERRED_MEDIA_TYPE = 'application/vnd.github.v3.raw+json'
+PREFERRED_MEDIA_TYPE = 'application/vnd.github.v3.raw+json, application/vnd.github.machine-man-preview+json'
 # to get markdown AND html body, use 'application/vnd.github.v3.full+json'
 
 GH_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
-GH_GET_HEADERS = {'Authorization': ('token %s' % (USER_AUTH_TOKEN or OPENTREEAPI_AUTH_TOKEN)),
+if USER_AUTH_TOKEN:
+    auth_header_value = 'token %s' % USER_AUTH_TOKEN
+else:
+    GITHUB_APP_INSTALLATION_TOKEN = fetch_github_app_auth_token(request)
+    auth_header_value = 'token %s' % GITHUB_APP_INSTALLATION_TOKEN
+
+GH_GET_HEADERS = {'Authorization': auth_header_value,
                   'Accept': PREFERRED_MEDIA_TYPE}
-GH_POST_HEADERS = {'Authorization': ('token %s' % (USER_AUTH_TOKEN or OPENTREEAPI_AUTH_TOKEN)),
+GH_POST_HEADERS = {'Authorization': auth_header_value,
                    'Content-Type': 'application/json',
                    'Accept': PREFERRED_MEDIA_TYPE}
 

--- a/webapp/models/db.py
+++ b/webapp/models/db.py
@@ -205,14 +205,6 @@ class GitHubAccount(OAuthAccount):
 
         return dict(auth_user_fields)
 
-# add our GitHub app's private key from a separate file (kept out of source repo)
-# NOTE that we'll load and stash private keys in .pem format, to be extracted later
-if os.path.isfile("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application):
-    private_key_pem = open("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application).read().strip()
-    conf.set("apis", "github_app_private_key", private_key_pem)
-else:
-    conf.set("apis", "github_app_private_key", "PRIVATE-KEY PEM NOT FOUND")
-
 # use the class above to build a new login form
 auth.settings.login_form=GitHubAccount()
 

--- a/webapp/models/db.py
+++ b/webapp/models/db.py
@@ -205,6 +205,13 @@ class GitHubAccount(OAuthAccount):
 
         return dict(auth_user_fields)
 
+# add our GitHub app's private key from a separate file (kept out of source repo)
+# NOTE that we'll load and stash private keys in .pem format, to be extracted later
+if os.path.isfile("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application):
+    private_key_pem = open("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application).read().strip()
+    conf.set("apis", "github_app_private_key", private_key_pem)
+else:
+    conf.set("apis", "github_app_private_key", "PRIVATE-KEY PEM NOT FOUND")
 
 # use the class above to build a new login form
 auth.settings.login_form=GitHubAccount()

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -161,6 +161,61 @@ def get_user_login():
     # no name or id found (this should never happen)
     return 'UNKNOWN'
 
+def fetch_github_app_auth_token(request):
+    # fetch a new token, or confirm that a known token is still current (or replace it)
+    # see https://developer.github.com/v3/apps/#create-a-new-installation-token
+    # TODO: include 'repository_ids' "feedback" (?)
+
+    # build a new JWT, since they expire
+    import python_jwt as jwt, jwcrypto.jwk as jwk, datetime, requests
+    app_name = request.application
+    if (app_name == 'curator'):
+        pass
+    else: # 'webapp' or 'opentree' (aliases)
+        pass
+    #key = jwk.JWK.generate(kty='RSA', size=2048)
+    conf = get_conf(request)
+    try:
+        github_app_id = conf.get("apis", "github_app_id")
+    except:
+        raise Exception("[apis] github_app_id not found in config!")
+
+    try:
+        app_installation_id = conf.get("apis", "github_app_installation_id")
+    except:
+        raise Exception("[apis] github_app_installation_id not found in config!")
+
+    # load our GitHub app's private key from a separate file (kept out of source repo)
+    if os.path.isfile("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application):
+        try:
+            private_key_pem = open("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application).read().strip()
+            private_key = jwk.JWK.from_pem(private_key_pem)
+            #key_json = private_key.export(private_key=True)
+        except:
+            raise Exception("Invalid private-key .pem!")
+    else:
+        raise Exception("Private-key .pem file not found!")
+
+    payload = {
+        # issued at time
+        'iat': datetime.timedelta(minutes=0),
+        # JWT expiration time (10 min max)
+        'exp': datetime.timedelta(minutes=10),
+        # issuer? (GitHub app identifier)
+        'iss': github_app_id,
+    }
+    app_jwt = jwt.generate_jwt(payload, private_key, 'RS256', datetime.timedelta(minutes=5))
+    # use this JWT to request an auth token for the current GitHub app (bot)
+    resp = requests.post( ("https://api.github.com/app/installations/%s/access_tokens" % app_installation_id),
+                          headers={'Authorization': ('Bearer %s' % app_jwt),
+                                   'Accept': "application/vnd.github.machine-man-preview+json"})
+    resp_json = resp.json()
+    try:
+        new_token = resp_json.get("token")
+    except:
+        raise Exception("Installation token not found in JSON response!")
+    return new_token
+
 def get_domain_banner_text(request):
     # Add an optional CSS banner to indicate a test domain, or none if
     # we're on a production server.

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -186,9 +186,9 @@ def fetch_github_app_auth_token(request):
         raise Exception("[apis] github_app_installation_id not found in config!")
 
     # load our GitHub app's private key from a separate file (kept out of source repo)
-    if os.path.isfile("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application):
+    if os.path.isfile("applications/%s/private/GITHUB_APP_PRIVATE_KEY_PEM" % request.application):
         try:
-            private_key_pem = open("applications/%s/private/TREE_EXPLORER_PRIVATE_KEY_PEM" % request.application).read().strip()
+            private_key_pem = open("applications/%s/private/GITHUB_APP_PRIVATE_KEY_PEM" % request.application).read().strip()
             private_key = jwk.JWK.from_pem(private_key_pem)
             #key_json = private_key.export(private_key=True)
         except:

--- a/webapp/private/config.example
+++ b/webapp/private/config.example
@@ -13,12 +13,18 @@ secure_sessions_with_HTTPS = false
 #study_to_status_script = /usr/share/open-tree/avatol_nexsons/nexson2treemach/study_nexson_to_status_html.py
 
 [apis]
-# These values can be obtained by registering your instance as an
-# application with GitHub, at https://github.com/settings/applications/new
+# Settings for a registered app on GitHub, for example on devtree:
+# <https://github.com/settings/apps/open-tree-tree-explorer-dev>
+github_app_id = YOUR_APP_ID_HERE
 github_client_id = YOUR_CLIENT_ID_HERE
 github_redirect_uri = YOUR_REDIRECT_URI_HERE
 # DON'T INCLUDE 'github_client_secret' value here. For better security, this is
 # loaded from a separate file and added to config data on-the-fly.
+#
+# github_app_installation_id can be found from the installing organization's page, e.g.
+# <https://github.com/organizations/OpenTreeOfLife/settings/installations>
+# (the installation ID is in the URL of the Configure button here)
+github_app_installation_id = YOUR_APP_INSTALLATION_ID_HERE
 
 # List public-facing base URL for treemachine and taxomachine services
 # (NOTE that these are used by both server- and client-side code)


### PR DESCRIPTION
This replaces OAuth app behavior (deprecated, too-permissive and permanent tokens) with new-style behavior of GitHub apps (short-lived tokens, minted regularly, with narrow permissions) in both web-apps.

This has been tested locally (for anonymous operations) but not with logged-in users. So not ready to merge yet.