### PR TITLE
SVG inkscape fix

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10829,28 +10829,13 @@ function updateSaveTreeViewLink() {
         // copy the main page's tree-view stylesheet exactly
         // N.B. putting it where even Inkscape can find it :-/
         var stylesheetHTML = $treeStylesheet[0].outerHTML;
-        // Inkscape is picky about `svg:style` vs. `xhtml:style`!
-        /* NO, this is later unrecognized in the SVG DOM
-        stylesheetHTML = stylesheetHTML.replace('<style', '<svg:style')
-                                       .replace('</style', '</svg:style');
+        /* Inkscape is picky about `svg:style` vs. `xhtml:style`!
+         * jQuery's $.prepend() implicitly creates a DOM element from our HTML, and
+         * that element is always from the xhtml namespace. We need to use an
+         * alternative, explicit method to create an `svg:style` element.
         */
-        /* NO, this results in a second 'xmlns' attribute (invalid)
-        stylesheetHTML = stylesheetHTML.replace('<style', '<style xmlns="http://www.w3.org/2000/svg"');
-        *;
-        /* NO, the final result is always an `xhtml:style` element
-        // Replace its implicit namespace with explicit? or remove entirely?
-        //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', '');
-        //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
-        */
-
-        /* OK the problem is *here*. jQuery's prepend is implicitly creating a
-         * DOM element from our HTML, and that element is always from the xhtml
-         * namespace. We need to use an alternative, explicit method to create
-         * an `svg:style` element.
-        */
-        //var svgEl = document.createElementNS(svgUrl, "style");
         var svgHolder = document.createElementNS(svgUrl, "svg");
-        svgHolder.innerHTML = stylesheetHTML;  // will this inherit the parent's namespace?
+        svgHolder.innerHTML = stylesheetHTML;  // N.B. this inherits the parent's namespace!
         $treeSVG.prepend( svgHolder.firstChild );
     }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10833,7 +10833,12 @@ function updateSaveTreeViewLink() {
         stylesheetHTML = stylesheetHTML.replace('<style', '<svg:style')
                                        .replace('</style', '</svg:style');
         */
+        /* ADDS a second xmlns!
         stylesheetHTML = stylesheetHTML.replace('<style', '<style xmlns="http://www.w3.org/2000/svg"');
+        */
+        // Replace its implicit namespace with explicit? or remove entirely?
+        stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', '');
+        // stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
         $treeSVG.prepend( stylesheetHTML );
     }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10848,7 +10848,7 @@ console.log(stylesheetHTML);
     // create a temporary XML document
     var serializer = new XMLSerializer();
     var tempXMLDoc = document.implementation.createDocument(
-        null,   // desired namespace, or null
+        "http://www.w3.org/2000/svg",   // desired namespace, or null
         "svg",  // name of top-level element
         null    // desired doctype, or null
     )

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10827,7 +10827,11 @@ function updateSaveTreeViewLink() {
     if ($treeSVG.find('style').length === 0) {
         // copy the main page's tree-view stylesheet exactly
         // N.B. putting it where even Inkscape can find it :-/
-        $treeSVG.prepend( $treeStylesheet[0].outerHTML );
+        var stylesheetHTML = $treeStylesheet[0].outerHTML;
+        // Inkscape is picky about `svg:style` vs. `xhtml:style`!
+        stylesheetHTML = stylesheetHTML.replace('<style', '<svg:style')
+                                       .replace('</style', '</svg:style');
+        $treeSVG.prepend( stylesheetHTML );
     }
 
     // Serialize the main SVG node (converting HTML entities to Unicode); first, we

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10829,8 +10829,11 @@ function updateSaveTreeViewLink() {
         // N.B. putting it where even Inkscape can find it :-/
         var stylesheetHTML = $treeStylesheet[0].outerHTML;
         // Inkscape is picky about `svg:style` vs. `xhtml:style`!
+        /*
         stylesheetHTML = stylesheetHTML.replace('<style', '<svg:style')
                                        .replace('</style', '</svg:style');
+        */
+        stylesheetHTML = stylesheetHTML.replace('<style', '<style xmlns="http://www.w3.org/2000/svg"');
         $treeSVG.prepend( stylesheetHTML );
     }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10821,7 +10821,8 @@ function updateSaveTreeViewLink() {
     var fileName = slugify( treeName ) +'.svg';
 
     // confirm SVG has needed attributes (missing in Firefox)
-    $treeSVG.attr({ version: '1.1' , xmlns:"http://www.w3.org/2000/svg"});
+    var svgUrl = "http://www.w3.org/2000/svg";
+    $treeSVG.attr({ version: '1.1' , xmlns: svgUrl});
 
     // confirm SVG has our CSS styles for the tree view (or add them now)
     if ($treeSVG.find('style').length === 0) {
@@ -10829,19 +10830,28 @@ function updateSaveTreeViewLink() {
         // N.B. putting it where even Inkscape can find it :-/
         var stylesheetHTML = $treeStylesheet[0].outerHTML;
         // Inkscape is picky about `svg:style` vs. `xhtml:style`!
-        /*
+        /* NO, this is later unrecognized in the SVG DOM
         stylesheetHTML = stylesheetHTML.replace('<style', '<svg:style')
                                        .replace('</style', '</svg:style');
         */
-console.log("========== BEFORE:");
-console.log(stylesheetHTML);
+        /* NO, this results in a second 'xmlns' attribute (invalid)
         stylesheetHTML = stylesheetHTML.replace('<style', '<style xmlns="http://www.w3.org/2000/svg"');
-console.log("========== AFTER:");
-console.log(stylesheetHTML);
+        *;
+        /* NO, the final result is always an `xhtml:style` element
         // Replace its implicit namespace with explicit? or remove entirely?
         //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', '');
         //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
-        $treeSVG.prepend( stylesheetHTML );
+        */
+
+        /* OK the problem is *here*. jQuery's prepend is implicitly creating a
+         * DOM element from our HTML, and that element is always from the xhtml
+         * namespace. We need to use an alternative, explicit method to create
+         * an `svg:style` element.
+        */
+        //var svgEl = document.createElementNS(svgUrl, "style");
+        var svgHolder = document.createElementNS(svgUrl, "svg");
+        svgHolder.innerHTML = stylesheetHTML;  // will this inherit the parent's namespace?
+        $treeSVG.prepend( svgHolder.firstChild );
     }
 
     // Serialize the main SVG node (converting HTML entities to Unicode); first, we

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10833,12 +10833,14 @@ function updateSaveTreeViewLink() {
         stylesheetHTML = stylesheetHTML.replace('<style', '<svg:style')
                                        .replace('</style', '</svg:style');
         */
-        /* ADDS a second xmlns!
+console.log("========== BEFORE:");
+console.log(stylesheetHTML);
         stylesheetHTML = stylesheetHTML.replace('<style', '<style xmlns="http://www.w3.org/2000/svg"');
-        */
+console.log("========== AFTER:");
+console.log(stylesheetHTML);
         // Replace its implicit namespace with explicit? or remove entirely?
         //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', '');
-        stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
+        //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
         $treeSVG.prepend( stylesheetHTML );
     }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -10837,8 +10837,8 @@ function updateSaveTreeViewLink() {
         stylesheetHTML = stylesheetHTML.replace('<style', '<style xmlns="http://www.w3.org/2000/svg"');
         */
         // Replace its implicit namespace with explicit? or remove entirely?
-        stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', '');
-        // stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
+        //stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', '');
+        stylesheetHTML = stylesheetHTML.replace('xmlns="http://www.w3.org/1999/xhtml"', 'xmlns="http://www.w3.org/2000/svg"');
         $treeSVG.prepend( stylesheetHTML );
     }
 


### PR DESCRIPTION
Make the SVG namespace explicit in our internal (borrowed) stylesheet, so that tree styles and colors are recognized by the popular Inkscape program. This is tested and working on **devtree**.