### PR TITLE
Fix mess from long, unbroken words in tree name

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -402,7 +402,7 @@ body {
                   <tbody data-bind="foreach: { data: viewModel.filteredTrees().pagedItems(), as: 'tree' }">
                     <tr data-bind="if: true">
                         <td>
-                            <a href="#" data-bind="click: showTreeWithHistory,
+                            <a href="#" style="hyphens: auto; overflow-wrap: anywhere;" data-bind="click: showTreeWithHistory,
                                 text: tree['@label'],
                                 attr: { href : getViewURLFromStudyID(studyID) + '/?tab=trees&tree=' + tree['@id'] },
                                 css: viewModel.ticklers.TREES">&nbsp;</a>


### PR DESCRIPTION
See Luna's bug report in Gitter:
https://gitter.im/OpenTreeOfLife/ot-private?at=60244c0f24cd6b60d82fc9de

This fix is working on **devtree**. I don't have an example study handy, but I tweaked the text in the browser's dev tools to test it.