### PR TITLE
pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests
 python-dateutil==2.2
 locket==0.1.1
 bleach
-jwcrypto
+jwcrypto==0.9.1
 python_jwt


### PR DESCRIPTION
I think https://pypi.org/project/jwcrypto/0.9.1/ is the last version (planned) to support python 2.7 v1.0 is pulled down without pinning, and it is definitely not py2.7 compatible