### PR TITLE
Fix an error in new bulk TNRS (no matches == null)

### DIFF
--- a/curator/static/js/tnrs/tnrs-main.js
+++ b/curator/static/js/tnrs/tnrs-main.js
@@ -1069,13 +1069,13 @@ function requestTaxonMapping( nameToMap ) {
 
                 case 1:
                     // the expected case
-                    candidateMatches = data.results[0].matches;
+                    candidateMatches = data.results[0].matches || [ ];
                     break;
 
                 default:
                     console.warn('MULTIPLE SEARCH RESULT SETS (USING FIRST)');
                     console.warn(data['results']);
-                    candidateMatches = data.results[0].matches;
+                    candidateMatches = data.results[0].matches || [ ];
             }
         }
         // TODO: Filter candidate matches based on their properties, scores, etc.?


### PR DESCRIPTION
The previous version of TNRS returned an empty array for
`results.matches` if there were no matches found.

I've added a safety net to the JS to emulate the old response in the
curator app, but we should probably try to keep the old behavior if
there are any other API consumers out there.