### PR TITLE
new stats

### DIFF
--- a/webapp/static/statistics/ott.json
+++ b/webapp/static/statistics/ott.json
@@ -6,6 +6,12 @@
         "===": "visible_taxon_count comes from `cleaned_ott/index.html` in propinquity output",
         "===": "For proper sorting, all `date` strings must be in the form {yyyy-mm-dd}!",
 
+        "version": "ott3.3",
+        "date": "2021-06-01",
+        "taxon_count":         4528126,
+        "visible_taxon_count": 3943129
+    },
+    {
         "version": "ott3.2",
         "date": "2019-10-30",
         "taxon_count":         4528053,

--- a/webapp/static/statistics/synthesis.json
+++ b/webapp/static/statistics/synthesis.json
@@ -122,5 +122,14 @@
         "tree_count": 1216,
         "total_OTU_count": 87740,
         "tip_count": 2391916
+    },
+    "2021-06-18T00Z": {
+        "===": "tree_count from https://files.opentreeoflife.org/synthesis/opentree13.4/output/index.html",
+        "===": "total_OTU_count and tip_count found in https://files.opentreeoflife.org/synthesis/opentree13.4/output/labelled_supertree/index.html",
+        "version": "v13.4",
+        "OTT_version": "ott3.3draft1",
+        "tree_count": 1239,
+        "total_OTU_count": 94028,
+        "tip_count": 2392042
     }
 }


### PR DESCRIPTION
13.4 is now being served on tree, but I forgot that I'd need to merge and deploy this before the metadata pages load correctly.
Can you merge this if it looks OK to you, @jimallman ?    Thanks,
Mark