### PR TITLE
Isolated feedback panel

### DIFF
--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -41,7 +41,7 @@ def index():
 
     # handle the first arg (path part) found
     if len(request.args) > 0:
-        if request.args[0] in ['argus',]:  # TODO: add 'onezoom','phylet', others?
+        if request.args[0] in ['argus', 'feedback', 'properties']:  # TODO: add 'onezoom','phylet', others?
             treeview_dict['viewer'] = request.args[0]
         elif '@' in request.args[0]:
             treeview_dict['domSource'], treeview_dict['nodeID'] = request.args[0].split('@')

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -206,7 +206,7 @@ function loadLocalComments( chosenFilter ) {
         fetchArgs.url = getCommentIndexURL();
 
         commentLabel = window.document.title;
-        if (commendLabel.match(/ - opentree$/)) {
+        if (commentLabel.match(/ - opentree$/)) {
             // trim to just the distinctive page title
             commentLabel = commentLabel.slice(0, -11);
         }

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -170,7 +170,7 @@ function loadLocalComments( chosenFilter ) {
     // add a mnemonic to the comment header (for this page? which node?)
     var commentLabel = '';
 
-    if (argus.treeData) {
+    if (argus && argus.treeData) {
         // default filter is for the current location in the synthetic tree
         // TODO: pivot based on current page/view type..
         fetchArgs.filter = chosenFilter || 'synthtree_id,synthtree_node_id';

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -240,6 +240,7 @@ function loadLocalComments( chosenFilter ) {
 /* Not all tree viewers use argus! but we still need other functions in this file.
  * N.B. 'viewer' should be defined in the parent page
  */
+var viewer;
 if (viewer !== 'feedback') {
 
     $(document).ready(function() {

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -206,7 +206,7 @@ function loadLocalComments( chosenFilter ) {
         fetchArgs.url = getCommentIndexURL();
 
         commentLabel = window.document.title;
-        if (commentLabel.endsWidth(' - opentree')) {
+        if (commendLabel.match(/ - opentree$/)) {
             // trim to just the distinctive page title
             commentLabel = commentLabel.slice(0, -11);
         }

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -94,13 +94,16 @@ body {
 #comments-panel.isolated-feedback {
   /* special style when used in isolation */
     width: 100% !important;
-    max-width: auto !important;
+    max-width: none !important;
     margin: 0 !important;
 }
 div.viewer-frame {
     width: 100%;  /* TODO: adapt to narrower window!? */
     margin-left: 0;
     margin-right: 0;
+}
+div.viewer-frame.isolated-feedback {
+    display: none !important;
 }
 #provenance-panel {
     /* margin-right: -200%; */
@@ -438,6 +441,9 @@ div#r0 {
 }
 #footer  .pull-right{
     float: right;
+}
+#footer.isolated-feedback {
+    display: none !important;
 }
 #screen-size-indicator {
     position: absolute;

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -63,6 +63,9 @@ body {
     top: 90px;  /* allow for taller (wrapping) main title? */
     bottom: 0px;  /* WAS 25px for minimal footer */
 }
+#viewer-collection.isolated-feedback {
+    display: none !important;
+}
 #viewer-collection,
 #comments-panel .panel-edges,
 #provenance-panel .panel-edges {

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -91,6 +91,12 @@ body {
     margin-left: -50%;
     margin-right: 0;
 }
+#comments-panel.isolated-feedback {
+  /* special style when used in isolation */
+    width: 100% !important;
+    max-width: auto !important;
+    margin: 0 !important;
+}
 div.viewer-frame {
     width: 100%;  /* TODO: adapt to narrower window!? */
     margin-left: 0;

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -63,9 +63,6 @@ body {
     top: 90px;  /* allow for taller (wrapping) main title? */
     bottom: 0px;  /* WAS 25px for minimal footer */
 }
-#viewer-collection.isolated-feedback {
-    display: none !important;
-}
 #viewer-collection,
 #comments-panel .panel-edges,
 #provenance-panel .panel-edges {
@@ -94,19 +91,10 @@ body {
     margin-left: -50%;
     margin-right: 0;
 }
-#comments-panel.isolated-feedback {
-  /* special style when used in isolation */
-    width: 100% !important;
-    max-width: none !important;
-    margin: 0 !important;
-}
 div.viewer-frame {
     width: 100%;  /* TODO: adapt to narrower window!? */
     margin-left: 0;
     margin-right: 0;
-}
-div.viewer-frame.isolated-feedback {
-    display: none !important;
 }
 #provenance-panel {
     /* margin-right: -200%; */
@@ -445,9 +433,6 @@ div#r0 {
 #footer  .pull-right{
     float: right;
 }
-#footer.isolated-feedback {
-    display: none !important;
-}
 #screen-size-indicator {
     position: absolute;
     left: 0;
@@ -561,4 +546,17 @@ div#r0 {
 }
 .argus-error .action-item li {
     list-style: circle;
+}
+
+/* special styles when showing only feedback UI */
+body.isolated-feedback #comments-panel {
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+}
+body.isolated-feedback #viewer-collection,
+body.isolated-feedback div.viewer-frame,
+body.isolated-feedback #footer
+{
+    display: none !important;
 }

--- a/webapp/static/plugin_layouts/opentree/default.css
+++ b/webapp/static/plugin_layouts/opentree/default.css
@@ -554,7 +554,9 @@ body.isolated-feedback #comments-panel {
     max-width: none !important;
     margin: 0 !important;
 }
-body.isolated-feedback #viewer-collection,
+body.isolated-feedback #viewer-collection {
+    top: 0px !important;
+}
 body.isolated-feedback div.viewer-frame,
 body.isolated-feedback #footer
 {

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -199,7 +199,7 @@
 {{ if viewer == 'feedback': }}
   <script type="text/javascript">
     // hide all but the feedback (comments) panel
-    $('#comments-panel, #viewer-collection .viewer-frame, #footer').addClass('isolated-feedback');
+    $('#comments-panel, #viewer-collection, .viewer-frame, #footer').addClass('isolated-feedback');
     $commentsPanel = $('#comments-panel');
     $commentsPanel.siblings().hide();
     $commentsPanel.parentsUntil('body').each(function() {

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -199,7 +199,8 @@
 {{ if viewer == 'feedback': }}
   <script type="text/javascript">
     // hide all but the feedback (comments) panel
-    $('#comments-panel, #viewer-collection, .viewer-frame, #footer').addClass('isolated-feedback');
+    //$('#comments-panel, #viewer-collection, .viewer-frame, #footer').addClass('isolated-feedback');
+    $('body').addClass('isolated-feedback');
     $commentsPanel = $('#comments-panel');
     $commentsPanel.siblings().hide();
     $commentsPanel.parentsUntil('body').each(function() {

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -193,9 +193,8 @@
         forcedByURL: true
      {{ pass }}
     };
-  </script>
     // treeview.js will examine this to determine our starting view
-  <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
+  </script>
 
 {{ if viewer == 'feedback': }}
   <script type="text/javascript">
@@ -209,6 +208,8 @@
     });
     $commentsPanel.show();
   </script>
+{{ else: }}
+  <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
 {{ pass }}
 
 <!-- hidden template for argus (tree-viewer) legend -->

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -193,11 +193,13 @@
         forcedByURL: true
      {{ pass }}
     };
+  </script>
     // treeview.js will examine this to determine our starting view
+  <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
 
-   {{ if viewer == 'feedback': }}
+{{ if viewer == 'feedback': }}
+  <script type="text/javascript">
     // hide all but the feedback (comments) panel
-debugger;
     $('#comments-panel, #viewer-collection .viewer-frame, #footer').addClass('isolated-feedback');
     $commentsPanel = $('#comments-panel');
     $commentsPanel.siblings().hide();
@@ -206,11 +208,8 @@ debugger;
         $ancestor.siblings().hide();
     });
     $commentsPanel.show();
-
-   {{ pass }}
   </script>
-  <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
-</script>
+{{ pass }}
 
 <!-- hidden template for argus (tree-viewer) legend -->
 <div class="modal hide fade" id="tree-view-legend" style="display: none;">

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -182,6 +182,7 @@
     var syntheticTreeID = '{{=draftTreeName}}';
     var syntheticTreeDefaultStartingNodeID = '{{=startingNodeID}}';
         // TODO: Allow other choices via URL?
+    var viewer = '{{=viewer}}';
 
     // if inbound URL points to a particular location+view, record it here
     var urlState = {

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -197,11 +197,13 @@
 
    {{ if viewer == 'feedback': }}
     // hide all but the feedback (comments) panel
-    $('#comments-panel').siblings().hide();
-    $('#comments-panel').parentsUntil('body').each(function() {
+    $commentsPanel = $('#comments-panel');
+    $commentsPanel.siblings().hide();
+    $commentsPanel.parentsUntil('body').each(function() {
         var $ancestor = $(this);
         $ancestor.siblings().hide();
     });
+    $commentsPanel.addClass('isolated-feedback').show();
    {{ pass }}
   </script>
   <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -196,6 +196,8 @@
     // treeview.js will examine this to determine our starting view
   </script>
 
+<script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
+
 {{ if viewer == 'feedback': }}
   <script type="text/javascript">
     // hide all but the feedback (comments) panel
@@ -208,9 +210,8 @@
         $ancestor.siblings().hide();
     });
     $commentsPanel.show();
+    loadLocalComments();
   </script>
-{{ else: }}
-  <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
 {{ pass }}
 
 <!-- hidden template for argus (tree-viewer) legend -->

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -197,7 +197,8 @@
 
    {{ if viewer == 'feedback': }}
     // hide all but the feedback (comments) panel
-    $('#comments-panel, .viewer-frame, #footer').addClass('isolated-feedback');
+debugger;
+    $('#comments-panel, #viewer-collection .viewer-frame, #footer').addClass('isolated-feedback');
     $commentsPanel = $('#comments-panel');
     $commentsPanel.siblings().hide();
     $commentsPanel.parentsUntil('body').each(function() {

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -197,13 +197,15 @@
 
    {{ if viewer == 'feedback': }}
     // hide all but the feedback (comments) panel
+    $('#comments-panel, .viewer-frame, #footer').addClass('isolated-feedback');
     $commentsPanel = $('#comments-panel');
     $commentsPanel.siblings().hide();
     $commentsPanel.parentsUntil('body').each(function() {
         var $ancestor = $(this);
         $ancestor.siblings().hide();
     });
-    $commentsPanel.addClass('isolated-feedback').show();
+    $commentsPanel.show();
+
    {{ pass }}
   </script>
   <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -194,6 +194,13 @@
      {{ pass }}
     };
     // treeview.js will examine this to determine our starting view
+
+   {{ if viewer == 'feedback': }}
+    $('#comments-panel').siblings().hide();
+    $('#comments-panel').parentsUntil('body').each( ancestor, function() {
+        $(ancestor).siblings().hide();
+    });
+   {{ pass }}
   </script>
   <script type="text/javascript" src="/opentree/static/js/treeview.js"></script>
 </script>

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -196,9 +196,11 @@
     // treeview.js will examine this to determine our starting view
 
    {{ if viewer == 'feedback': }}
+    // hide all but the feedback (comments) panel
     $('#comments-panel').siblings().hide();
-    $('#comments-panel').parentsUntil('body').each( ancestor, function() {
-        $(ancestor).siblings().hide();
+    $('#comments-panel').parentsUntil('body').each(function() {
+        var $ancestor = $(this);
+        $ancestor.siblings().hide();
     });
    {{ pass }}
   </script>


### PR DESCRIPTION
This hides and disables most of our current synth-tree viewer, so that only the feedback UI is visible. It addresses two use cases:

 - Someone browsing the synthetic tree on OneZoom (or other viewer) wants to comment on a taxon. If they build an appropriate feedback URL, with the target nodeid (and ideally synthesis version) we can index their feedback for later review.

 - This will also allow us to gather general feedback (esp. bug reports and feature requests) from our other web apps, esp. the curation tool.

This is working now on **devtree**. Note the difference between these URLs for an example:

Normal view:
https://devtree.opentreeoflife.org/opentree/argus/opentree12.3@ott93302/cellular-organisms

Isolated feedback: https://devtree.opentreeoflife.org/opentree/feedback/opentree12.3@ott93302/cellular-organisms
