### PR TITLE
Test for script-managed trees, show warning msg

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9139,6 +9139,19 @@ function currentStudyVersionContributedToLatestSynthesis() {
     return (viewModel.startingCommitSHA === latestSynthesisSHA);
 }
 
+function studyContainsScriptManagedTrees() {
+    // check for signature for this in Nexson (to modify UI, hide/block some features?)
+    var allTrees = viewModel.elementTypes.tree.gatherAll(viewModel.nexml);
+    var bigTrees = ko.utils.arrayFilter(
+        allTrees,
+        function (tree) {
+            // if this property is found (even if it's an empty object), assume it's a huge script-managed tree
+            return (tree["^ot:external_data"] !== undefined);
+        }
+    );
+    return (bigTrees.length > 0);
+}
+
 function getNormalizedStudyPublicationURL() {
     // just the bare URL, or '' if not found
     var url = $.trim(viewModel.nexml['^ot:studyPublication']['@href']);

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -374,6 +374,20 @@ body {
                </div>
               </div>
 
+               <!-- ko if: studyContainsScriptManagedTrees() -->
+                <div class="empty-list-prompt">
+                    This study contains 
+                    <a target="_blank"
+                       href="https://github.com/OpenTreeOfLife/script-managed-trees/blob/master/README.md">script-managed trees</a> 
+                    that are too large to store in phylesystem.
+                    These cannot be managed in the curation web app, nor can
+                    this study's OTUs, but you can edit the study's metadata
+                    and see its revision history.
+                </div>
+
+               <!-- /ko -->
+
+               <!-- ko if: ! studyContainsScriptManagedTrees() -->
                 <div class="empty-list-prompt" data-bind="visible: viewModel.filteredTrees().pagedItems().length === 0">
                     No matching trees found! Add new trees or clear the
                     filter above to see trees in this study.
@@ -525,6 +539,7 @@ body {
                     </li>
                   </ul>
                 </div>
+               <!-- /ko -->
 
             </div>
 


### PR DESCRIPTION
As discussed, we should detect studies with script-managed trees and flag them in the curation app. If such a tree is found, this message will appear instead of the normal tree list:
![Screen Shot 2020-09-24 at 1 20 07 AM](https://user-images.githubusercontent.com/446375/94104397-f6133680-fe04-11ea-9fe9-8c4dc34c4dde.png)

The test function appears to be working on **devtree**, but this PR is **blocked** since such a study won't load properly in the curation web-app. See for example https://devtree.opentreeoflife.org/curator/study/view/tt_217
The footer message that appears points to a Nexson validation error:
```
Exception in coercing to the required NexSON version for validation.
```