### PR TITLE
Smarter collection refresh

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1265,22 +1265,44 @@ function updateCollectionTrees ( collection ) {
                                     return;
                             }
                             if (foundTree) {
-                                /* Still here? Compare the tree's current name and study
-                                 * reference to the version stored in this collection
+                                /* Still here? Compare the found study and tree's properties (name, study reference,
+                                 * compact reference, date) to the version stored in this collection.
                                  */
+                                // tree name (NB - modified to include compact reference!)
                                 var foundTreeName = $.trim(foundTree['@label']);
                                 var proposedName = $.trim(foundTreeName || decision.treeID) +' ('+ compactStudyRef +')';
-                                var treeLabelHasChanged = false;
-                                if (proposedName == decision.name) {
+                                var treeLabelHasChanged = (proposedName != decision['name']);
+                                // focal clade
+                                var proposedClade = foundStudy['ot:focalCladeOTTTaxonName'];
+                                var focalCladeHasChanged = (proposedClade == decision['ot:focalCladeOTTTaxonName']);
+                                // publication URL
+                                var proposedPubURL = foundStudy['ot:studyPublication'];
+                                var pubUrlHasChanged = (proposedPubURL != decision['ot:studyPublication']);
+                                // full study reference (text)
+                                var proposedFullRef = foundStudy['ot:studyPublicationReference'];
+                                var fullRefHasChanged = (proposedFullRef != decision['ot:studyPublicationReference']);
+                                // compact study reference (already generated above)
+                                var compactRefHasChanged = (compactStudyRef != decision['compactRefText']);
+                                // study year
+                                var proposedYear = foundStudy['ot:studyYear'];
+                                var studyYearHasChanged = (proposedYear != decision['ot:studyYear']);
+
+                                if (treeLabelHasChanged || focalCladeHasChanged || pubUrlHasChanged || fullRefHasChanged 
+                                    || compactRefHasChanged || studyYearHasChanged) {
+                                    treesChanged += 1;
+                                    // Update the existing collection record for this tree; mark it for review
+                                    decision['name'] = proposedName;
+                                    decision['ot:focalCladeOTTTaxonName'] = proposedClade;
+                                    decision['ot:studyPublication'] = proposedPubURL;
+                                    decision['ot:studyPublicationReferenc'] = proposedFullRef;
+                                    decision['compactRefText'] = compactStudyRef;
+                                    decision['ot:studyYear'] = proposedYear;
+                                    // Highlight this in the list, mark as MODIFIED
+                                    decision.status = 'MODIFIED';
+                                } else {
                                     treesUnchanged += 1;
                                     // UN-highlight this in the list, mark as UNCHANGED
                                     decision.status = 'UNCHANGED';
-                                } else {
-                                    // Update the existing collection record for this tree; mark it for review
-                                    treesChanged += 1;
-                                    decision.name = proposedName;
-                                    // Highlight this in the list, mark as MODIFIED
-                                    decision.status = 'MODIFIED';
                                 }
                                 /* TODO: Should we update the tree's SHA? Not currently available! */
                             }

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1181,7 +1181,7 @@ function updateCollectionTrees ( collection ) {
          * Update its compact study reference, if changed
          * Update UI along the way...
          *    grey block = UNCHANGED
-         *    yellow block = RENAMED (either label or compact reference)
+         *    yellow block = MODIFIED (label, references, year, etc.)
          *    red block = REMOVED
          */
         // look for a matching tree in the study index
@@ -1279,8 +1279,8 @@ function updateCollectionTrees ( collection ) {
                                     // Update the existing collection record for this tree; mark it for review
                                     treesChanged += 1;
                                     decision.name = proposedName;
-                                    // Highlight this in the list, mark as RENAMED
-                                    decision.status = 'RENAMED';
+                                    // Highlight this in the list, mark as MODIFIED
+                                    decision.status = 'MODIFIED';
                                 }
                                 /* TODO: Should we update the tree's SHA? Not currently available! */
                             }
@@ -1328,7 +1328,7 @@ function updateCollectionTrees ( collection ) {
                         if (treesChanged > 0) {
                             summaryMsg += (String(treesChanged) +' tree'+ (treesChanged == 1 ? '' : 's')
                                 +' (marked in yellow) ' + (treesChanged == 1 ? 'has' : 'have')
-                                +' been renamed. New names are usually an improvement and worth saving. ');
+                                +' been modified (changes to name, reference, year, clade). These changes are usually an improvement and worth saving. ');
                         }
                         summaryMsg += 'Remember to save this collection after your review, or cancel to ignore these changes.';
                         showErrorMessage(summaryMsg);
@@ -1799,8 +1799,7 @@ function addPendingCollectionChange( action, studyID, treeID ) {
             msg = ('Changed ranking of trees.');
             break;
         case 'UPDATE':
-            //msg = ('Tree names and status renamed in phylesystem.');
-            msg = ('Tree '+ treeID +' from study '+ studyID +' renamed in phylesystem.');
+            msg = ('Tree '+ treeID +' from study '+ studyID +' modified in phylesystem.');
             break;
         default:
             console.error('UNKNOWN collection change: '+ action);
@@ -2228,7 +2227,7 @@ function saveTreeCollection( collection ) {
     // remove explicit ranking values (rely on array order)
     stripTreeCollectionRanking( collection );
 
-    // remove any 'status' property markers (RENAMED, REMOVED, etc.)
+    // remove any 'status' property markers (MODIFIED, REMOVED, etc.)
     stripTreeCollectionStatusMarkers( collection );
 
     // push changes back to storage

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1274,7 +1274,7 @@ function updateCollectionTrees ( collection ) {
                                 var treeLabelHasChanged = (proposedName != decision['name']);
                                 // focal clade
                                 var proposedClade = foundStudy['ot:focalCladeOTTTaxonName'];
-                                var focalCladeHasChanged = (proposedClade == decision['ot:focalCladeOTTTaxonName']);
+                                var focalCladeHasChanged = (proposedClade != decision['ot:focalCladeOTTTaxonName']);
                                 // publication URL
                                 var proposedPubURL = foundStudy['ot:studyPublication'];
                                 var pubUrlHasChanged = (proposedPubURL != decision['ot:studyPublication']);

--- a/curator/static/js/tree-collection-editor.js
+++ b/curator/static/js/tree-collection-editor.js
@@ -1193,7 +1193,7 @@ function scrubJsonForTransport( collection ) {
     // remove explicit ranking values (rely on array order)
     stripTreeCollectionRanking( collection );
 
-    // remove any 'status' property markers (RENAMED, REMOVED, etc.)
+    // remove any 'status' property markers (MODIFIED, REMOVED, etc.)
     stripTreeCollectionStatusMarkers( collection );
 
     // avoid empty or missing decision list

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -515,7 +515,7 @@ body {
                   <tbody data-bind="foreach: { data: viewModel.filteredTrees().pagedItems(), as: 'tree' }">
                     <tr data-bind="attr: { class: (userIsEditingCollection($parent) && $data['status'] == 'REMOVED') ?
                                                     'single-tree-row error' :
-                                                    (userIsEditingCollection($parent) && $data['status'] == 'RENAMED' ?
+                                                    (userIsEditingCollection($parent) && $data['status'] == 'MODIFIED' ?
                                                       'single-tree-row warning' :
                                                       'single-tree-row-'+ $data['status'] )
                                           },
@@ -571,9 +571,9 @@ body {
                         <div data-bind="visible: $data['status'] == 'REMOVED',
                                         css: viewModel.ticklers.TREES"
                              class="tree-status-marker text-error">REMOVED</div>
-                        <div data-bind="visible: $data['status'] == 'RENAMED',
+                        <div data-bind="visible: $data['status'] == 'MODIFIED',
                                         css: viewModel.ticklers.TREES"
-                             class="tree-status-marker text-warning">RENAMED</div>
+                             class="tree-status-marker text-warning">MODIFIED</div>
 
                         <!-- ko if: !userIsEditingCollection($parent) -->
                         <div data-bind="text: $data['rank']"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -779,7 +779,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                          data-bind="foreach: { data: $data.data.decisions }">
                       <tr data-bind="attr: { class: (userIsEditingCollection($parent) && $data['status'] == 'REMOVED') ?
                                                       'single-tree-row error' :
-                                                      (userIsEditingCollection($parent) && $data['status'] == 'RENAMED' ?
+                                                      (userIsEditingCollection($parent) && $data['status'] == 'MODIFIED' ?
                                                         'single-tree-row warning' :
                                                         'single-tree-row-'+ $data['status'] )
                                             }">
@@ -830,8 +830,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                            <!-- ko if: $data['status'] == 'REMOVED' -->
                              <div class="tree-status-marker text-error">REMOVED</div>
                            <!-- /ko -->
-                           <!-- ko if: $data['status'] == 'RENAMED' -->
-                             <div class="tree-status-marker text-warning">RENAMED</div>
+                           <!-- ko if: $data['status'] == 'MODIFIED' -->
+                             <div class="tree-status-marker text-warning">MODIFIED</div>
                            <!-- /ko -->
 
                           <!-- /ko --><!-- END of editing widgets -->


### PR DESCRIPTION
When refreshing/updating trees in a collection, we now compare all the study+tree properties that are stored in the tree collection to the latest study+tree in phylesystem. If any of these properties have changed, the tree is marked as MODIFIED (formerly RENAMED) for curator approval. Of course, saving the changes should store the new values in each case. Addresses #1300.

This is tested and working (afaict) on **devtree**.