### PR TITLE
Smarter cookie management (GDPR)

### DIFF
--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -1086,7 +1086,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
       "position": "bottom",
       "type": "opt-out",
       "onStatusChange": function(status) {
-          console.warn('onStatusChange, status = '+ status);
           if (this.hasConsented()) {
               // anything to do here?
           } else {
@@ -1094,7 +1093,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
           }
       },
       "onInitialise": function(status) {
-          console.warn('onInitialise, status = '+ status);
           if (status === 'deny') {
             forceDeleteTrackingCookies();
           }

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -3,6 +3,7 @@
 from applications.opentree.modules.opentreewebapputil import get_user_login, get_user_display_name, get_conf, get_domain_banner_text, get_domain_banner_hovertext, get_currently_deployed_opentree_branch
 }}
 <html lang="{{=T.accepted_language or 'en'}}" class="no-js"><!-- no-js need it for modernzr -->
+  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" />
   <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-143548106-1"></script>
@@ -1052,5 +1053,62 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
     </div>
 {{ pass }}
 
+<!-- cookie consent for first-time visitors -->
+<script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js" data-cfasync="false"></script>
+<script type="text/javascript">
+    function showCurrentCookieStatus() {
+        // TODO: Vary this message based on latest user decision?
+        return "This website uses cookies to maintain user sessions (essential) and to anonymously track how people use the website (optional).";
+    }
+    function forceDeleteTrackingCookies() {
+      // Clear any existing tracking cookies from Google Analytics!
+      ///window['ga-disable-UA-143548106-1'] = true;
+      // N.B. `document.cookie` is a smart setter, won't affect other cookies
+      document.cookie = "_ga=;max-age=-1;path=/;domain=.opentreeoflife.org";
+      document.cookie = "_gid=;max-age=-1;path=/;domain=.opentreeoflife.org";
+      // sometimes these cookies are set to third-level domains! why?!
+      document.cookie = "_ga=;max-age=-1;path=/;domain=.devtree.opentreeoflife.org";
+      document.cookie = "_gid=;max-age=-1;path=/;domain=.devtree.opentreeoflife.org";
+      document.cookie = "_ga=;max-age=-1;path=/;domain=.tree.opentreeoflife.org";
+      document.cookie = "_gid=;max-age=-1;path=/;domain=.tree.opentreeoflife.org";
+    }
+    window.cookieconsent.initialise({
+      "palette": {
+        "popup": {
+          "background": "#cc0000",
+          "text": "#ffffff"
+        },
+        "button": {
+          "background": "#ffffff"
+        }
+      },
+      "theme": "classic",
+      "position": "bottom",
+      "type": "opt-out",
+      "onStatusChange": function(status) {
+          console.warn('onStatusChange, status = '+ status);
+          if (this.hasConsented()) {
+              // anything to do here?
+          } else {
+              forceDeleteTrackingCookies();
+          }
+      },
+      "onInitialise": function(status) {
+          console.warn('onInitialise, status = '+ status);
+          if (status === 'deny') {
+            forceDeleteTrackingCookies();
+          }
+      },
+      "onStatusChange": function(status) {
+          console.warn('onStatusChange, status = '+ status);
+      },
+      "content": {
+        "message": showCurrentCookieStatus(),
+        // "dismiss": "OK",
+        "deny": "Refuse tracking",
+        "href": "/about/privacy-policy"
+      }
+    });
+</script>
   </body>
 </html>

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -1099,9 +1099,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
             forceDeleteTrackingCookies();
           }
       },
-      "onStatusChange": function(status) {
-          console.warn('onStatusChange, status = '+ status);
-      },
       "content": {
         "message": showCurrentCookieStatus(),
         // "dismiss": "OK",

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -595,6 +595,10 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
 <!-- cookie consent for first-time visitors -->
 <script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js" data-cfasync="false"></script>
 <script type="text/javascript">
+    function showCurrentCookieStatus() {
+        // TODO: Vary this message based on latest user decision?
+        return "This website uses cookies to maintain user sessions (essential) and to anonymously track how people use the website (optional).";
+    }
     window.cookieconsent.initialise({
       "palette": {
         "popup": {
@@ -608,9 +612,26 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
       "theme": "classic",
       "position": "bottom",
       "type": "opt-out",
+      "onStatusChange": function(status) {
+          console.warn('onStatusChange, status = '+ status);
+          if (this.hasConsented()) {
+              // anything to do here?
+          } else {
+              // TODO: Clear any existing tracking cookie!
+          }
+      },
+      "onInitialise": function(status) {
+          console.warn('onInitialise, status = '+ status);
+      },
+      "onPopupOpen": function() {
+          console.warn('onPopupOpen');
+      },
+      "onStatusChange": function(status) {
+          console.warn('onStatusChange, status = '+ status);
+      },
       "content": {
-        "message": "This website uses cookies to maintain user sessions (essential) and to anonymously track how people use the website (optional).",
-        "dismiss": "OK",
+        "message": showCurrentCookieStatus(),
+        // "dismiss": "OK",
         "deny": "Refuse tracking",
         "href": "/about/privacy-policy"
       }

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -638,9 +638,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
             forceDeleteTrackingCookies();
           }
       },
-      "onStatusChange": function(status) {
-          console.warn('onStatusChange, status = '+ status);
-      },
       "content": {
         "message": showCurrentCookieStatus(),
         // "dismiss": "OK",

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -599,6 +599,13 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         // TODO: Vary this message based on latest user decision?
         return "This website uses cookies to maintain user sessions (essential) and to anonymously track how people use the website (optional).";
     }
+    function forceDeleteTrackingCookies() {
+      // Clear any existing tracking cookies from Google Analytics!
+      ///window['ga-disable-UA-143548106-1'] = true;
+      // N.B. `document.cookie` is a smart setter, won't affect other cookies
+      document.cookie = "_ga=;max-age=-1;path=/;domain=.opentreeoflife.org";
+      document.cookie = "_gid=;max-age=-1;path=/;domain=.opentreeoflife.org";
+    }
     window.cookieconsent.initialise({
       "palette": {
         "popup": {
@@ -617,18 +624,14 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
           if (this.hasConsented()) {
               // anything to do here?
           } else {
-              // Clear any existing tracking cookies from Google Analytics!
-              ///window['ga-disable-UA-143548106-1'] = true;
-              // N.B. `document.cookie` is a smart setter, won't affect other cookies
-              document.cookie = "_ga=;max-age=-1;path=/;domain=.opentreeoflife.org";
-              document.cookie = "_gid=;max-age=-1;path=/;domain=.opentreeoflife.org";
+              forceDeleteTrackingCookies();
           }
       },
       "onInitialise": function(status) {
           console.warn('onInitialise, status = '+ status);
-      },
-      "onPopupOpen": function() {
-          console.warn('onPopupOpen');
+          if (status === 'deny') {
+            forceDeleteTrackingCookies();
+          }
       },
       "onStatusChange": function(status) {
           console.warn('onStatusChange, status = '+ status);

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -625,7 +625,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
       "position": "bottom",
       "type": "opt-out",
       "onStatusChange": function(status) {
-          console.warn('onStatusChange, status = '+ status);
           if (this.hasConsented()) {
               // anything to do here?
           } else {
@@ -633,7 +632,6 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
           }
       },
       "onInitialise": function(status) {
-          console.warn('onInitialise, status = '+ status);
           if (status === 'deny') {
             forceDeleteTrackingCookies();
           }

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -617,7 +617,11 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
           if (this.hasConsented()) {
               // anything to do here?
           } else {
-              // TODO: Clear any existing tracking cookie!
+              // Clear any existing tracking cookies from Google Analytics!
+              ///window['ga-disable-UA-143548106-1'] = true;
+              // N.B. `document.cookie` is a smart setter, won't affect other cookies
+              document.cookie = "_ga=;max-age=-1;path=/;domain=.opentreeoflife.org";
+              document.cookie = "_gid=;max-age=-1;path=/;domain=.opentreeoflife.org";
           }
       },
       "onInitialise": function(status) {

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -605,6 +605,11 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
       // N.B. `document.cookie` is a smart setter, won't affect other cookies
       document.cookie = "_ga=;max-age=-1;path=/;domain=.opentreeoflife.org";
       document.cookie = "_gid=;max-age=-1;path=/;domain=.opentreeoflife.org";
+      // sometimes these cookies are set to third-level domains! why?!
+      document.cookie = "_ga=;max-age=-1;path=/;domain=.devtree.opentreeoflife.org";
+      document.cookie = "_gid=;max-age=-1;path=/;domain=.devtree.opentreeoflife.org";
+      document.cookie = "_ga=;max-age=-1;path=/;domain=.tree.opentreeoflife.org";
+      document.cookie = "_gid=;max-age=-1;path=/;domain=.tree.opentreeoflife.org";
     }
     window.cookieconsent.initialise({
       "palette": {


### PR DESCRIPTION
I've tightened up the logic here, so that any existing tracking cookies (Google Analytics) are cleared when the user chooses **Refuse tracking**. I've also cloned the logic and UI for this to the curation app, so that the behavior is consistent across our main web-apps.

This is tested and working now on **devtree**. 