### PR TITLE
Repair the broken URL to a conflict-tree view

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1812,8 +1812,7 @@ function displayConflictSummary(conflictInfo) {
     var $reportArea = $('#analysis-results');
     var targetTree = $('#reference-select').val();
     var referenceTreeID = $('#tree-select').val();
-    var treeURL = getViewURLFromStudyID(studyID) +"?tab=trees&tree="+ referenceTreeID;
-      +"&conflict="+ targetTree;
+    var treeURL = getViewURLFromStudyID(studyID) +"?tab=trees&tree="+ referenceTreeID +"&conflict="+ targetTree;
     $reportArea.empty()
            .append('<h4>Conflict summary</h4>')
            .append('<p><a href="'+ treeURL +'" target="conflicttree">Open labelled tree in new window</a></p>')


### PR DESCRIPTION
The JS that builds this URL was broken with an unwanted semicolon, and
the resulting fragment is apparently "valid" JS. Not sure how long this
has been broken, but the fix addresses #1222.