### PR TITLE
Use a simpler scheme for safe element IDs

### DIFF
--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8005,7 +8005,7 @@ function getNextElementOrdinalNumber( elementType, nexml ) {
         // have we previously stored a higher ID for this type?
         var oldStoredValue = 0;
         if (nexml['highestMintedElementIDs']) {
-            oldStoredValue = nexml['highestMintedElementIDs'][elementType]) || 0;
+            oldStoredValue = (nexml['highestMintedElementIDs'][elementType]) || 0;
         }
         // track the *highest* of these, to avoid accidental re-use of a deleted ID
         typeInfo.highestOrdinalNumber = Math.max( highestIdInUse, oldStoredValue);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7989,6 +7989,9 @@ function getNextAvailableElementID( elementType, nexml ) {
 }
 function getNextElementOrdinalNumber( elementType, nexml ) {
     // increment and returns the next available ordinal number for this type
+    if (!nexml) {
+        nexml = viewModel.nexml;
+    }
     if (!(elementType in viewModel.elementTypes)) {
         console.error('getNextElementOrdinalNumber(): type "'+ elementType +'" not found!');
         return;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -751,6 +751,11 @@ function loadSelectedStudy() {
              * simple integer tallies to show determine the next available ID in the
              * current study.
              *
+             * These IDs should *persist* in the saved study, to avoid problems with
+             * stale IDs being re-used in some cases. (This causes confusion with, e.g.,
+             * tree collections that include a now-missing tree4, but now we have a
+             * new, unrelated tree4 in its place.)
+             *
              * N.B. Unless otherwise specified with a 'prefix' property, the
              * key in each case is also the preferred prefix.
              */
@@ -2510,6 +2515,7 @@ function scrubNexsonForTransport( nexml ) {
      *   - remove "empty" elements if server doesn't expect them
      *   - clean up empty/unused OTU alt-labels
      *   - remove client-side MRCA test results
+     *   - ADD element-ID trackers, if not found
      */
     if (!nexml) {
         nexml = viewModel.nexml;
@@ -2578,6 +2584,28 @@ function scrubNexsonForTransport( nexml ) {
             }
         }
     });
+
+    // add (or update) our element-ID trackers to avoid re-using deleted IDs
+    if (!(['highestMintedElementIDs'] in nexml)) {
+        nexml['highestMintedElementIDs'] = {};
+    }
+    /* Record the highest ID found (or next available?) for each
+     * element type found in the live study. If the tracker already exists,
+     * weigh its currently stored number against whatever else we find.
+     */
+    for (var elType in viewModel.elementTypes) {
+        var typeInfo = viewModel.elementTypes[ elType ];
+        var typePrefix = typeInfo.prefix || elementType;
+        var highestIdInUse = findHighestElementOrdinalNumberInUse(
+                nexml,
+                typePrefix,
+                typeInfo.gatherAll
+            );
+        }
+        // is there a previously stored value for this type?
+        var oldStoredValue = (nexml['highestMintedElementIDs'][ elType ]) || 0;
+        nexml['highestMintedElementIDs'][ elType ] = Math.max( highestIdInUse, oldStoredValue);
+    }
 }
 
 function saveFormDataToStudyJSON() {
@@ -7969,17 +7997,22 @@ function getNextElementOrdinalNumber( elementType, nexml ) {
     var typeInfo = viewModel.elementTypes[elementType];
     var typePrefix = typeInfo.prefix || elementType;
     if (typeInfo.highestOrdinalNumber === null) {
-        typeInfo.highestOrdinalNumber = findHighestElementOrdinalNumber(
+        // first scan all elements in the current study
+        var highestIdInUse = findHighestElementOrdinalNumberInUse(
             nexml,
             typePrefix,
             typeInfo.gatherAll
         );
+        // have we previously stored a higher ID for this type?
+        var oldStoredValue = (nexml['highestMintedElementIDs'][elementType]) || 0;
+        // track the *highest* of these, to avoid accidental re-use of a deleted ID
+        typeInfo.highestOrdinalNumber = Math.max( highestIdInUse, oldStoredValue);
     }
-    // increment the highest ID for faster assignment next time
+    // increment the highest ID, since we're minting a new ID right now
     typeInfo.highestOrdinalNumber++;
     return typeInfo.highestOrdinalNumber;
 }
-function findHighestElementOrdinalNumber( nexml, prefix, gatherAllFunc ) {
+function findHighestElementOrdinalNumberInUse( nexml, prefix, gatherAllFunc ) {
     // Return the numeric component of the highest element ID matching
     // these specs, eg, 'node2336' => 2336
     if (!nexml) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8003,7 +8003,10 @@ function getNextElementOrdinalNumber( elementType, nexml ) {
             typeInfo.gatherAll
         );
         // have we previously stored a higher ID for this type?
-        var oldStoredValue = (nexml['highestMintedElementIDs'][elementType]) || 0;
+        var oldStoredValue = 0;
+        if (nexml['highestMintedElementIDs']) {
+            oldStoredValue = nexml['highestMintedElementIDs'][elementType]) || 0;
+        }
         // track the *highest* of these, to avoid accidental re-use of a deleted ID
         typeInfo.highestOrdinalNumber = Math.max( highestIdInUse, oldStoredValue);
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2597,11 +2597,10 @@ function scrubNexsonForTransport( nexml ) {
         var typeInfo = viewModel.elementTypes[ elType ];
         var typePrefix = typeInfo.prefix || elementType;
         var highestIdInUse = findHighestElementOrdinalNumberInUse(
-                nexml,
-                typePrefix,
-                typeInfo.gatherAll
-            );
-        }
+            nexml,
+            typePrefix,
+            typeInfo.gatherAll
+        );
         // is there a previously stored value for this type?
         var oldStoredValue = (nexml['highestMintedElementIDs'][ elType ]) || 0;
         nexml['highestMintedElementIDs'][ elType ] = Math.max( highestIdInUse, oldStoredValue);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2593,8 +2593,8 @@ function scrubNexsonForTransport( nexml ) {
      * element type found in the live study. If the tracker already exists,
      * weigh its currently stored number against whatever else we find.
      */
-    for (var elType in viewModel.elementTypes) {
-        var typeInfo = viewModel.elementTypes[ elType ];
+    for (var elementType in viewModel.elementTypes) {
+        var typeInfo = viewModel.elementTypes[ elementType ];
         var typePrefix = typeInfo.prefix || elementType;
         var highestIdInUse = findHighestElementOrdinalNumberInUse(
             nexml,
@@ -2602,8 +2602,8 @@ function scrubNexsonForTransport( nexml ) {
             typeInfo.gatherAll
         );
         // is there a previously stored value for this type?
-        var oldStoredValue = (nexml['highestMintedElementIDs'][ elType ]) || 0;
-        nexml['highestMintedElementIDs'][ elType ] = Math.max( highestIdInUse, oldStoredValue);
+        var oldStoredValue = (nexml['highestMintedElementIDs'][ elementType ]) || 0;
+        nexml['highestMintedElementIDs'][ elementType ] = Math.max( highestIdInUse, oldStoredValue);
     }
 }
 


### PR DESCRIPTION
As discussed, we'd like to have single- or double-digit IDs for elements (esp. trees). This scheme will keep track of the highest minted IDs for each element type and store it in phylesystem. Addresses #1302.