### PR TITLE
Allow reusing taxon names

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -11124,10 +11124,11 @@ function taxonCondidateIsValid( candidate, options ) {
             }
             return false;
         case 'FOUND IN TAXONOMY':
+            // we want to allow existing taxon names, but let's give a warning too
             if (options.REPORT_ERRORS) {
-                showErrorMessage('There is already a taxon with this name! Homonyms are not currently allowed.');
+                showInfoMessage('There is already a taxon with this name! Proceed with caution.');
             }
-            return false;
+            // return false;
         case 'NOT FOUND':
             // it's a unique name! no problem here
             break;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -11124,11 +11124,14 @@ function taxonCondidateIsValid( candidate, options ) {
             }
             return false;
         case 'FOUND IN TAXONOMY':
-            // we want to allow existing taxon names, but let's give a warning too
+            // we want to allow existing taxon names, and we already show a warning
+            /*
             if (options.REPORT_ERRORS) {
                 showInfoMessage('There is already a taxon with this name! Proceed with caution.');
             }
             // return false;
+            */
+            break;
         case 'NOT FOUND':
             // it's a unique name! no problem here
             break;
@@ -11306,7 +11309,7 @@ function proposedTaxonNameStatusMessage(candidate) {
         case 'NOT FOUND':
             return "No duplicates found.";
         case 'FOUND IN TAXONOMY':
-            return "Already in OT taxonomy!";
+            return "Already in OT taxonomy! Are you sure?";
         case 'FOUND IN CANDIDATES':
             return "Already in proposed taxa!";
         default:


### PR DESCRIPTION
As discussed, we will allow a curator to propose a new taxon with a name that already exists in OTT. (A warning will be displayed, but we won't block submission of the name.) This is tested and working now on **devtree**.