### PR TITLE
Conflict with source tree2

### DIFF
--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -929,6 +929,7 @@ function getPhylesystemLookupPanel( context ) {
             console.error("getPhylesystemLookupPanel(): UNKNOWN context '"+ context +"'!");
             return null;
     }
+    return $container;
 }
 
 var showingResultsForStudyLookupText = '';

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1066,7 +1066,7 @@ function searchForMatchingStudy() {
                 var pathParts = $link.attr('href').split('/');
                 var studyID = pathParts[ pathParts.length - 1 ];
                 // update hidden field
-                $('input[name=study-lookup-id]').val( studyID );
+                $container.find('input[name=study-lookup-id]').val( studyID );
                 // hide menu and reset search field
                 clearTimeout(studyLookupTimeoutID);
                 $lookupResults.html('');

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2082,10 +2082,15 @@ function loadStudyListForLookup() {
         return true;
     }
 
-    // disable "Add tree" button until the list is loaded
-    var $newTreeStartButton = $('#new-collection-tree-start');
-    $newTreeStartButton.attr('disabled', 'disabled')
-                       .addClass('btn-info-disabled');
+    // find the correct UI components for the current context
+    var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
+
+    // disable lookup form until the list is loaded
+    var $formInitButtons = $container.parent().find('.form-init');
+    $formInitButtons.attr('disabled', 'disabled')
+                    .addClass('btn-info-disabled');
 
     $.ajax({
         type: 'POST',
@@ -2093,8 +2098,7 @@ function loadStudyListForLookup() {
         url: findAllStudies_url,
         data: { verbose: true },
         success: function( data, textStatus, jqXHR ) {
-            // this should be properly parsed JSON
-
+            // this should be properly parsed JSON;
             // report errors or malformed data, if any
             if (textStatus !== 'success') {
                 showErrorMessage('Sorry, there was an error loading the list of studies.');
@@ -2104,10 +2108,11 @@ function loadStudyListForLookup() {
                 showErrorMessage('Sorry, there is a problem with the study-list data.');
                 return;
             }
-
+            // save global lookup list!
             studyListForLookup = data['matched_studies'];
             bindStudyAndTreeLookups();
-            if (collectionUI === 'FULL_PAGE') {
+            if (context === 'COLLECTION_EDITOR_ADD_TREE' &&
+                collectionUI === 'FULL_PAGE') {
                 // refresh tree list in collections editor
                 nudgeTickler('TREES', {modelHasChanged: false});
             }

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1197,7 +1197,7 @@ function resetStudyLookup() {
     var $container = getPhylesystemLookupPanel( context );
     var $treeSelector = $container.find('select[name=tree-lookup]');
     $treeSelector.find('option').remove();
-    var $promptOption = $('<option disabled="disabled" value="">Find the study above first</option>');
+    var $promptOption = $('<option disabled="disabled" value="">Choose a study first</option>');
     $treeSelector.append( $promptOption );
     $container.find('select[name=tree-lookup]').val('');
     $container.find('select[name=tree-lookup]').attr('disabled','disabled');

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -905,14 +905,16 @@ function getPhylesystemLookupContext() {
         return 'COLLECTION_EDITOR_ADD_TREE';
     }
 
-    if ($('#tree-viewer').is(":visible") || treeViewerIsInUse) {
-        return 'PHYLOGRAM_CONFLICT_CHOOSE_TREE2';
-    }
-
     var $tabBar = $('ul.nav-tabs:eq(0)');
     var activeTabName = $.trim($tabBar.find('li.active a').text());
     if (activeTabName.indexOf('Analyses') === 0) {
         return 'ANALYSES_CONFLICT_CHOOSE_TREE2';
+    }
+
+    if ((activeTabName.indexOf('Home') === 0) ||
+       $('#tree-viewer').is(":visible") ||
+       treeViewerIsInUse) {
+        return 'PHYLOGRAM_CONFLICT_CHOOSE_TREE2';
     }
 
     console.error("getPhylesystemLookupContext(): UNKNOWN context!");
@@ -2074,7 +2076,7 @@ function bindStudyAndTreeLookups() {
     $newTreeStartButton.attr('disabled', null)
                        .removeClass('btn-info-disabled');
 }
-function loadStudyListForLookup() {
+function loadStudyListForLookup( context ) {
     ///console.warn('STARTING loadStudyListForLookup');
     // if list is available, bind UI and return
     if (studyListForLookup) {
@@ -2083,7 +2085,9 @@ function loadStudyListForLookup() {
     }
 
     // find the correct UI components for the current context
-    var context = getPhylesystemLookupContext();
+    if (!context) {
+        context = getPhylesystemLookupContext();
+    }
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -893,7 +893,9 @@ function getPhylesystemLookupContext() {
      * NB - It's entirely possible to open the source-tree viewer, then
      * the collection editor on top of that. Choose wisely!
      */
-    if ($('#tree-collection-viewer').is(":visible")) {
+    if ($('#tree-collection-viewer').is(":visible") ||
+       $('div#Home [id=tree-collection-viewer]').length === 1) {
+        // we're editing a collection, either in a popup modal OR the full-page editor
         return 'COLLECTION_EDITOR_ADD_TREE';
     }
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -657,7 +657,7 @@ async function showCollectionViewer( collection, options ) {
             $newTreeOptionsPanels.find('input').val('');
             $newTreeByURLButton.attr('disabled', 'disabled')
                 .addClass('btn-info-disabled');
-            updateNewCollTreeUI();
+            updateTreeLookupUI();
             // (re)bind study and tree lookups
             loadStudyListForLookup();
             // disable the Add Tree button until they finish or cancel
@@ -778,13 +778,60 @@ function getFullGitHubURLForCollection(collection) {
     return '';
 }
 
-function updateNewCollTreeUI() {
+function updateTreeLookupUI() {
     // find the correct UI components for the current context
     var context = getPhylesystemLookupContext();
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
+    // update by-lookup widgets
+    var $addByLookupPanel = $('#new-collection-tree-by-lookup');
+    var $submitByLookupButton = $addByLookupPanel.find('button').eq(0);
+    var $studyIDField = $addByLookupPanel.find('input[name=study-lookup-id]');
+    var $treeSelector = $addByLookupPanel.find('select[name=tree-lookup]');
     switch(context) {
         case 'COLLECTION_EDITOR_ADD_TREE':
+            var $submitByAnyInputButton = $('#add-tree-by-any-input');
+            if (collectionUI === 'FULL_PAGE') {
+                // disable our all-purpose add-tree button, then check below
+                $submitByAnyInputButton.attr('disabled', 'disabled')
+                                       .addClass('btn-info-disabled');
+            }
+
+            if (($.trim($studyIDField.val()) == '') || ($.trim($treeSelector.val()) == '')) {
+                // no ids found!
+                if (collectionUI === 'POPUP') {
+                    $submitByLookupButton.attr('disabled', 'disabled')
+                                         .addClass('btn-info-disabled');
+                }
+            } else {
+                // both ids found!
+                if (collectionUI === 'POPUP') {
+                    $submitByLookupButton.attr('disabled', null)
+                                         .removeClass('btn-info-disabled');
+                } else {
+                    $submitByAnyInputButton.attr('disabled', null)
+                                           .removeClass('btn-info-disabled');
+                }
+            }
+
+            // update by-URL widgets
+            var $addByURLPanel = $('#new-collection-tree-by-url');
+            var $urlField = $addByURLPanel.find('input[name=tree-url]');
+            var $submitByURLButton = $addByURLPanel.find('button').eq(0);
+            if ($.trim($urlField.val()) == '') {
+                if (collectionUI === 'POPUP') {
+                    $submitByURLButton.attr('disabled', 'disabled')
+                                      .addClass('btn-info-disabled');
+                }
+            } else {
+                if (collectionUI === 'POPUP') {
+                    $submitByURLButton.attr('disabled', null)
+                                      .removeClass('btn-info-disabled');
+                } else {
+                    $submitByAnyInputButton.attr('disabled', null)
+                                           .removeClass('btn-info-disabled');
+                }
+            }
             break;
         case 'PHYLOGRAM_CONFLICT_CHOOSE_TREE2':
             break;
@@ -792,53 +839,6 @@ function updateNewCollTreeUI() {
             break;
         default:  // missing/unknown context!
             return;
-    }
-    // update by-lookup widgets
-    var $addByLookupPanel = $('#new-collection-tree-by-lookup');
-    var $submitByLookupButton = $addByLookupPanel.find('button').eq(0);
-    var $studyIDField = $addByLookupPanel.find('input[name=study-lookup-id]');
-    var $treeSelector = $addByLookupPanel.find('select[name=tree-lookup]');
-    var $submitByAnyInputButton = $('#add-tree-by-any-input');
-    if (collectionUI === 'FULL_PAGE') {
-        // disable our all-purpose add-tree button, then check below
-        $submitByAnyInputButton.attr('disabled', 'disabled')
-                               .addClass('btn-info-disabled');
-    }
-
-    if (($.trim($studyIDField.val()) == '') || ($.trim($treeSelector.val()) == '')) {
-        // no ids found!
-        if (collectionUI === 'POPUP') {
-            $submitByLookupButton.attr('disabled', 'disabled')
-                                 .addClass('btn-info-disabled');
-        }
-    } else {
-        // both ids found!
-        if (collectionUI === 'POPUP') {
-            $submitByLookupButton.attr('disabled', null)
-                                 .removeClass('btn-info-disabled');
-        } else {
-            $submitByAnyInputButton.attr('disabled', null)
-                                   .removeClass('btn-info-disabled');
-        }
-    }
-
-    // update by-URL widgets
-    var $addByURLPanel = $('#new-collection-tree-by-url');
-    var $urlField = $addByURLPanel.find('input[name=tree-url]');
-    var $submitByURLButton = $addByURLPanel.find('button').eq(0);
-    if ($.trim($urlField.val()) == '') {
-        if (collectionUI === 'POPUP') {
-            $submitByURLButton.attr('disabled', 'disabled')
-                              .addClass('btn-info-disabled');
-        }
-    } else {
-        if (collectionUI === 'POPUP') {
-            $submitByURLButton.attr('disabled', null)
-                              .removeClass('btn-info-disabled');
-        } else {
-            $submitByAnyInputButton.attr('disabled', null)
-                                   .removeClass('btn-info-disabled');
-        }
     }
 }
 
@@ -1072,7 +1072,7 @@ function searchForMatchingStudy() {
                 // Load + enable tree lookup
                 $container.find('select[name=tree-lookup]').val('');
                 $container.find('select[name=tree-lookup]').attr('disabled','disabled');
-                updateNewCollTreeUI();
+                updateTreeLookupUI();
                 $.ajax({
                     global: false,  // suppress web2py's aggressive error handling
                     type: 'POST',
@@ -1151,7 +1151,7 @@ function searchForMatchingStudy() {
                                     });
                                     $treeSelector.attr('disabled', null);
                                     if (context == '') {
-                                        updateNewCollTreeUI();
+                                        updateTreeLookupUI();
                                     }
                                     return;
 
@@ -1202,7 +1202,7 @@ function resetStudyLookup() {
     // N.B. The icon element will shift if its display is set to block
     $container.find('i.study-lookup-active').css('display', 'inline-block');
 
-    updateNewCollTreeUI();
+    updateTreeLookupUI();
 }
 
 function createNewTreeCollection() {

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1186,6 +1186,8 @@ function searchForMatchingStudy() {
 function resetStudyLookup() {
     // Clear/disable tree lookup
     var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
     var $treeSelector = $container.find('select[name=tree-lookup]');
     $treeSelector.find('option').remove();
     var $promptOption = $container.find('<option disabled="disabled" value="">Find the study above first</option>');

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1060,6 +1060,7 @@ function searchForMatchingStudy() {
                 // update hidden field
                 $('input[name=study-lookup-id]').val( studyID );
                 // hide menu and reset search field
+                clearTimeout(studyLookupTimeoutID);
                 $lookupResults.html('');
                 $lookupResults.hide();
                 // replace input field with static indicator (and trigger to search again?)

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -899,7 +899,7 @@ function getPhylesystemLookupContext() {
         return 'COLLECTION_EDITOR_ADD_TREE';
     }
 
-    if ($('#tree-viewer').is(":visible")) {
+    if ($('#tree-viewer').is(":visible") || treeViewerIsInUse) {
         return 'PHYLOGRAM_CONFLICT_CHOOSE_TREE2';
     }
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1190,7 +1190,7 @@ function resetStudyLookup() {
     var $container = getPhylesystemLookupPanel( context );
     var $treeSelector = $container.find('select[name=tree-lookup]');
     $treeSelector.find('option').remove();
-    var $promptOption = $container.find('<option disabled="disabled" value="">Find the study above first</option>');
+    var $promptOption = $('<option disabled="disabled" value="">Find the study above first</option>');
     $treeSelector.append( $promptOption );
     $container.find('select[name=tree-lookup]').val('');
     $container.find('select[name=tree-lookup]').attr('disabled','disabled');

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -1071,7 +1071,7 @@ function searchForMatchingStudy() {
                 $lookupResults.hide();
                 // replace input field with static indicator (and trigger to search again?)
                 $container.find('.study-lookup-active').hide();
-                $container.find('[id=study-lookup-indicator]')
+                $container.find('a.study-lookup-indicator')
                     .attr({'href': $link.attr('href'), 'title': $link.attr('title')})
                     .html( $link.html() );
                 $container.find('.study-lookup-passive').show();

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -862,6 +862,12 @@ function setStudyLookupFuse(e) {
     // reset the timeout for another n milliseconds
     studyLookupTimeoutID = setTimeout(searchForMatchingStudy, lookupDelay);
 
+    // find the correct UI components for the current context
+    var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
+    var $lookupResults = $container.find('[id=study-lookup-results]');     // display matching stuff
+
     /* If the last key pressed was the ENTER key, stash the current (trimmed)
      * string and auto-jump if it's a valid taxon name.
      */
@@ -877,7 +883,7 @@ function setStudyLookupFuse(e) {
             case 39:
             case 40:
                 // down or right arrows should try to select first result
-                $('#study-lookup-results a:eq(0)').focus();
+                $lookupResults.find('a:eq(0)').focus();
                 break;
             default:
                 hopefulStudyLookupName = null;
@@ -954,15 +960,15 @@ function searchForMatchingStudy() {
         default:  // missing/unknown context!
             return;
     }
-    var $studynameinput = $container.find('input[name=study-lookup]');    // search text field
+    var $studyNameInput = $container.find('input[name=study-lookup]');    // search text field
     var $lookupResults = $container.find('[id=study-lookup-results]');     // display matching stuff
 
-    if ($studynameinput.length === 0) {
+    if ($studyNameInput.length === 0) {
         $container.find('#study-lookup-results').html('');
         console.log("Input field not found!");
         return false;
     }
-    var searchText = $.trim( $studynameinput.val() );
+    var searchText = $.trim( $studyNameInput.val() );
     var searchTokens = tokenizeSearchTextKeepingQuotes(searchText);
 
     if ((searchTokens.length === 0) ||
@@ -1045,7 +1051,7 @@ function searchForMatchingStudy() {
             var matchURL = getViewURLFromStudyID(studyInfo['ot:studyId']);
             var matchText = fullToCompactReference(studyInfo['ot:studyPublicationReference']);
             var mouseOver = studyInfo['ot:studyPublicationReference'];
-            $('#study-lookup-results').append(
+            $lookupResults.append(
                 '<li><a href="'+ matchURL +'" title="'+ mouseOver +'">'+ matchText +'</a></li>'
             );
             visibleResults++;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1843,7 +1843,9 @@ function updatePhylesystemLookupWidgets(chooser) {
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
     if (newValue == 'STUDYID_TREEID') {
-        // show study + tree lookup widgets (keep old values, if any)
+        // show study + tree lookup widgets, clearing old values for both
+        // TODO: Try to keep old tree+study values, if any
+        resetStudyLookup();
         $container.find('.lookup-widgets').show();
     } else {
         // hide 'em

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -159,6 +159,12 @@ if ( History && History.enabled ) {
                     activeFilter = viewModel.listFilters.OTUS;
                     filterDefaults = listFilterDefaults.OTUS;
                     break;
+
+                case 'analyses':
+                    // enable study+tree lookup in tree-viewer popup, Analyses tab
+                    loadStudyListForLookup();
+                    console.log('LOADING STUDY LIST...');
+                    break;
             }
             if (activeFilter) {
                 // assert any saved filter values
@@ -468,10 +474,6 @@ $(document).ready(function() {
     studyHasUnsavedChanges = false;
     disableSaveButton();
     loadSelectedStudy();
-
-    // enable study+tree lookup in tree-viewer popup, Analyses tab
-    loadStudyListForLookup();
-    //bindStudyAndTreeLookups();
 
     // Initialize the jQuery File Upload widgets
     $('#fileupload').fileupload({

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2337,19 +2337,14 @@ function updateTreeConflictWidgets(conflictInfo) {
     var selectedTreeID = $container.find('[name=tree-lookup] option:selected').val();
     if (!selectedTreeID) {
         // we need to populate the selection widgets to match!
-        console.warn("TODO: update study and tree selection widgets!");
         if (referenceTreeID.indexOf('@') !== -1) {
             // it's a compound ID (study and tree IDs)!
             var idParts = referenceTreeID.split('@');
             var studyID = idParts[0];
             var treeID = idParts[1];
-            console.log(">>> BEFORE setting it to STUDYID_TREEID: "
-              + $container.find('.treeview-reference-select').val() );
-            $container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
-            console.log(">>> AFTER setting it to STUDYID_TREEID: "
-              + $container.find('.treeview-reference-select').val() );
-            // TODO: update the study+tree selectors
-            // (for now, just show a sensible footer message)
+            /* TODO: update the study+tree selectors to reflect incoming conflict URL?
+             * (for now, we just show a sensible footer message)
+             */
             var studyURL = getViewURLFromStudyID(studyID);
             studyURL += ("/?tab=home&tree=" + treeID);
             showErrorMessage('Showing conflict vs. <a target="_blank" href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
@@ -2359,7 +2354,7 @@ function updateTreeConflictWidgets(conflictInfo) {
             $container.find('.treeview-reference-select').val( referenceTreeID );
         }
     } else {
-        console.warn("NO NEED to update study + tree selectors.");
+        console.log("NO NEED to update study + tree selectors.");
     }
 }
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7679,13 +7679,13 @@ function getNodeConflictDescription(tree, node) {
 
                 default:
                     /* The reference tree is presumably a curated tree in a
-                     * published study, e.g. 'ot_234#tree3'. We should build
-                     * our typical URL to point directly to a node in the
-                     * curation app's tree viewer.
+                     * published study, e.g. 'pg_2866%23tree6656' or
+                     * 'pg_2866#tree6656'. We should build our typical URL to
+                     * point directly to a node in the curation app's tree
+                     * viewer.
                      */
-
                     // split the witnessID into study and tree IDs, or complain if we can't
-                    var studyAndTreeIDs = witnessID.split( /#|@/s );  // test for all possible delimiters!
+                    var studyAndTreeIDs = (tree.conflictDetails.referenceTreeID).split( /#|@/s );  // test for all possible delimiters!
                     if (studyAndTreeIDs.length < 2) {
                         console.error(">> Unable to find study and tree IDs in witnessID: '"+ witnessID +"'");
                     } else {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1823,7 +1823,7 @@ function updatePhylesystemLookupWidgets(chooser) {
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
     console.log("NEW value is: "+ newValue);
-    if (newValue == '') {
+    if (newValue == 'STUDYID_TREEID') {
         // show study + tree lookup widgets (keep old values, if any)
         $container.find('.lookup-widgets').show();
     } else {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2367,7 +2367,7 @@ function showConflictDetailsWithHistory(tree, referenceTreeID) {
                 'conflict': referenceTreeID
             }
         );
-        History.pushState( newState, (window.document.title), ('?tab=home&tree='+ newState.tree +'&conflict='+ newState.conflict) );
+        History.pushState( newState, (window.document.title), ('?tab=home&tree='+ newState.tree +'&conflict='+ encodeURIComponent(newState.conflict)) );
     } else {
         // show conflict normally (ignore browser history)
         showTreeConflictDetailsFromPopup(tree);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7684,7 +7684,7 @@ function getNodeConflictDescription(tree, node) {
                      * point directly to a node in the curation app's tree
                      * viewer.
                      */
-                    // split the witnessID into study and tree IDs, or complain if we can't
+                    // split the referenceTreeID into study and tree IDs, or complain if we can't
                     var possibleDelimiters = /#|@|%23/s ;  // regex tests for all possible delimiters
                     var studyAndTreeIDs = (tree.conflictDetails.referenceTreeID).split( possibleDelimiters );
                     if (studyAndTreeIDs.length < 2) {
@@ -7694,7 +7694,7 @@ function getNodeConflictDescription(tree, node) {
                         var witnessTreeID = studyAndTreeIDs[1];
                         witnessURL = getViewURLFromStudyID( witnessStudyID )
                             +"?tab=home&tree="+ witnessTreeID
-                            +"&node="+ nodeID;
+                            +"&node="+ witnessID;
                     }
                     break;
             }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2116,6 +2116,9 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
         var chosenStudyID = $container.find('[name=study-lookup-id]').val();
         var chosenTreeID = $container.find('[name=tree-lookup] option:selected').val();
         if (!chosenStudyID || !chosenTreeID) {
+            console.log("choose study+tree (B)");
+            console.log('  chosenStudyID: '+ chosenStudyID);
+            console.log('  chosenTreeID: '+ chosenTreeID);
             showErrorMessage('Please choose a study and tree for comparison');
             return;
         }
@@ -2417,6 +2420,9 @@ function showConflictDetailsWithHistory(tree, referenceTreeID) {
         var chosenStudyID = $container.find('[name=study-lookup-id]').val();
         var chosenTreeID = $container.find('[name=tree-lookup] option:selected').val();
         if (!chosenStudyID || !chosenTreeID) {
+            console.log("choose study+tree (A)");
+            console.log('  chosenStudyID: '+ chosenStudyID);
+            console.log('  chosenTreeID: '+ chosenTreeID);
             showErrorMessage('Please choose a study and tree for comparison');
             return;
         }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4294,6 +4294,10 @@ function showTreeViewer( tree, options ) {
         ko.applyBindings(tree,el);
     });
 
+    // enable study+tree lookup in tree-viewer popup
+    loadStudyListForLookup();
+    //bindStudyAndTreeLookups();
+
     // enable collection search (in tree-viewer popup)
     $('input[name=collection-search]').unbind('keyup change')
                                       .bind('keyup change', setCollectionSearchFuse )
@@ -4398,6 +4402,7 @@ function showTreeViewer( tree, options ) {
         }
 
         ///hideModalScreen();
+        bindStudyAndTreeLookups();
     }
 
     var $treeViewerTabs = $('#tree-viewer .modal-header a[data-toggle="tab"]');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2133,7 +2133,7 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
             break;
         default:
             referenceTreeName = referenceTreeID;  // echo studyID#treeID here
-            referenceTreeID = referenceTreeID.replace('@','%23');  // encode this as '#' for the API
+            referenceTreeID = referenceTreeID.replace( /@|%40/g , '%23' );  // encode this as '#' for the API
             break;
     }
     var conflictURL = treeConflictStatus_url

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2167,6 +2167,7 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
                 return;
             }
             callback(conflictInfo);
+            updateTreeConflictWidgets(conflictInfo);
             hideModalScreen();
         }
     });
@@ -2210,6 +2211,9 @@ function fetchAndShowTreeConflictDetails(inputTreeID, referenceTreeID, options) 
             if (options.SHOW_SPINNER) {
                 hideModalScreen();
             }
+
+            // refresh UI (study + tree selectors) if we just opened this page
+            updateTreeConflictWidgets( conflictInfo );
         },
         false  // don't reuse a cached response
     );
@@ -2283,16 +2287,17 @@ function addConflictInfoToTree( treeOrID, conflictInfo ) {
     }
 }
 
-function updateTreeConflictWidgets(conflictDetails) {
+function updateTreeConflictWidgets(conflictInfo) {
     // this should work even for incoming URLs, esp. for conflict with a published tree
     var context = getPhylesystemLookupContext();
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
 
-    var referenceTreeID = conflictDetails.referenceTreeID;
-    var referenceTreeName = conflictDetails.referenceTreeName;
+    var referenceTreeID = conflictInfo.referenceTreeID;
+    var referenceTreeName = conflictInfo.referenceTreeName;
     console.warn("referenceTreeID: "+ referenceTreeID);
     console.warn("referenceTreeName: "+ referenceTreeName);
+    console.warn(conflictInfo);
 
     //$container.find('.treeview-reference-select option:selected').val();
 

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2119,7 +2119,7 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
             showErrorMessage('Please choose a study and tree for comparison');
             return;
         }
-        referenceTreeID = encodeURIComponent(chosenStudyID +'@'+ chosenTreeID);
+        referenceTreeID = (chosenStudyID +'@'+ chosenTreeID);
     }
 
     var referenceTreeName;
@@ -2133,7 +2133,7 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
             break;
         default:
             referenceTreeName = referenceTreeID;  // echo studyID#treeID here
-            referenceTreeID = referenceTreeID.replace( /@|%40/g , '%23' );  // encode this as '#' for the API
+            referenceTreeID = referenceTreeID.replace( /@|%40/g , '%23' );  // encode '@' as '#' for the API
             break;
     }
     var conflictURL = treeConflictStatus_url

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -185,6 +185,19 @@ if ( History && History.enabled ) {
                 // omit conflict spinner when handling inbound URLs; it conflicts with others
                 if (conflictReferenceTree) {
                     fetchAndShowTreeConflictDetails(currentTree, conflictReferenceTree, {SHOW_SPINNER: false});
+                    // refresh UI (study + tree selectors) if we just opened this page?
+                    var context = getPhylesystemLookupContext();
+                    var $container = getPhylesystemLookupPanel( context );
+                    var referenceTreeID = $container.find('.treeview-reference-select option:selected').val();
+                    if (referenceTreeID === 'STUDYID_TREEID') {
+                        var selectedTreeID = $container.find('.tree-lookup option:selected').val();
+                        if (!selectedTreeID) {
+                            // we need to populate the selection widgets to match!
+                            console.warn("TODO: update study and tree selection widgets!");
+                        } else {
+                            console.warn("NO NEED to update study + tree selectors.");
+                        }
+                    }
                 } else {
                     hideTreeConflictDetails(currentTree, {SHOW_SPINNER: false});
                 }
@@ -2208,19 +2221,6 @@ function fetchAndShowTreeConflictDetails(inputTreeID, referenceTreeID, options) 
             drawTree(inputTreeID);
             if (options.SHOW_SPINNER) {
                 hideModalScreen();
-            }
-            // refresh UI (study + tree selectors) if we just opened this page?
-            var context = getPhylesystemLookupContext();
-            var $container = getPhylesystemLookupPanel( context );
-            var referenceTreeID = $container.find('.treeview-reference-select option:selected').val();
-            if (referenceTreeID === 'STUDYID_TREEID') {
-                var selectedTreeID = $container.find('.tree-lookup option:selected').val();
-                if (!selectedTreeID) {
-                    // we need to populate the selection widgets to match!
-                    console.warn("TODO: update study and tree selection widgets!");
-                } else {
-                    console.warn("NO NEED to update study + tree selectors.");
-                }
             }
         },
         false  // don't reuse a cached response

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2300,26 +2300,27 @@ function updateTreeConflictWidgets(conflictInfo) {
     var $container = getPhylesystemLookupPanel( context );
 
     var referenceTreeID = conflictInfo.referenceTreeID;
-    var referenceTreeName = conflictInfo.referenceTreeName;
-    console.warn("referenceTreeID: "+ referenceTreeID);
-    console.warn("referenceTreeName: "+ referenceTreeName);
-    console.warn(conflictInfo);
-
     //$container.find('.treeview-reference-select option:selected').val();
 
-    if (referenceTreeID === 'STUDYID_TREEID') {
-        var selectedTreeID = $container.find('.tree-lookup option:selected').val();
-        if (!selectedTreeID) {
-            // we need to populate the selection widgets to match!
-            console.warn("TODO: update study and tree selection widgets!");
+    var selectedTreeID = $container.find('.tree-lookup option:selected').val();
+    if (!selectedTreeID) {
+        // we need to populate the selection widgets to match!
+        console.warn("TODO: update study and tree selection widgets!");
+        if (referenceTreeID.indexOf('@') !== -1) {
+            // it's a compound ID (study and tree IDs)!
+            var idParts = referenceTreeID.split('@');
+            var studyID = idParts[0];
+            var treeID = idParts[1];
+            $container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
+            // TODO: update the study+tree selectors
+            //$container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
         } else {
-            console.warn("NO NEED to update study + tree selectors.");
+            // a simpler update to the reference-tree selector
+            $container.find('.treeview-reference-select').val( referenceTreeID );
         }
+    } else {
+        console.warn("NO NEED to update study + tree selectors.");
     }
-
-    // update the reference-tree selector
-    // TODO: $container.find('.treeview-reference-select').val();
-    // TODO: update the study+tree selectors
 }
 
 function removeTaxonMappingInfoFromTree( treeOrID ) {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -185,7 +185,6 @@ if ( History && History.enabled ) {
                 // omit conflict spinner when handling inbound URLs; it conflicts with others
                 if (conflictReferenceTree) {
                     fetchAndShowTreeConflictDetails(currentTree, conflictReferenceTree, {SHOW_SPINNER: false});
-                    updateTreeConflictWidgets();
                 } else {
                     hideTreeConflictDetails(currentTree, {SHOW_SPINNER: false});
                 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2159,6 +2159,9 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
             if (textStatus !== 'success') {
                 if (jqXHR.status >= 500) {
                     // major server-side error, just show raw response for tech support
+                    console.log(">>ERROR fetching conflict report!")
+                    console.log(">>  status: "+ jqXHR.status);
+                    console.log(">>  statusText: "+ jqXHR.statusText);
                     var errMsg = 'Sorry, there was an error generating a conflict report. <a href="#" onclick="toggleFlashErrorDetails(this); return false;">Show details</a><pre class="error-details" style="display: none;">'+ jqXHR.responseText +'</pre>';
                     hideModalScreen();
                     showErrorMessage(errMsg);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2333,10 +2333,10 @@ function updateTreeConflictWidgets(conflictInfo) {
             var studyID = idParts[0];
             var treeID = idParts[1];
             console.log(">>> BEFORE setting it to STUDYID_TREEID: "
-              + $container.find('.treeview-reference-select').val());
+              + $container.find('.treeview-reference-select').val() );
             $container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
             console.log(">>> AFTER setting it to STUDYID_TREEID: "
-              + $container.find('.treeview-reference-select').val());
+              + $container.find('.treeview-reference-select').val() );
             // TODO: update the study+tree selectors
             // (for now, just show a sensible footer message)
             var studyURL = getViewURLFromStudyID(studyID);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -4295,7 +4295,6 @@ function showTreeViewer( tree, options ) {
     });
 
     // enable collection search (in tree-viewer popup)
-    console.warn('BINDING COLLECTION SEARCH');
     $('input[name=collection-search]').unbind('keyup change')
                                       .bind('keyup change', setCollectionSearchFuse )
                                       .unbind('keydown')  // block errant form submission

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -185,6 +185,7 @@ if ( History && History.enabled ) {
                 // omit conflict spinner when handling inbound URLs; it conflicts with others
                 if (conflictReferenceTree) {
                     fetchAndShowTreeConflictDetails(currentTree, conflictReferenceTree, {SHOW_SPINNER: false});
+                    updateTreeConflictWidgets();
                 } else {
                     hideTreeConflictDetails(currentTree, {SHOW_SPINNER: false});
                 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1829,6 +1829,7 @@ function updatePhylesystemLookupWidgets(chooser) {
         // hide 'em
         $container.find('.lookup-widgets').hide();
     }
+    updateTreeViewerHeight({'MAINTAIN_SCROLL': true});
 }
 
 /* Support conflict display in the tree viewer */
@@ -2207,6 +2208,19 @@ function fetchAndShowTreeConflictDetails(inputTreeID, referenceTreeID, options) 
             drawTree(inputTreeID);
             if (options.SHOW_SPINNER) {
                 hideModalScreen();
+            }
+            // refresh UI (study + tree selectors) if we just opened this page?
+            var context = getPhylesystemLookupContext();
+            var $container = getPhylesystemLookupPanel( context );
+            var referenceTreeID = $container.find('.treeview-reference-select option:selected').val();
+            if (referenceTreeID === 'STUDYID_TREEID') {
+                var selectedTreeID = $container.find('.tree-lookup option:selected').val();
+                if (!selectedTreeID) {
+                    // we need to populate the selection widgets to match!
+                    console.warn("TODO: update study and tree selection widgets!");
+                } else {
+                    console.warn("NO NEED to update study + tree selectors.");
+                }
             }
         },
         false  // don't reuse a cached response

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2104,7 +2104,7 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
             return;
         default:
             referenceTreeName = referenceTreeID;  // echo studyID#treeID here
-            referenceTreeID = referenceTreeID.replace('#','%23');  // confirm encoding!
+            referenceTreeID = referenceTreeID.replace('@','%23');  // encode this as '#' for the API
             break;
     }
     var conflictURL = treeConflictStatus_url
@@ -2352,7 +2352,7 @@ function showConflictDetailsWithHistory(tree, referenceTreeID) {
             showErrorMessage('Please choose a study and tree for comparison');
             return;
         }
-        referenceTreeID = encodeURIComponent(chosenStudyID +'#'+ chosenTreeID);
+        referenceTreeID = encodeURIComponent(chosenStudyID +'@'+ chosenTreeID);
     }
     if (studyHasUnsavedChanges) {
         showInfoMessage('REMINDER: Conflict analysis uses the last-saved version of this study!');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2105,6 +2105,23 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
         return;
     }
     var fullInputTreeID = (studyID +"%23"+ inputTreeID);
+
+    var comparingToPhylesystemTree = (referenceTreeID == 'STUDYID_TREEID');
+    if (comparingToPhylesystemTree) {
+        // build and parse from study and tree selector widgets
+        var context = getPhylesystemLookupContext();
+        // what's the parent element for study+tree lookup UI?
+        var $container = getPhylesystemLookupPanel( context );
+        // replace reference tree ID with found study AND tree ids
+        var chosenStudyID = $container.find('[name=study-lookup-id]').val();
+        var chosenTreeID = $container.find('[name=tree-lookup] option:selected').val();
+        if (!chosenStudyID || !chosenTreeID) {
+            showErrorMessage('Please choose a study and tree for comparison');
+            return;
+        }
+        referenceTreeID = encodeURIComponent(chosenStudyID +'@'+ chosenTreeID);
+    }
+
     var referenceTreeName;
     switch(referenceTreeID) {
         // these are the only ids allowed for now
@@ -2114,10 +2131,6 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
         case 'synth':
             referenceTreeName = 'Synthetic Tree of Life';
             break;
-        case 'STUDYID_TREEID':
-            hideModalScreen();
-            console.error('fetchTreeConflictStatus(): ERROR, expecting a fully specified studyID#treeID as referenceTreeID!');
-            return;
         default:
             referenceTreeName = referenceTreeID;  // echo studyID#treeID here
             referenceTreeID = referenceTreeID.replace('@','%23');  // encode this as '#' for the API

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -146,6 +146,8 @@ if ( History && History.enabled ) {
             goToTab( currentTab );
             switch(slugify(currentTab)) {
                 case 'home':
+                    // enable study+tree lookup in tree-viewer popup
+                    loadStudyListForLookup();
                     activeFilter = viewModel.listFilters.TREES;
                     filterDefaults = listFilterDefaults.TREES;
                     break;
@@ -161,7 +163,7 @@ if ( History && History.enabled ) {
                     break;
 
                 case 'analyses':
-                    // enable study+tree lookup in tree-viewer popup, Analyses tab
+                    // enable study+tree lookup in Analyses tab
                     loadStudyListForLookup();
                     console.log('LOADING STUDY LIST...');
                     break;

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2104,6 +2104,7 @@ function fetchTreeConflictStatus(inputTreeID, referenceTreeID, callback, useCach
             return;
         default:
             referenceTreeName = referenceTreeID;  // echo studyID#treeID here
+            referenceTreeID = referenceTreeID.replace('#','%23');  // confirm encoding!
             break;
     }
     var conflictURL = treeConflictStatus_url
@@ -2367,7 +2368,7 @@ function showConflictDetailsWithHistory(tree, referenceTreeID) {
                 'conflict': referenceTreeID
             }
         );
-        History.pushState( newState, (window.document.title), ('?tab=home&tree='+ newState.tree +'&conflict='+ encodeURIComponent(newState.conflict)) );
+        History.pushState( newState, (window.document.title), ('?tab=home&tree='+ newState.tree +'&conflict='+ newState.conflict) );
     } else {
         // show conflict normally (ignore browser history)
         showTreeConflictDetailsFromPopup(tree);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -185,19 +185,7 @@ if ( History && History.enabled ) {
                 // omit conflict spinner when handling inbound URLs; it conflicts with others
                 if (conflictReferenceTree) {
                     fetchAndShowTreeConflictDetails(currentTree, conflictReferenceTree, {SHOW_SPINNER: false});
-                    // refresh UI (study + tree selectors) if we just opened this page?
-                    var context = getPhylesystemLookupContext();
-                    var $container = getPhylesystemLookupPanel( context );
-                    var referenceTreeID = $container.find('.treeview-reference-select option:selected').val();
-                    if (referenceTreeID === 'STUDYID_TREEID') {
-                        var selectedTreeID = $container.find('.tree-lookup option:selected').val();
-                        if (!selectedTreeID) {
-                            // we need to populate the selection widgets to match!
-                            console.warn("TODO: update study and tree selection widgets!");
-                        } else {
-                            console.warn("NO NEED to update study + tree selectors.");
-                        }
-                    }
+                    updateTreeConflictWidgets();
                 } else {
                     hideTreeConflictDetails(currentTree, {SHOW_SPINNER: false});
                 }
@@ -2236,7 +2224,7 @@ function showTreeConflictDetailsFromPopup(tree) {
     var context = getPhylesystemLookupContext();
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
-    var newReferenceTreeID = $container.find('.treeview-reference-select').val();
+    var newReferenceTreeID = $container.find('.treeview-reference-select option:selected').val();
     if (!newReferenceTreeID) {
         hideTreeConflictDetails( tree );
     } else {
@@ -2290,13 +2278,37 @@ function addConflictInfoToTree( treeOrID, conflictInfo ) {
     }
 
     if (treeViewerIsInUse) {
-        var context = getPhylesystemLookupContext();
-        // what's the parent element for study+tree lookup UI?
-        var $container = getPhylesystemLookupPanel( context );
-        // update the reference-tree selector
-        $container.find('.treeview-reference-select').val(tree.conflictDetails.referenceTreeID);
+        updateTreeConflictWidgets(tree.conflictDetails);
         $('#treeview-clear-conflict').show();
     }
+}
+
+function updateTreeConflictWidgets(conflictDetails) {
+    // this should work even for incoming URLs, esp. for conflict with a published tree
+    var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
+
+    var referenceTreeID = conflictDetails.referenceTreeID;
+    var referenceTreeName = conflictDetails.referenceTreeName;
+    console.warn("referenceTreeID: "+ referenceTreeID);
+    console.warn("referenceTreeName: "+ referenceTreeName);
+
+    //$container.find('.treeview-reference-select option:selected').val();
+
+    if (referenceTreeID === 'STUDYID_TREEID') {
+        var selectedTreeID = $container.find('.tree-lookup option:selected').val();
+        if (!selectedTreeID) {
+            // we need to populate the selection widgets to match!
+            console.warn("TODO: update study and tree selection widgets!");
+        } else {
+            console.warn("NO NEED to update study + tree selectors.");
+        }
+    }
+
+    // update the reference-tree selector
+    // TODO: $container.find('.treeview-reference-select').val();
+    // TODO: update the study+tree selectors
 }
 
 function removeTaxonMappingInfoFromTree( treeOrID ) {
@@ -2341,6 +2353,7 @@ function removeConflictInfoFromTree( treeOrID ) {
         var $container = getPhylesystemLookupPanel( context );
         // update the reference-tree selector
         $container.find('.treeview-reference-select').val('');
+        // TODO: clear study+tree selectors
         $('#treeview-clear-conflict').hide();
     }
 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1822,7 +1822,6 @@ function updatePhylesystemLookupWidgets(chooser) {
     var context = getPhylesystemLookupContext();
     // what's the parent element for study+tree lookup UI?
     var $container = getPhylesystemLookupPanel( context );
-    console.log("NEW value is: "+ newValue);
     if (newValue == 'STUDYID_TREEID') {
         // show study + tree lookup widgets (keep old values, if any)
         $container.find('.lookup-widgets').show();

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2334,7 +2334,7 @@ function updateTreeConflictWidgets(conflictInfo) {
     var referenceTreeID = conflictInfo.referenceTreeID;
     //$container.find('.treeview-reference-select option:selected').val();
 
-    var selectedTreeID = $container.find('.tree-lookup option:selected').val();
+    var selectedTreeID = $container.find('[name=tree-lookup] option:selected').val();
     if (!selectedTreeID) {
         // we need to populate the selection widgets to match!
         console.warn("TODO: update study and tree selection widgets!");

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -1817,6 +1817,21 @@ function getBranchLengthToggleStyle(tree) {
     return {'color': '#999999'};
 }
 
+function updatePhylesystemLookupWidgets(chooser) {
+    var newValue = $(chooser).val();
+    var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
+    console.log("NEW value is: "+ newValue);
+    if (newValue == '') {
+        // show study + tree lookup widgets (keep old values, if any)
+        $container.find('.lookup-widgets').show();
+    } else {
+        // hide 'em
+        $container.find('.lookup-widgets').hide();
+    }
+}
+
 /* Support conflict display in the tree viewer */
 function getTreeConflictSummary(conflictInfo) {
     // Expects a JS object from conflict service; returns an object with
@@ -2204,7 +2219,10 @@ function showTreeConflictDetailsFromPopup(tree) {
         console.warn("showTreeConflictDetailsFromPopup(): No tree specified!");
         return;
     }
-    var newReferenceTreeID = $('#treeview-reference-select').val();
+    var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
+    var newReferenceTreeID = $container.find('.treeview-reference-select').val();
     if (!newReferenceTreeID) {
         hideTreeConflictDetails( tree );
     } else {
@@ -2258,8 +2276,11 @@ function addConflictInfoToTree( treeOrID, conflictInfo ) {
     }
 
     if (treeViewerIsInUse) {
+        var context = getPhylesystemLookupContext();
+        // what's the parent element for study+tree lookup UI?
+        var $container = getPhylesystemLookupPanel( context );
         // update the reference-tree selector
-        $('#treeview-reference-select').val(tree.conflictDetails.referenceTreeID);
+        $container.find('.treeview-reference-select').val(tree.conflictDetails.referenceTreeID);
         $('#treeview-clear-conflict').show();
     }
 }
@@ -2301,16 +2322,22 @@ function removeConflictInfoFromTree( treeOrID ) {
         delete node.conflictDetails;
     });
     if (treeViewerIsInUse) {
+        var context = getPhylesystemLookupContext();
+        // what's the parent element for study+tree lookup UI?
+        var $container = getPhylesystemLookupPanel( context );
         // update the reference-tree selector
-        $('#treeview-reference-select').val('');
+        $container.find('.treeview-reference-select').val('');
         $('#treeview-clear-conflict').hide();
     }
 }
 
 function showConflictDetailsWithHistory(tree, referenceTreeID) {
     // triggered from tree-view popup UI, works via History
+    var context = getPhylesystemLookupContext();
+    // what's the parent element for study+tree lookup UI?
+    var $container = getPhylesystemLookupPanel( context );
     if (typeof referenceTreeID !== 'string') {
-        referenceTreeID = $('#treeview-reference-select').val();
+        referenceTreeID = $container.find('.treeview-reference-select').val();
     }
     if (!referenceTreeID) {
         showErrorMessage('Please choose a target (reference) tree for comparison');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2313,6 +2313,9 @@ function updateTreeConflictWidgets(conflictInfo) {
             var treeID = idParts[1];
             $container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
             // TODO: update the study+tree selectors
+            // (for now, just show a sensible footer message)
+            var studyURL = getViewURLFromStudyID(studyID);
+            showInfoMessage('Showing conflict vs. <a href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
             //$container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
         } else {
             // a simpler update to the reference-tree selector

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2351,7 +2351,7 @@ function showConflictDetailsWithHistory(tree, referenceTreeID) {
             showErrorMessage('Please choose a study and tree for comparison');
             return;
         }
-        referenceTreeID = (chosenStudyID +'#'+ chosenTreeID);
+        referenceTreeID = encodeURIComponent(chosenStudyID +'#'+ chosenTreeID);
     }
     if (studyHasUnsavedChanges) {
         showInfoMessage('REMINDER: Conflict analysis uses the last-saved version of this study!');

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -453,10 +453,6 @@ $(document).ready(function() {
     bindHistoryAwareWidgets();
     bindHelpPanels();
 
-    // enable study+tree lookup in tree-viewer popup, Analyses tab
-    loadStudyListForLookup();
-    //bindStudyAndTreeLookups();
-
     // NOTE that our initial state is set in the main page template, so we
     // can build it from incoming URL in web2py. Try to recapture this state,
     // ideally through manipulating history.
@@ -472,6 +468,10 @@ $(document).ready(function() {
     studyHasUnsavedChanges = false;
     disableSaveButton();
     loadSelectedStudy();
+
+    // enable study+tree lookup in tree-viewer popup, Analyses tab
+    loadStudyListForLookup();
+    //bindStudyAndTreeLookups();
 
     // Initialize the jQuery File Upload widgets
     $('#fileupload').fileupload({

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2336,7 +2336,7 @@ function updateTreeConflictWidgets(conflictInfo) {
             // TODO: update the study+tree selectors
             // (for now, just show a sensible footer message)
             var studyURL = getViewURLFromStudyID(studyID);
-            showErrorMessage('Showing conflict vs. <a href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
+            showErrorMessage('Showing conflict vs. <a target="_blank" href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
             //$container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
         } else {
             // a simpler update to the reference-tree selector

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2332,7 +2332,11 @@ function updateTreeConflictWidgets(conflictInfo) {
             var idParts = referenceTreeID.split('@');
             var studyID = idParts[0];
             var treeID = idParts[1];
+            console.log(">>> BEFORE setting it to STUDYID_TREEID: "
+              + $container.find('.treeview-reference-select').val());
             $container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
+            console.log(">>> AFTER setting it to STUDYID_TREEID: "
+              + $container.find('.treeview-reference-select').val());
             // TODO: update the study+tree selectors
             // (for now, just show a sensible footer message)
             var studyURL = getViewURLFromStudyID(studyID);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2336,6 +2336,7 @@ function updateTreeConflictWidgets(conflictInfo) {
             // TODO: update the study+tree selectors
             // (for now, just show a sensible footer message)
             var studyURL = getViewURLFromStudyID(studyID);
+            studyURL += ("/?tab=home&tree=" + treeID);
             showErrorMessage('Showing conflict vs. <a target="_blank" href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
             //$container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
         } else {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -2323,7 +2323,7 @@ function updateTreeConflictWidgets(conflictInfo) {
             // TODO: update the study+tree selectors
             // (for now, just show a sensible footer message)
             var studyURL = getViewURLFromStudyID(studyID);
-            showInfoMessage('Showing conflict vs. <a href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
+            showErrorMessage('Showing conflict vs. <a href="'+ studyURL +'">reference tree '+ treeID +' from study '+ studyID +'</a>.');
             //$container.find('.treeview-reference-select').val( 'STUDYID_TREEID' );
         } else {
             // a simpler update to the reference-tree selector

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7699,8 +7699,7 @@ function getNodeConflictDescription(tree, node) {
                 witnessHTML = "anonymous synth node";
                 break;
             default:
-                // for published trees (e.g. 'ot_234#tree2') witness info should always be provided
-                console.warn('showNodeOptionsMenu(): ERROR, expecting either "ott" or "synth" as referenceTreeID!');
+                witnessHTML = "anonymous source-tree node";
                 return;
         }
     }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7656,7 +7656,6 @@ function getNodeConflictDescription(tree, node) {
                     break;
 
                 case 'synth':
-                default:  // presumably a source tree, e.g. 'ot_234#tree3'
                     if (isNaN(witnessID)) {
                         // it's a synthetic-tree node ID (e.g. 'ott1234' or 'mrcaott123ott456')
                         /* N.B. Ideally we'd include the current synth-version (e.g. '/opentree7.0@ott123'),
@@ -7674,8 +7673,27 @@ function getNodeConflictDescription(tree, node) {
                         */
                         witnessURL = "/opentree/argus/@{NODE_ID}".replace('{NODE_ID}', witnessID);
                     } else {
-                        // it's a numeric OTT taxon ID (e.g. '1234')
+                        // it's an (legacy?) numeric OTT taxon ID (e.g. '1234')
                         witnessURL = "/opentree/argus/ottol@{NODE_ID}".replace('{NODE_ID}', witnessID);
+                    }
+
+                default:
+                    /* The reference tree is presumably a curated tree in a
+                     * published study, e.g. 'ot_234#tree3'. We should build
+                     * our typical URL to point directly to a node in the
+                     * curation app's tree viewer.
+                     */
+
+                    // split the witnessID into study and tree IDs, or complain if we can't
+                    var studyAndTreeIDs = witnessID.split( /#|@/s );  // test for all possible delimiters!
+                    if (studyAndTreeIDs.length < 2) {
+                        console.error(">> Unable to find study and tree IDs in witnessID: '"+ witnessID +"'");
+                    } else {
+                        var witnessStudyID = studyAndTreeIDs[0];
+                        var witnessTreeID = studyAndTreeIDs[1];
+                        witnessURL = getViewURLFromStudyID( witnessStudyID )
+                            +"?tab=home&tree="+ witnessTreeID
+                            +"&node="+ nodeID;
                     }
                     break;
             }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -184,8 +184,14 @@ if ( History && History.enabled ) {
                 }
                 // omit conflict spinner when handling inbound URLs; it conflicts with others
                 if (conflictReferenceTree) {
+                    // bare-bones conflict metadata
+                    var minimalConflictInfo = {
+                        inputTreeID: currentTree,
+                        referenceTreeID: conflictReferenceTree,
+                        referenceTreeName: conflictReferenceTree
+                    }
+                    updateTreeConflictWidgets( minimalConflictInfo );
                     fetchAndShowTreeConflictDetails(currentTree, conflictReferenceTree, {SHOW_SPINNER: false});
-                    updateTreeConflictWidgets();
                 } else {
                     hideTreeConflictDetails(currentTree, {SHOW_SPINNER: false});
                 }

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -7685,7 +7685,8 @@ function getNodeConflictDescription(tree, node) {
                      * viewer.
                      */
                     // split the witnessID into study and tree IDs, or complain if we can't
-                    var studyAndTreeIDs = (tree.conflictDetails.referenceTreeID).split( /#|@/s );  // test for all possible delimiters!
+                    var possibleDelimiters = /#|@|%23/s ;  // regex tests for all possible delimiters
+                    var studyAndTreeIDs = (tree.conflictDetails.referenceTreeID).split( possibleDelimiters );
                     if (studyAndTreeIDs.length < 2) {
                         console.error(">> Unable to find study and tree IDs in witnessID: '"+ witnessID +"'");
                     } else {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -453,6 +453,10 @@ $(document).ready(function() {
     bindHistoryAwareWidgets();
     bindHelpPanels();
 
+    // enable study+tree lookup in tree-viewer popup, Analyses tab
+    loadStudyListForLookup();
+    //bindStudyAndTreeLookups();
+
     // NOTE that our initial state is set in the main page template, so we
     // can build it from incoming URL in web2py. Try to recapture this state,
     // ideally through manipulating history.
@@ -4347,10 +4351,6 @@ function showTreeViewer( tree, options ) {
         ko.cleanNode(el);
         ko.applyBindings(tree,el);
     });
-
-    // enable study+tree lookup in tree-viewer popup
-    loadStudyListForLookup();
-    //bindStudyAndTreeLookups();
 
     // enable collection search (in tree-viewer popup)
     $('input[name=collection-search]').unbind('keyup change')

--- a/curator/static/js/tree-collection-editor.js
+++ b/curator/static/js/tree-collection-editor.js
@@ -920,7 +920,7 @@ function loadSelectedCollection() {
             // emulate original popup behavior from editCollection()
             showCollectionViewer( viewModel );  // to refresh the UI
             loadStudyListForLookup();
-            updateNewCollTreeUI();
+            updateTreeLookupUI();
             //pushPageExitWarning('UNSAVED_COLLECTION_CHANGES',
             //                    "WARNING: This page contains unsaved changes.");
             viewModel.ticklers.TREES.subscribe(countHiddenTreeColumns);

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -402,7 +402,7 @@ body {
                       Update trees <i class="icon-refresh"></i>
               </button>
               <button id="new-collection-tree-start" type="submit"
-                      class="btn btn-info Xbtn-info-disabled"
+                      class="btn btn-info Xbtn-info-disabled form-init"
                       onclick="return false;"
               ><span data-bind="text: ($data.data.decisions.length > 0) ? 'Add another tree' : 'Add a tree to this collection'">ADD TREE</span>
                     &nbsp;<i class="icon-plus Xicon-upload icon-white"></i>

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -422,6 +422,7 @@ body {
                 <!-- "active" wiget for study lookup -->
                 <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>
                 <input type="text" name="study-lookup"
+                    autocomplete="off"
                     class="input-xlarge study-lookup-active" style="margin-bottom: 2px; padding-left: 25px;"
                     placeholder="Enter its title, DOI, reference, tag, ID..."
                     data-bind="value: '',

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -439,7 +439,7 @@ body {
                    onclick="resetStudyLookup(); return false;">
                     <i class="icon-search"></i>
                 </a>
-                <a id="study-lookup-indicator" class="study-lookup-passive"
+                <a class="study-lookup-indicator study-lookup-passive"
                    style="font-weight: bold; display: none;"
                    title="" href="" target="_blank">...</a>
                 <br />

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -426,13 +426,13 @@ body {
                     placeholder="Enter its title, DOI, reference, tag, ID..."
                     data-bind="value: '',
                                valueUpdate: ['afterkeydown', 'input'],
-                               event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                               event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 ></input>
                 <!-- hidden field to store chosen ID -->
                 <input type="hidden" name="study-lookup-id"
                        data-bind="value: '',
-                                  event: { change: updateNewCollTreeUI }
+                                  event: { change: updateTreeLookupUI }
                                  "></input>
                 <!-- "passive" wiget once study is chosen -->
                 <a class="btn btn-small study-lookup-passive" style="display: none; margin: 3px 0 3px;"
@@ -451,7 +451,7 @@ body {
                     placeholder="Enter its name, ID, ingroup clade..."
                     data-bind="value: '',
                                valueUpdate: ['afterkeydown', 'input'],
-                               event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                               event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 >
                     <option disabled="disabled" value="">Find the study above first</option>
@@ -470,7 +470,7 @@ body {
                     placeholder=".../curator/study/view/pg_2826/?tab=trees&tree=tree6573"
                     data-bind="value: '',
                                valueUpdate: ['afterkeydown', 'input'],
-                               event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                               event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 ></input>
                 <button class="btn btn-info"

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -454,7 +454,7 @@ body {
                                event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 >
-                    <option disabled="disabled" value="">Find the study above first</option>
+                    <option disabled="disabled" value="">Choose a study first</option>
                 </select>
                 <button class="btn btn-info"
                         data-bind="click: function() {addTreeToCollection($data, 'FROM_LOOKUPS'); return false;}"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -927,6 +927,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                 <!-- "active" wiget for study lookup -->
                 <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>
                 <input type="text" name="study-lookup"
+                    autocomplete="off"
                     class="input-xlarge study-lookup-active" style="margin-bottom: 2px; padding-left: 25px;"
                     placeholder="Enter its title, DOI, reference, tag, ID..."
                     data-bind="value: '',

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -931,13 +931,13 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                     placeholder="Enter its title, DOI, reference, tag, ID..."
                     data-bind="value: '',
                                valueUpdate: ['afterkeydown', 'input'],
-                               event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                               event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 ></input>
                 <!-- hidden field to store chosen ID -->
                 <input type="hidden" name="study-lookup-id"
                        data-bind="value: '',
-                                  event: { change: updateNewCollTreeUI }
+                                  event: { change: updateTreeLookupUI }
                                  "></input>
                 <!-- "passive" wiget once study is chosen -->
                 <a class="btn btn-small study-lookup-passive" style="display: none; margin: 3px 0 3px;"
@@ -956,7 +956,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                     placeholder="Enter its name, ID, ingroup clade..."
                     data-bind="value: '',
                                valueUpdate: ['afterkeydown', 'input'],
-                               event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                               event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 >
                     <option disabled="disabled" value="">Find the study above first</option>
@@ -975,7 +975,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                     placeholder=".../curator/study/view/pg_2826/?tab=trees&tree=tree6573"
                     data-bind="value: '',
                                valueUpdate: ['afterkeydown', 'input'],
-                               event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                               event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 ></input>
                 <button class="btn btn-info"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -959,7 +959,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                                event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                "
                 >
-                    <option disabled="disabled" value="">Find the study above first</option>
+                    <option disabled="disabled" value="">Choose a study first</option>
                 </select>
                 <button class="btn btn-info"
                         data-bind="click: function() {addTreeToCollection($data, 'FROM_LOOKUPS'); return false;}"

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -907,7 +907,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
             <!-- TODO: Put add-collection widgets! -->
             <div xclass="form-actions" style="margin-top: 0px; margin-bottom: 0.25em;">
               <button id="new-collection-tree-start" type="submit"
-                      class="btn btn-info Xbtn-info-disabled"
+                      class="btn btn-info Xbtn-info-disabled form-init"
                       onclick="return false;"
               ><span data-bind="text: ($data.data.decisions.length > 0) ? 'Add another tree' : 'Add a tree to this collection'">ADD TREE</span>
                     &nbsp;<i class="icon-plus Xicon-upload icon-white"></i>

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -944,7 +944,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                    onclick="resetStudyLookup(); return false;">
                     <i class="icon-search"></i>
                 </a>
-                <a id="study-lookup-indicator" class="study-lookup-passive"
+                <a class="study-lookup-indicator study-lookup-passive"
                    style="font-weight: bold; display: none;"
                    title="" href="" target="_blank">...</a>
                 <br />

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1738,7 +1738,7 @@ body {
                          data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
 
                  <!-- Optional widgets to choose a study+tree from phylesystem -->
-                 <div style="display: block; text-align: right; padding-top: 8px;" id="target-source-tree-options">
+                 <div style="display: block; text-align: right; padding-top: 8px;">
 
                     <label style="display: inline-block;">Choose a study &nbsp;</label>
                     <!-- "active" wiget for study lookup -->
@@ -1761,7 +1761,7 @@ body {
                        onclick="resetStudyLookup(); return false;">
                         <i class="icon-search"></i>
                     </a>
-                    <a id="analysis-study-lookup-indicator" class="study-lookup-passive"
+                    <a class="study-lookup-passive"
                        style="font-weight: bold; display: none;"
                        title="" href="" target="_blank">...</a>
 
@@ -3165,6 +3165,7 @@ cat, Felis catus, 563166"
     </div>
     <div class="modal-footer">
       <div id="tree-phylogram-options" class="pull-left form-inline" style="display: none;">
+        <div style="display: inline-block; vertical-align: top;">
           <!-- N.B. data bindings mimic toggleRadialTreeLayoutInViewer() -->
           <label class="checkbox" style="margin-left: 25px;" for="branch-length-toggle"
                  data-bind="attr: getBranchLengthToggleAttributes($data),
@@ -3180,7 +3181,6 @@ cat, Felis catus, 563166"
               Radial tree layout
           </label>
 
-        <div style="display: inline-block; vertical-align: top;">
           <label style="margin-left: 25px; position: relative; top: 1px;">Show conflict versus</label>
           <select class="treeview-reference-select"
                   data-bind="value: $data.conflictDetails ? $data.conflictDetails.referenceTreeID : ''"
@@ -3190,9 +3190,51 @@ cat, Felis catus, 563166"
               <option value="ott">Open Tree Taxonomy</option>
               <option value="STUDYID_TREEID">Source tree from a published study</option>
           </select>
-          <div class="lookup-widgets" style="display: none;">
-              BUTTONS GO HERE
+
+          <!-- Optional widgets to choose a study+tree from phylesystem -->
+          <div class="lookup-widgets" 
+               style="display: none; text-align: right; padding-top: 8px;">
+ 
+             <label style="display: inline-block;">Choose a study &nbsp;</label>
+             <!-- "active" wiget for study lookup -->
+             <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>
+             <input type="text" name="study-lookup"
+                 class="input-xlarge study-lookup-active" style="margin-bottom: 2px; padding-left: 25px;"
+                 placeholder="Enter its title, DOI, reference, tag, ID..."
+                 data-bind="value: '',
+                            valueUpdate: ['afterkeydown', 'input'],
+                            event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                            "
+             ></input>
+             <!-- hidden field to store chosen ID -->
+             <input type="hidden" name="study-lookup-id"
+                    data-bind="value: '',
+                               event: { change: updateNewCollTreeUI }
+                              "></input>
+             <!-- "passive" wiget once study is chosen -->
+             <a class="btn btn-small study-lookup-passive" style="display: none; margin: 3px 0 3px;"
+                onclick="resetStudyLookup(); return false;">
+                 <i class="icon-search"></i>
+             </a>
+             <a class="study-lookup-passive"
+                style="font-weight: bold; display: none;"
+                title="" href="" target="_blank">...</a>
+ 
+             <label style="padding-left: 1em; display: inline-block;">&nbsp; and one of its trees &nbsp;</label>
+             <select name="tree-lookup"
+                 class="input-xlarge" style="margin-bottom: 2px;"
+                 disabled="disabled"
+                 placeholder="Enter its name, ID, ingroup clade..."
+                 data-bind="value: '',
+                            valueUpdate: ['afterkeydown', 'input'],
+                            event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                            "
+             >
+                 <option disabled="disabled" value="">Find the study above first</option>
+             </select>
+             <button class="btn btn-info" data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
           </div>
+
         </div>
 
           <button id="treeview-fetch-conflict" class="btn btn-info" data-bind="click: showConflictDetailsWithHistory">GO!</button>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1739,7 +1739,11 @@ body {
 
                  <!-- Optional widgets to choose a study+tree from phylesystem -->
                  <div style="display: block; text-align: right; padding-top: 8px;">
-
+                    <div class="dropup" style="position: relative; margin-left: 146px;">
+                        <ul id="study-lookup-results" class="dropdown-menu" role="menu">
+                            ...
+                        </ul>
+                    </div>
                     <label style="display: inline-block;">Choose a study &nbsp;</label>
                     <!-- "active" wiget for study lookup -->
                     <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>
@@ -1748,13 +1752,13 @@ body {
                         placeholder="Enter its title, DOI, reference, tag, ID..."
                         data-bind="value: '',
                                    valueUpdate: ['afterkeydown', 'input'],
-                                   event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                                   event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                    "
                     ></input>
                     <!-- hidden field to store chosen ID -->
                     <input type="hidden" name="study-lookup-id"
                            data-bind="value: '',
-                                      event: { change: updateNewCollTreeUI }
+                                      event: { change: updateTreeLookupUI }
                                      "></input>
                     <!-- "passive" wiget once study is chosen -->
                     <a class="btn btn-small study-lookup-passive" style="display: none; margin: 3px 0 3px;"
@@ -1772,7 +1776,7 @@ body {
                         placeholder="Enter its name, ID, ingroup clade..."
                         data-bind="value: '',
                                    valueUpdate: ['afterkeydown', 'input'],
-                                   event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                                   event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                    "
                     >
                         <option disabled="disabled" value="">Find the study above first</option>
@@ -3203,13 +3207,13 @@ cat, Felis catus, 563166"
                  placeholder="Enter its title, DOI, reference, tag, ID..."
                  data-bind="value: '',
                             valueUpdate: ['afterkeydown', 'input'],
-                            event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                            event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                             "
              ></input>
              <!-- hidden field to store chosen ID -->
              <input type="hidden" name="study-lookup-id"
                     data-bind="value: '',
-                               event: { change: updateNewCollTreeUI }
+                               event: { change: updateTreeLookupUI }
                               "></input>
              <!-- "passive" wiget once study is chosen -->
              <a class="btn btn-small study-lookup-passive" style="display: none; margin: 3px 0 3px;"
@@ -3227,7 +3231,7 @@ cat, Felis catus, 563166"
                  placeholder="Enter its name, ID, ingroup clade..."
                  data-bind="value: '',
                             valueUpdate: ['afterkeydown', 'input'],
-                            event: { keyup: updateNewCollTreeUI, change: updateNewCollTreeUI }
+                            event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                             "
              >
                  <option disabled="disabled" value="">Find the study above first</option>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3232,7 +3232,6 @@ cat, Felis catus, 563166"
              >
                  <option disabled="disabled" value="">Find the study above first</option>
              </select>
-             <button class="btn btn-info" data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
           </div>
 
         </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3180,13 +3180,21 @@ cat, Felis catus, 563166"
               Radial tree layout
           </label>
 
+        <div style="display: inline-block; vertical-align: top;">
           <label style="margin-left: 25px; position: relative; top: 1px;">Show conflict versus</label>
-          <select id="treeview-reference-select" data-bind="value: $data.conflictDetails ? $data.conflictDetails.referenceTreeID : ''">
+          <select class="treeview-reference-select"
+                  data-bind="value: $data.conflictDetails ? $data.conflictDetails.referenceTreeID : ''"
+                  onchange="updatePhylesystemLookupWidgets(this);">
               <option value="">Choose a target...</option>
               <option value="synth">Synthetic Tree of Life</option>
               <option value="ott">Open Tree Taxonomy</option>
               <option value="STUDYID_TREEID">Source tree from a published study</option>
           </select>
+          <div class="lookup-widgets" style="display: none;">
+              BUTTONS GO HERE
+          </div>
+        </div>
+
           <button id="treeview-fetch-conflict" class="btn btn-info" data-bind="click: showConflictDetailsWithHistory">GO!</button>
           <button id="treeview-clear-conflict" class="btn" data-bind="click: hideConflictDetailsWithHistory">Hide conflict</button>
       </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1779,7 +1779,7 @@ body {
                                    event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                                    "
                     >
-                        <option disabled="disabled" value="">Find the study above first</option>
+                        <option disabled="disabled" value="">Choose a study first</option>
                     </select>
                     <button class="btn btn-info" data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
                  </div>
@@ -3238,7 +3238,7 @@ cat, Felis catus, 563166"
                             event: { keyup: updateTreeLookupUI, change: updateTreeLookupUI }
                             "
              >
-                 <option disabled="disabled" value="">Find the study above first</option>
+                 <option disabled="disabled" value="">Choose a study first</option>
              </select>
           </div>
 

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1739,7 +1739,7 @@ body {
 
                  <!-- Optional widgets to choose a study+tree from phylesystem -->
                  <div style="display: block; text-align: right; padding-top: 8px;">
-                    <div class="dropup" style="position: relative; margin-left: 146px;">
+                    <div class="dropup" style="position: relative; margin-left: 110px; text-align: left;">
                         <ul id="study-lookup-results" class="dropdown-menu" role="menu">
                             ...
                         </ul>
@@ -1765,7 +1765,7 @@ body {
                        onclick="resetStudyLookup(); return false;">
                         <i class="icon-search"></i>
                     </a>
-                    <a class="study-lookup-passive"
+                    <a class="study-lookup-indicator study-lookup-passive"
                        style="font-weight: bold; display: none;"
                        title="" href="" target="_blank">...</a>
 
@@ -3224,7 +3224,7 @@ cat, Felis catus, 563166"
                 onclick="resetStudyLookup(); return false;">
                  <i class="icon-search"></i>
              </a>
-             <a class="study-lookup-passive"
+             <a class="study-lookup-indicator study-lookup-passive"
                 style="font-weight: bold; display: none;"
                 title="" href="" target="_blank">...</a>
  

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1741,8 +1741,9 @@ body {
                  <!-- Optional widgets to choose a study+tree from phylesystem -->
                  <div class="lookup-widgets"
                       style="display: none; text-align: right; padding-top: 8px;">
-                    <div class="dropup" style="position: relative; margin-left: 146px; text-align: left;">
-                        <ul id="study-lookup-results" class="dropdown-menu" role="menu">
+                    <div class="Xdropup" style="position: relative; margin-left: 274px; text-align: left;">
+                        <ul id="study-lookup-results" class="dropdown-menu" role="menu"
+                            style="top: 24px; left: 45px;">
                             ...
                         </ul>
                     </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1739,7 +1739,7 @@ body {
 
                  <!-- Optional widgets to choose a study+tree from phylesystem -->
                  <div style="display: block; text-align: right; padding-top: 8px;">
-                    <div class="dropup" style="position: relative; margin-left: 110px; text-align: left;">
+                    <div class="dropup" style="position: relative; margin-left: 146px; text-align: left;">
                         <ul id="study-lookup-results" class="dropdown-menu" role="menu">
                             ...
                         </ul>
@@ -3198,7 +3198,7 @@ cat, Felis catus, 563166"
           <!-- Optional widgets to choose a study+tree from phylesystem -->
           <div class="lookup-widgets" 
                style="display: none; text-align: right; padding-top: 8px;">
-             <div class="dropup" style="position: relative; margin-left: 146px;">
+             <div class="dropup" style="position: relative; margin-left: 110px; text-align: left;">
                 <ul id="study-lookup-results" class="dropdown-menu" role="menu">
                     ...
                 </ul>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3200,8 +3200,9 @@ cat, Felis catus, 563166"
           <!-- Optional widgets to choose a study+tree from phylesystem -->
           <div class="lookup-widgets"
                style="display: none; text-align: right; padding-top: 8px;">
-             <div class="dropup" style="position: relative; margin-left: 110px; text-align: left;">
-                <ul id="study-lookup-results" class="dropdown-menu" role="menu">
+             <div class="Xdropup" style="position: relative; margin-left: 110px; text-align: left;">
+                <ul id="study-lookup-results" class="dropdown-menu" role="menu"
+                    style="margin-top: 28px; margin-left: 164px;">
                     ...
                 </ul>
              </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1738,7 +1738,8 @@ body {
                          data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
 
                  <!-- Optional widgets to choose a study+tree from phylesystem -->
-                 <div style="display: block; text-align: right; padding-top: 8px;">
+                 <div class="lookup-widgets"
+                      style="display: none; text-align: right; padding-top: 8px;">
                     <div class="dropup" style="position: relative; margin-left: 146px; text-align: left;">
                         <ul id="study-lookup-results" class="dropdown-menu" role="menu">
                             ...
@@ -3196,7 +3197,7 @@ cat, Felis catus, 563166"
           </select>
 
           <!-- Optional widgets to choose a study+tree from phylesystem -->
-          <div class="lookup-widgets" 
+          <div class="lookup-widgets"
                style="display: none; text-align: right; padding-top: 8px;">
              <div class="dropup" style="position: relative; margin-left: 110px; text-align: left;">
                 <ul id="study-lookup-results" class="dropdown-menu" role="menu">

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1751,6 +1751,7 @@ body {
                     <!-- "active" wiget for study lookup -->
                     <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>
                     <input type="text" name="study-lookup"
+                        autocomplete="off"
                         class="input-xlarge study-lookup-active" style="margin-bottom: 2px; padding-left: 25px;"
                         placeholder="Enter its title, DOI, reference, tag, ID..."
                         data-bind="value: '',
@@ -3211,6 +3212,7 @@ cat, Felis catus, 563166"
              <!-- "active" wiget for study lookup -->
              <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>
              <input type="text" name="study-lookup"
+                 autocomplete="off"
                  class="input-xlarge study-lookup-active" style="margin-bottom: 2px; padding-left: 25px;"
                  placeholder="Enter its title, DOI, reference, tag, ID..."
                  data-bind="value: '',

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1785,7 +1785,6 @@ body {
                     >
                         <option disabled="disabled" value="">Choose a study first</option>
                     </select>
-                    <button class="btn btn-info" data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
                  </div>
 
              </form>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3185,6 +3185,7 @@ cat, Felis catus, 563166"
               <option value="">Choose a target...</option>
               <option value="synth">Synthetic Tree of Life</option>
               <option value="ott">Open Tree Taxonomy</option>
+              <option value="STUDYID_TREEID">Source tree from a published study</option>
           </select>
           <button id="treeview-fetch-conflict" class="btn btn-info" data-bind="click: showConflictDetailsWithHistory">GO!</button>
           <button id="treeview-clear-conflict" class="btn" data-bind="click: hideConflictDetailsWithHistory">Hide conflict</button>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3200,9 +3200,9 @@ cat, Felis catus, 563166"
           <!-- Optional widgets to choose a study+tree from phylesystem -->
           <div class="lookup-widgets"
                style="display: none; text-align: right; padding-top: 8px;">
-             <div class="Xdropup" style="position: relative; margin-left: 110px; text-align: left;">
+             <div class="dropup" style="position: relative; margin-left: 110px; text-align: left;">
                 <ul id="study-lookup-results" class="dropdown-menu" role="menu"
-                    style="margin-top: 28px; margin-left: 164px;">
+                    style="margin-top: 28px; Xmargin-left: 164px;">
                     ...
                 </ul>
              </div>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1734,7 +1734,7 @@ body {
                      <option value="ott">Open Tree Taxonomy</option>
                      <option value="STUDYID_TREEID">Source tree from a published study</option>
                  </select>
-                 <button id="simple-conflict-button" class="btn btn-info"
+                 <button id="simple-conflict-button" class="btn btn-info form-action"
                          data-bind="click: fetchAndShowTreeConflictSummary">GO!</button>
 
                  <!-- Optional widgets to choose a study+tree from phylesystem -->

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1728,7 +1728,8 @@ body {
                  </select>
 
                  <label>against target</label>
-                 <select id="reference-select">
+                 <select id="reference-select"
+                         onchange="updatePhylesystemLookupWidgets(this);">
                      <option value="">Choose a target...</option>
                      <option value="synth">Synthetic Tree of Life</option>
                      <option value="ott">Open Tree Taxonomy</option>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -3198,7 +3198,11 @@ cat, Felis catus, 563166"
           <!-- Optional widgets to choose a study+tree from phylesystem -->
           <div class="lookup-widgets" 
                style="display: none; text-align: right; padding-top: 8px;">
- 
+             <div class="dropup" style="position: relative; margin-left: 146px;">
+                <ul id="study-lookup-results" class="dropdown-menu" role="menu">
+                    ...
+                </ul>
+             </div>
              <label style="display: inline-block;">Choose a study &nbsp;</label>
              <!-- "active" wiget for study lookup -->
              <i class="icon-search study-lookup-active" style="position: absolute; margin: 8px 0 0 7px; pointer-events: none;"></i>


### PR DESCRIPTION
Adapt the study+tree browsing UI to support conflict reporting vs. other trees in phylesystem. This seems to be working now (on **devtree**) in all these contexts:

- In the single-tree view popup (conflict details)
- In the Analyses tab for a study (conflict summary)
- In the tree-collection editor, the original context for study+tree lookup (adding tree to a collection)