### PR TITLE
Isolated feedback panel (preserve parent window's URL)

### DIFF
--- a/curator/static/css/default.css
+++ b/curator/static/css/default.css
@@ -958,3 +958,9 @@ a.node-direct-link {
     font-weight: bold;
     margin: 4px 0 0 2px;
 }
+
+.curation-feedback-btn {
+    clear: right;
+    float: right;
+    margin: -6px 0 10px;
+}

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -191,10 +191,12 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
   // Open a new window for bug reports and other feedback
   function showFeedbackWindow() {
       // pass along the root-relative URL of the calling page.
-      var parentWindowURL = (window.opener ? window.opener.location.pathname : "");
+      //var parentWindowURL = (window.opener ? window.opener.location.pathname : "");
+      var mainWindowPath = window.location.pathname || "";
+      var mainWindowURL = window.location.href || "";
       var fbUrl = window.location.protocol + "//" + window.location.hostname
           + (window.location.port ? ':' + window.location.port: '')
-          + "/opentree/feedback"+ parentWindowURL;
+          + "/opentree/feedback?url="+ escape(mainWindowURL));
       console.warn("fbUrl:\n"+ fbUrl);
       console.warn("window.opener.location.href: "+ (window.opener ? window.opener.location.pathname : ""));
       console.warn("main title text: "+ escape( $('#main-title').text() ));
@@ -497,11 +499,10 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
           <p></p>
           {{end}}
           <p></p>
-          <a class="btn btn-small" href="#"
+        {{pass}}
+          <a class="btn btn-small" href="#" style="clear: right; float: right;"
              onclick="showFeedbackWindow(); return false;">Bug reports and feature suggestions</a>
         </div>
-        {{pass}}
-
     </section><!-- #main.main row -->
     </div><!-- .container -->
       <!--</div>--><!-- main -->

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -196,7 +196,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       var mainWindowURL = window.location.href || "";
       var fbUrl = window.location.protocol + "//" + window.location.hostname
           + (window.location.port ? ':' + window.location.port: '')
-          + "/opentree/feedback?url="+ escape(mainWindowURL));
+          + "/opentree/feedback?url="+ escape(mainWindowURL);
       console.warn("fbUrl:\n"+ fbUrl);
       console.warn("window.opener.location.href: "+ (window.opener ? window.opener.location.pathname : ""));
       console.warn("main title text: "+ escape( $('#main-title').text() ));

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -196,16 +196,10 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       var mainWindowURL = window.location.href || "";
       var fbUrl = window.location.protocol + "//" + window.location.hostname
           + (window.location.port ? ':' + window.location.port: '')
-          + "/opentree/feedback?url="+ escape(mainWindowURL);
-      console.warn("fbUrl:\n"+ fbUrl);
-      console.warn("window.opener.location.href: "+ (window.opener ? window.opener.location.pathname : ""));
-      console.warn("main title text: "+ escape( $('#main-title').text() ));
-
+          + "/opentree/feedback?parentWindowURL="+ escape(mainWindowURL);
       var fbWindow = window.open(fbUrl, 'feedback');
       if (fbWindow) {
           fbWindow.focus();
-          // pass any qualifying information via URL? Or wait for a call to `window.opener`?
-
       } else {
           alert("Couldn't open a new window. Are you using a popup blocker?");
           return false;

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -190,13 +190,10 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
 
   // Open a new window for bug reports and other feedback
   function showFeedbackWindow() {
-      // pass along the root-relative URL of the calling page.
-      //var parentWindowURL = (window.opener ? window.opener.location.pathname : "");
-      var mainWindowPath = window.location.pathname || "";
-      var mainWindowURL = window.location.href || "";
+      // ASSUMES that synth-tree viewer is on the same domain!
       var fbUrl = window.location.protocol + "//" + window.location.hostname
           + (window.location.port ? ':' + window.location.port: '')
-          + "/opentree/feedback?parentWindowURL="+ escape(mainWindowURL);
+          + "/opentree/feedback";
       var fbWindow = window.open(fbUrl, 'feedback');
       if (fbWindow) {
           fbWindow.focus();

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -193,7 +193,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       // ASSUMES that synth-tree viewer is on the same domain!
       var fbUrl = window.location.protocol + "//" + window.location.hostname
           + (window.location.port ? ':' + window.location.port: '')
-          + "/opentree/feedback";
+          + "/opentree/feedback?parentWindowURL="+ escape(window.location.href);
       var fbWindow = window.open(fbUrl, 'feedback');
       if (fbWindow) {
           fbWindow.focus();

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -190,13 +190,15 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
 
   // Open a new window for bug reports and other feedback
   function showFeedbackWindow() {
+      // pass along the root-relative URL of the calling page.
+      var parentWindowURL = (window.opener ? window.opener.location.pathname : "");
       var fbUrl = window.location.protocol + "//" + window.location.hostname
           + (window.location.port ? ':' + window.location.port: '')
-          + "/opentree/feedback/"+ escape( $('#main-title').text() );
+          + "/opentree/feedback"+ parentWindowURL;
       console.warn("fbUrl:\n"+ fbUrl);
-      console.warn("request.vars['url']:\n {{= request.vars['url'] or 'NOPE' }}";
-      console.warn("request.get('env').get('http_referer'):\n {{= request.get('env').get('http_referer') or 'NADA' }}";
-      console.warn("window.opener.location.href: "+ window.opener.location.href || 'NOSIREE' );
+      console.warn("window.opener.location.href: "+ (window.opener ? window.opener.location.pathname : ""));
+      console.warn("main title text: "+ escape( $('#main-title').text() ));
+
       var fbWindow = window.open(fbUrl, 'feedback');
       if (fbWindow) {
           fbWindow.focus();

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -188,6 +188,28 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       $('#maintenance-notice').modal('show');
   }
 
+  // Open a new window for bug reports and other feedback
+  function showFeedbackWindow() {
+      var fbUrl = window.location.protocol + "//" + window.location.hostname
+          + (window.location.port ? ':' + window.location.port: '')
+          + "/opentree/feedback/"+ escape( $('#main-title').text() );
+      console.warn("fbUrl:\n"+ fbUrl);
+      console.warn("request.vars['url']:\n {{= request.vars['url'] or 'NOPE' }}";
+      console.warn("request.get('env').get('http_referer'):\n {{= request.get('env').get('http_referer') or 'NADA' }}";
+      console.warn("window.opener.location.href: "+ window.opener.location.href || 'NOSIREE' );
+      var fbWindow = window.open(fbUrl, 'feedback');
+      if (fbWindow) {
+          fbWindow.focus();
+          // pass any qualifying information via URL? Or wait for a call to `window.opener`?
+
+      } else {
+          alert("Couldn't open a new window. Are you using a popup blocker?");
+          return false;
+      };
+      return false;
+  }
+
+
   // Fetch the current user information for general use
   var userLogin = "{{= get_user_login() }}";
   var userLoginASCII = "{{= get_user_login().encode('ascii','ignore') }}";
@@ -472,6 +494,9 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
           <h3>Right Sidebar</h3>
           <p></p>
           {{end}}
+          <p></p>
+          <a class="btn btn-small" href="#"
+             onclick="showFeedbackWindow(); return false;">Bug reports and feature suggestions</a>
         </div>
         {{pass}}
 

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -491,8 +491,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
           {{end}}
           <p></p>
         {{pass}}
-          <a class="btn btn-small" href="#" style="clear: right; float: right;"
-             onclick="showFeedbackWindow(); return false;">Bug reports and feature suggestions</a>
+          <a class="btn Xbtn-small btn-info curation-feedback-btn" href="#"
+             onclick="showFeedbackWindow(); return false;">Submit a bug report or suggestion</a>
         </div>
     </section><!-- #main.main row -->
     </div><!-- .container -->

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -34,6 +34,7 @@ def index():
     treeview_dict['nudgingToLatestSyntheticTree'] = False
     treeview_dict['incomingDomSource'] = 'none'
     treeview_dict['showLegendOnLoad'] = request.vars.get('show-legend') or False
+    treeview_dict['feedbackParentWindowURL'] = request.vars.get('parentWindowURL', None)
 
     # add a flag to determine whether to force the viewer to this node (vs. using the
     # browser's stored state for this URL, or a default starting node)

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -23,6 +23,10 @@ def index():
     #
     # TODO: add another optional arg 'viewport', like so
     #   http://opentree.com/opentree/argus/0,23,100,400/ottol@123456/Homo+sapiens
+    try:
+        from urllib import unquote_plus
+    except ImportError:
+        from urllib.parse import unquote_plus
 
     # modify the normal view dictionary to include location+view hints from the URL
     treeview_dict = default_view_dict.copy()
@@ -34,7 +38,11 @@ def index():
     treeview_dict['nudgingToLatestSyntheticTree'] = False
     treeview_dict['incomingDomSource'] = 'none'
     treeview_dict['showLegendOnLoad'] = request.vars.get('show-legend') or False
-    treeview_dict['feedbackParentWindowURL'] = request.vars.get('parentWindowURL', None)
+    if request.vars.get('parentWindowURL', None):
+        plain_feedback_url = unquote_plus(request.vars.get('parentWindowURL'))
+        treeview_dict['feedbackParentWindowURL'] = plain_feedback_url
+    else:
+        treeview_dict['feedbackParentWindowURL'] = None
 
     # add a flag to determine whether to force the viewer to this node (vs. using the
     # browser's stored state for this URL, or a default starting node)

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -822,8 +822,8 @@ def get_local_comments(location={}):
     url = url.format(GH_BASE_URL, search_text)
     resp = requests.get(url, headers=GH_GET_HEADERS, timeout=10)  
     # N.B. Timeout is in seconds, and watches for *any* new data within that time (vs. whole response)
-    ##print(url)
-    ##print(resp)
+    print(url)
+    print(resp)
     try:
         resp.raise_for_status()
     except:
@@ -834,10 +834,10 @@ def get_local_comments(location={}):
     except:
         results = resp.json
     ##pprint(results)
-    ##print("Returned {0} issues ({1})".format(
-    ##  results["total_count"],
-    ##  results["incomplete_results"] and 'INCOMPLETE' or 'COMPLETE'
-    ##  ))
+    print("Returned {0} issues ({1})".format(
+      results["total_count"],
+      results["incomplete_results"] and 'INCOMPLETE' or 'COMPLETE'
+      ))
     return results['items']
 
 def clear_local_comments():

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -340,10 +340,14 @@ def index():
     ottol_id = request.vars['ottol_id']
     target_node_label = request.vars['target_node_label']
     url = request.vars['url'] or request.get('env').get('http_referer')
+    pprint("=== request.env.query_string: %s ===" % request.env.query_string)
     if 'parentWindowURL=' in request.env.query_string:
+        pprint("=== LOOKING for parentWindowURL...")
         # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
         raw_qs_value = request.env.query_string.split('parentWindowURL=')[1];
+        pprint("=== raw_qs_value: %s", raw_qs_value)
         url = str(web2pyHTMLParser(raw_qs_value))  # decode to a proper URL
+        pprint("=== NEW url: %s", url)
 
     filter = request.vars['filter']
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -329,6 +329,7 @@ def smartgrid():
 
 def index():
     # this is a tricky function that does simple display, handles POSTed comments, moderation, etc.
+    from gluon.html import web2pyHTMLParser
 
     # TODO: break this up into more sensible functions, and refactor
     # display/markup generation to shared code?
@@ -338,8 +339,11 @@ def index():
     sourcetree_id = request.vars['sourcetree_id']
     ottol_id = request.vars['ottol_id']
     target_node_label = request.vars['target_node_label']
-    # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
     url = request.vars['url'] or request.get('env').get('http_referer')
+    if 'parentWindowURL=' in request.env.query_string:
+        # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
+        raw_qs_value = request.env.query_string.split('parentWindowURL=')[1];
+        url = str(web2pyHTMLParser(raw_qs_value))  # decode to a proper URL
 
     filter = request.vars['filter']
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -329,7 +329,8 @@ def index():
     sourcetree_id = request.vars['sourcetree_id']
     ottol_id = request.vars['ottol_id']
     target_node_label = request.vars['target_node_label']
-    url = request.vars['url'] or request.get('env').get('http_referer')
+    # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
+    url = request.vars['parentWindowURL'] or request.vars['url'] or request.get('env').get('http_referer')
 
     filter = request.vars['filter']
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -597,6 +597,8 @@ def index():
         return node(new_msg)                
 
     # retrieve related comments, based on the chosen filter
+    pprint("=== filter: %s ===" % filter)
+    pprint("=== url: %s ===" % url)
     if filter == 'skip_comments':
         # sometimes we just want the markup/UI (eg, an empty page that's quickly updated by JS)
         comments = [ ]
@@ -611,6 +613,7 @@ def index():
     else:   # fall back to url
         comments = get_local_comments({"URL": url})
 
+    pprint("=== found %d comments ===" % len(comments))
     #pprint(comments) 
 
     for comment in comments:

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -612,7 +612,7 @@ def index():
             # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
             raw_qs_value = url.split('parentWindowURL=')[1];
             pprint("=== raw_qs_value: %s" % raw_qs_value)
-            url = str(web2pyHTMLParser(raw_qs_value))  # decode to a proper URL
+            url = str(web2pyHTMLParser(raw_qs_value).tree)  # decode to a proper URL
             pprint("=== NEW url: %s" % url)
         comments = get_local_comments({"URL": url})
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -328,7 +328,6 @@ def smartgrid():
 
 def index():
     # this is a tricky function that does simple display, handles POSTed comments, moderation, etc.
-    from gluon.html import web2pyHTMLParser
 
     # TODO: break this up into more sensible functions, and refactor
     # display/markup generation to shared code?
@@ -831,7 +830,7 @@ def get_local_comments(location={}):
     ##print("Returned {0} issues ({1})".format(
     ##  results["total_count"],
     ##  results["incomplete_results"] and 'INCOMPLETE' or 'COMPLETE'
-    ##))
+    ##  ))
     return results['items']
 
 def clear_local_comments():

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -608,18 +608,16 @@ def index():
         comments = get_local_comments({"Open Tree Taxonomy id": ottol_id})
     else:   # fall back to url
         if 'parentWindowURL=' in url:
-            pprint("=== NO LONGER LOOKING for parentWindowURL...")
-            """
+            #pprint("=== EXTRACTING parentWindowURL...")
             try:
                 from urllib import unquote_plus
             except ImportError:
                 from urllib.parse import unquote_plus
             # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
             raw_qs_value = url.split('parentWindowURL=')[1];
-            pprint("=== raw_qs_value: %s" % raw_qs_value)
+            #pprint("=== raw_qs_value: %s" % raw_qs_value)
             url = unquote_plus(raw_qs_value)  # decode to a proper URL
-            pprint("=== NEW url: %s" % url)
-            """
+            #pprint("=== NEW url: %s" % url)
         comments = get_local_comments({"URL": url})
 
     pprint("=== found %d comments ===" % len(comments))

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -340,7 +340,6 @@ def index():
     ottol_id = request.vars['ottol_id']
     target_node_label = request.vars['target_node_label']
     url = request.vars['url'] or request.get('env').get('http_referer')
-    pprint("=== request.env.query_string: %s ===" % request.env.query_string)
 
     filter = request.vars['filter']
 
@@ -612,9 +611,9 @@ def index():
             pprint("=== LOOKING for parentWindowURL...")
             # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
             raw_qs_value = url.split('parentWindowURL=')[1];
-            pprint("=== raw_qs_value: %s", raw_qs_value)
+            pprint("=== raw_qs_value: %s" % raw_qs_value)
             url = str(web2pyHTMLParser(raw_qs_value))  # decode to a proper URL
-            pprint("=== NEW url: %s", url)
+            pprint("=== NEW url: %s" % url)
         comments = get_local_comments({"URL": url})
 
     pprint("=== found %d comments ===" % len(comments))

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -609,7 +609,10 @@ def index():
     else:   # fall back to url
         if 'parentWindowURL=' in url:
             pprint("=== LOOKING for parentWindowURL...")
-            from urllib.parse import unquote_plus
+            try:
+                from urllib import unquote_plus
+            except ImportError:
+                from urllib.parse import unquote_plus
             # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
             raw_qs_value = url.split('parentWindowURL=')[1];
             pprint("=== raw_qs_value: %s" % raw_qs_value)

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -23,7 +23,6 @@ def SUL(*a,**b): return UL(*[u for u in a if u],**b)
 script=SCRIPT("""
 var action = null;
 var formhtml = null;
-
 function delete_all_forms() { 
     jQuery('div.plugin_localcomments div.reply').each(function() {
         if ($(this).closest('.issue').length === 0) {
@@ -593,8 +592,6 @@ def index():
         return node(new_msg)                
 
     # retrieve related comments, based on the chosen filter
-    pprint("=== filter: %s ===" % filter)
-    pprint("=== url: %s ===" % url)
     if filter == 'skip_comments':
         # sometimes we just want the markup/UI (eg, an empty page that's quickly updated by JS)
         comments = [ ]
@@ -620,7 +617,6 @@ def index():
             #pprint("=== NEW url: %s" % url)
         comments = get_local_comments({"URL": url})
 
-    pprint("=== found %d comments ===" % len(comments))
     #pprint(comments) 
 
     for comment in comments:
@@ -820,8 +816,8 @@ def get_local_comments(location={}):
     url = url.format(GH_BASE_URL, search_text)
     resp = requests.get(url, headers=GH_GET_HEADERS, timeout=10)  
     # N.B. Timeout is in seconds, and watches for *any* new data within that time (vs. whole response)
-    print(url)
-    print(resp)
+    ##print(url)
+    ##print(resp)
     try:
         resp.raise_for_status()
     except:
@@ -832,10 +828,10 @@ def get_local_comments(location={}):
     except:
         results = resp.json
     ##pprint(results)
-    print("Returned {0} issues ({1})".format(
-      results["total_count"],
-      results["incomplete_results"] and 'INCOMPLETE' or 'COMPLETE'
-      ))
+    ##print("Returned {0} issues ({1})".format(
+    ##  results["total_count"],
+    ##  results["incomplete_results"] and 'INCOMPLETE' or 'COMPLETE'
+    ##))
     return results['items']
 
 def clear_local_comments():

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -609,10 +609,11 @@ def index():
     else:   # fall back to url
         if 'parentWindowURL=' in url:
             pprint("=== LOOKING for parentWindowURL...")
+            from urllib.parse import unquote_plus
             # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
             raw_qs_value = url.split('parentWindowURL=')[1];
             pprint("=== raw_qs_value: %s" % raw_qs_value)
-            url = urllib.unquote_plus(raw_qs_value)  # decode to a proper URL
+            url = unquote_plus(raw_qs_value)  # decode to a proper URL
             pprint("=== NEW url: %s" % url)
         comments = get_local_comments({"URL": url})
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -341,13 +341,6 @@ def index():
     target_node_label = request.vars['target_node_label']
     url = request.vars['url'] or request.get('env').get('http_referer')
     pprint("=== request.env.query_string: %s ===" % request.env.query_string)
-    if 'parentWindowURL=' in request.env.query_string:
-        pprint("=== LOOKING for parentWindowURL...")
-        # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
-        raw_qs_value = request.env.query_string.split('parentWindowURL=')[1];
-        pprint("=== raw_qs_value: %s", raw_qs_value)
-        url = str(web2pyHTMLParser(raw_qs_value))  # decode to a proper URL
-        pprint("=== NEW url: %s", url)
 
     filter = request.vars['filter']
 
@@ -615,6 +608,13 @@ def index():
     elif filter == 'ottol_id':
         comments = get_local_comments({"Open Tree Taxonomy id": ottol_id})
     else:   # fall back to url
+        if 'parentWindowURL=' in url:
+            pprint("=== LOOKING for parentWindowURL...")
+            # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
+            raw_qs_value = url.split('parentWindowURL=')[1];
+            pprint("=== raw_qs_value: %s", raw_qs_value)
+            url = str(web2pyHTMLParser(raw_qs_value))  # decode to a proper URL
+            pprint("=== NEW url: %s", url)
         comments = get_local_comments({"URL": url})
 
     pprint("=== found %d comments ===" % len(comments))

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -23,6 +23,7 @@ def SUL(*a,**b): return UL(*[u for u in a if u],**b)
 script=SCRIPT("""
 var action = null;
 var formhtml = null;
+
 function delete_all_forms() { 
     jQuery('div.plugin_localcomments div.reply').each(function() {
         if ($(this).closest('.issue').length === 0) {
@@ -157,6 +158,14 @@ function capture_form() {
         if (!validateFeedbackForm({VERBOSE: true})) {
             // something's wrong
             return false;
+        }
+
+        if (window.opener) {
+            /* This window was opened by another page! Copy its URL to the 'url' field
+             * This is probably OneZoom, or our curation tool, or some other site using
+             * OpenTree data. We'll group these issues by URL.
+             */
+            $form.find('input[name="url"]').val( window.location.href );
         }
 
         jQuery.post(action,
@@ -330,7 +339,7 @@ def index():
     ottol_id = request.vars['ottol_id']
     target_node_label = request.vars['target_node_label']
     # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
-    url = request.get_vars['parentWindowURL'] or request.vars['url'] or request.get('env').get('http_referer')
+    url = request.vars['url'] or request.get('env').get('http_referer')
 
     filter = request.vars['filter']
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -330,7 +330,7 @@ def index():
     ottol_id = request.vars['ottol_id']
     target_node_label = request.vars['target_node_label']
     # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
-    url = request.vars['parentWindowURL'] or request.vars['url'] or request.get('env').get('http_referer')
+    url = request.get_vars['parentWindowURL'] or request.vars['url'] or request.get('env').get('http_referer')
 
     filter = request.vars['filter']
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -546,10 +546,10 @@ def index():
 
             # more useful links for some footer fields
             if url.startswith('http'):
-                # truncate visible link
-                url_link = '[{0}]({1})'.format(url.split('//')[1], url)
+                # repeat full (absolute) URL as link text
+                url_link = '[{0}]({1})'.format(url, url)
             else:
-                # expand hidden link
+                # expand hidden link for root-relative URL
                 url_link = '[{0}]({1}{2})'.format(url, request.get('env').get('http_origin'), url)
 
             # add full metadata for an issue 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -165,7 +165,7 @@ function capture_form() {
              * This is probably OneZoom, or our curation tool, or some other site using
              * OpenTree data. We'll group these issues by URL.
              */
-            $form.find('input[name="url"]').val( window.location.href );
+            $form.find('input[name="url"]').val( window.opener.location.href );
         }
 
         jQuery.post(action,

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -612,7 +612,7 @@ def index():
             # capture the absolute URL of a parent window (i.e. from OneZoom or the study-curation app)
             raw_qs_value = url.split('parentWindowURL=')[1];
             pprint("=== raw_qs_value: %s" % raw_qs_value)
-            url = str(web2pyHTMLParser(raw_qs_value).tree)  # decode to a proper URL
+            url = urllib.unquote_plus(raw_qs_value)  # decode to a proper URL
             pprint("=== NEW url: %s" % url)
         comments = get_local_comments({"URL": url})
 

--- a/webapp/controllers/plugin_localcomments.py
+++ b/webapp/controllers/plugin_localcomments.py
@@ -608,7 +608,8 @@ def index():
         comments = get_local_comments({"Open Tree Taxonomy id": ottol_id})
     else:   # fall back to url
         if 'parentWindowURL=' in url:
-            pprint("=== LOOKING for parentWindowURL...")
+            pprint("=== NO LONGER LOOKING for parentWindowURL...")
+            """
             try:
                 from urllib import unquote_plus
             except ImportError:
@@ -618,6 +619,7 @@ def index():
             pprint("=== raw_qs_value: %s" % raw_qs_value)
             url = unquote_plus(raw_qs_value)  # decode to a proper URL
             pprint("=== NEW url: %s" % url)
+            """
         comments = get_local_comments({"URL": url})
 
     pprint("=== found %d comments ===" % len(comments))

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -157,6 +157,7 @@
                    else:
                        filter = 'skip_comments'
                        url = request.url
+                   pass
                }}
                {{=plugin_localcomments(filter=filter,url=url)}}
              </div>

--- a/webapp/views/default/index.html
+++ b/webapp/views/default/index.html
@@ -151,9 +151,14 @@
              <div>
                {{  # initialize comments with a naive url-based query
                    # (this will probably be overwritten by tree-view data)
-                   url = request.url
+                   if feedbackParentWindowURL:
+                       filter = 'url'
+                       url = feedbackParentWindowURL
+                   else:
+                       filter = 'skip_comments'
+                       url = request.url
                }}
-               {{=plugin_localcomments(filter='skip_comments',url=url)}}
+               {{=plugin_localcomments(filter=filter,url=url)}}
              </div>
             </div>
            </div>


### PR DESCRIPTION
This version will keep track of the calling window's URL (or an arbitrary string, if preferred by a calling app) and find prior discussion at the same location. This is working and tested on **devtree**, see for example https://devtree.opentreeoflife.org/curator/study/view/ot_1164/

In the study curation webapp, I've put the feedback at the bottom of the sidebar (suggestions on text, style, and placement are of course welcome):

![Screen Shot 2020-06-03 at 6 59 47 PM](https://user-images.githubusercontent.com/446375/83697210-6e42bb80-a5cc-11ea-9bfa-7a10db954b8f.png)

Other callers like OneZoom should be able to adapt the Javascript function used here, something like:
```javascript
  // Open a new window for bug reports and other feedback
  function showOpenTreeFeedbackWindow() {      
      var fbUrl = "https://tree.opentreeoflife.org/opentree/feedback?parentWindowURL="
          + escape(window.location.href);
      /* or, if the literal URL is not useful, any uniquely identifiable string:
          + escape("OneZoom special location FOO");
        */ 
      var fbWindow = window.open(fbUrl, 'feedback');
      if (fbWindow) {
          fbWindow.focus();
      } else {
          alert("Couldn't open a new window. Are you using a popup blocker?");
          return false;
      };
      return false;
  }
```