### PR TITLE
Show failed study fetches in synth-tree viewer

### DIFF
--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1129,6 +1129,9 @@ function showObjectProperties( objInfo, options ) {
                                 waitingForStudyInfo = true;
                             } else if ('taxonomy' in moreInfo) {
                                 // no problem, taxo sources are not loaded via AJAX
+                            } else if (moreInfo['loadStatus'] === 'FAILED') {
+                                // add a stub to study collection; we'll show an apology here
+                                supportingStudyInfo[ moreInfo.study_id ] = 'FAILED TO LOAD';
                             } else {
                                 console.error("! expected a study, but found mysterious stuff in metaMap:");
                                 for (p2 in moreInfo) {
@@ -1154,46 +1157,50 @@ function showObjectProperties( objInfo, options ) {
                         for (studyID in supportingStudyInfo) {
                             ///console.log(">>> study data for "+ studyID +" is COMPLETE, adding it now...");
                             var studyInfo = supportingStudyInfo[ studyID ];
-                            var pRef, pCompactRef, pCompactYear, pCompactPrimaryAuthor, pCompactRef, pDOITestParts, pURL, pID, pCurator;
-                            // assemble and display study info
-                            pID = studyInfo['ot:studyId'];
-                            pRef = studyInfo['ot:studyPublicationReference'] || '???';
-                            pCompactRef = fullToCompactReference( pRef );
-                            // show compact reference for each study, with a toggle for more below
-                            displayVal = '<div class="related-study"><div class="compact-ref"><a href="/curator/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'+ pCompactRef +'</a></div>';
-                            displayVal += '<div class="full-study-details" style="display: none;">';
-                            displayVal += '<div class="full-ref">'+ pRef +'</div>';
+                            if (studyInfo === 'FAILED TO LOAD') {
+                                displayVal = '<div class="related-study">No information found for study '+ studyID +'</div>';
+                            } else {
+                                var pRef, pCompactRef, pCompactYear, pCompactPrimaryAuthor, pCompactRef, pDOITestParts, pURL, pID, pCurator;
+                                // assemble and display study info
+                                pID = studyInfo['ot:studyId'];
+                                pRef = studyInfo['ot:studyPublicationReference'] || '???';
+                                pCompactRef = fullToCompactReference( pRef );
+                                // show compact reference for each study, with a toggle for more below
+                                displayVal = '<div class="related-study"><div class="compact-ref"><a href="/curator/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'+ pCompactRef +'</a></div>';
+                                displayVal += '<div class="full-study-details" style="display: none;">';
+                                displayVal += '<div class="full-ref">'+ pRef +'</div>';
 
-                            // publication URL should always be present, non-empty, and a valid URL
-                            pURL = latestCrossRefURL( studyInfo['ot:studyPublication'] );
-                            if (pURL) {
-                                displayVal += 'Full publication: <a href="'+ pURL +'" target="_blank" title="Permanent link to the full study">'+ pURL +'</a><br/>';
-                            }
-
-                            /* Phylografter link
-                            displayVal += ('Open Tree curation: <a href="http://www.reelab.net/phylografter/study/view/'+ pID +'" target="_blank" title="Link to this study in Phylografter">Study '+ pID +'</a>');
-                            */
-                            displayVal += (
-                                'Open Tree curation of this study: <a href="/curator/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'+ pID +'</a><br/>'
-                              + 'Supporting '+ (studyInfo.supportingTrees.length > 1 ? 'trees:' : 'tree:')
-                            );
-                            for (var treeID in studyInfo.supportingTrees) {
-                                displayVal += (
-                                    '&nbsp; <a href="/curator/study/view/'+ pID +'?tab=trees&tree='+ treeID +'" '
-                                  + 'target="_blank" title="Link to this supporting tree in curation app">'+ treeID +'</a>'
-                                );
-                            }
-
-                            pCurator = studyInfo['ot:curatorName'];
-                            if (pCurator) {
-                                if ($.isArray(pCurator)) {
-                                    pCurator = pCurator.join(", ");
+                                // publication URL should always be present, non-empty, and a valid URL
+                                pURL = latestCrossRefURL( studyInfo['ot:studyPublication'] );
+                                if (pURL) {
+                                    displayVal += 'Full publication: <a href="'+ pURL +'" target="_blank" title="Permanent link to the full study">'+ pURL +'</a><br/>';
                                 }
-                                displayVal += ('<div>Curated by: '+ pCurator +'</div>');
+
+                                /* Phylografter link
+                                displayVal += ('Open Tree curation: <a href="http://www.reelab.net/phylografter/study/view/'+ pID +'" target="_blank" title="Link to this study in Phylografter">Study '+ pID +'</a>');
+                                */
+                                displayVal += (
+                                    'Open Tree curation of this study: <a href="/curator/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'+ pID +'</a><br/>'
+                                  + 'Supporting '+ (studyInfo.supportingTrees.length > 1 ? 'trees:' : 'tree:')
+                                );
+                                for (var treeID in studyInfo.supportingTrees) {
+                                    displayVal += (
+                                        '&nbsp; <a href="/curator/study/view/'+ pID +'?tab=trees&tree='+ treeID +'" '
+                                      + 'target="_blank" title="Link to this supporting tree in curation app">'+ treeID +'</a>'
+                                    );
+                                }
+
+                                pCurator = studyInfo['ot:curatorName'];
+                                if (pCurator) {
+                                    if ($.isArray(pCurator)) {
+                                        pCurator = pCurator.join(", ");
+                                    }
+                                    displayVal += ('<div>Curated by: '+ pCurator +'</div>');
+                                }
+                                displayVal += '</div>';  // end of .full-study-details
+                                displayVal += '<a class="full-ref-toggle" href="#">[show details]</a>';
+                                displayVal += '</div>';  // end of .related-study
                             }
-                            displayVal += '</div>';  // end of .full-study-details
-                            displayVal += '<a class="full-ref-toggle" href="#">[show details]</a>';
-                            displayVal += '</div>';  // end of .related-study
 
                             //$details.append('<dt>'+ dLabel +'</dt>');
                             $details.append('<dd class="'+ markerClass +'">'+ displayVal +'</dd>');

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -884,7 +884,9 @@ function showObjectProperties( objInfo, options ) {
                 // this supporting data is already in arguson
             } else {
                 // it's a study; call the index to get full details
-                if ((typeof sourceMetadata['sourceDetails'] === 'undefined') && (sourceMetadata['loadStatus'] !== 'PENDING')) {
+                if ((typeof sourceMetadata['sourceDetails'] === 'undefined')
+                 && (sourceMetadata['loadStatus'] !== 'PENDING')        // fetch in progress
+                 && (sourceMetadata['loadStatus'] !== 'FAILED')) {      // fetch tried and failed
                     // don't keep sending requests for the same source! we manage this with 'loadStatus'
                     sourceMetadata['loadStatus'] = 'PENDING';
                     ///console.warn('>>>>>>>>>>>>>>> sourceDetails NOT FOUND for sourceID '+ sourceID +', FETCHING NOW...');

--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -909,13 +909,13 @@ function showObjectProperties( objInfo, options ) {
                                     var studyInfo = data.matched_studies[0];
                                     cbSourceMetadata['sourceDetails'] = studyInfo;
                                     cbSourceMetadata['loadStatus'] = 'COMPLETE';
-                                    // Nudge for a refresh of the properties display?
-                                    showObjectProperties( objInfo );
                                 } else {
                                     console.log(">>>> EXPECTED to find a matching study for id '"+ (cbSourceMetadata).study_id +"', not this:");
                                     console.log(data);
                                     cbSourceMetadata['loadStatus'] = 'FAILED';
                                 }
+                                // In either case, nudge for a refresh of the properties display?
+                                showObjectProperties( objInfo );
                             }
                         }
                     );


### PR DESCRIPTION
This addresses a known issue on **devtree** (but not reported on **production**) where we sometimes can't retrieve information about supporting/conflicting studies ([example](https://devtree.opentreeoflife.org/opentree/argus/opentree12.3@mrcaott3190ott388185)). In these cases, the failed fetch will often block any studies from appearing here.

After these changes, we'll show whatever studies we can find, plus a brief explanation of any studies that could not be fetched:
![Screen Shot 2020-07-01 at 8 16 40 PM](https://user-images.githubusercontent.com/446375/86302935-4731d680-bbd8-11ea-97a3-85f38772b6e4.png)

This is working now on **devtree**.