### PR TITLE
Expect the curation app base URL in webapp config

### DIFF
--- a/curator/controllers/collection.py
+++ b/curator/controllers/collection.py
@@ -14,7 +14,7 @@
 #########################################################################
 
 from applications.opentree.modules.opentreewebapputil import(
-    get_opentree_services_method_urls, 
+    get_opentree_api_endpoints, 
     fetch_current_TNRS_context_names,
     fetch_trees_queued_for_synthesis,
     get_maintenance_info)
@@ -27,7 +27,7 @@ def index():
     Show list searchable/filtered list of all collections
     (default filter = My Collections, if logged in?)
     """
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['maintenance_info'] = get_maintenance_info(request)
     if auth.is_logged_in():
         # user is logged in, filter to their own collections by default?
@@ -46,7 +46,7 @@ def view():
     ? OR can this include work-in-progress from a personal branch?
     """
     response.view = 'collection/edit.html'
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['maintenance_info'] = get_maintenance_info(request)
     #view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
     view_dict['collectionID'] = request.args[0] +'/'+ request.args[1]
@@ -65,7 +65,7 @@ def create():
     if maintenance_info.get('maintenance_in_progress', False):
         redirect(URL('curator', 'default', 'index', vars={"maintenance_notice":"true"}))
         pass
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['message'] = "collection/create"
     return view_dict
 """
@@ -80,7 +80,7 @@ def edit():
             args=request.args))
     # Fetch a fresh list of search contexts for TNRS? see working example in
     # the header search of the main opentree webapp
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
     view_dict['treesQueuedForSynthesis'] = fetch_trees_queued_for_synthesis(request)
     view_dict['collectionID'] = request.args[0] +'/'+ request.args[1]
@@ -118,7 +118,7 @@ def _get_latest_synthesis_details_for_collection_id( collection_id ):
         import json
         import requests
 
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
 
         # fetch a list of all studies and collections that contribute to synthesis
         # TODO: Request that these fields be added

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from applications.opentree.modules.opentreewebapputil import(
-    get_opentree_services_method_urls,
+    get_opentree_api_endpoints,
     extract_nexson_from_http_call,
     fetch_github_app_auth_token,
     get_maintenance_info)
@@ -29,7 +29,7 @@ def index():
     a logged-in user.
     """
     #response.flash = T("Welcome to web2py!")
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['maintenance_info'] = get_maintenance_info(request)
 
     if False:  ## auth.is_logged_in():
@@ -45,12 +45,12 @@ def collections():
 
     TODO: move to collection/index?
     """
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['maintenance_info'] = get_maintenance_info(request)
     return view_dict
     
 def error():
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     return view_dict
 
 @auth.requires_login()
@@ -78,7 +78,7 @@ def profile():
     shows a personalized profile for any user (default = the current logged-in user) 
     http://..../{app}/default/profile/[username]
     """
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['maintenance_info'] = get_maintenance_info(request)
 
     # if the URL has a [username], try to load their information
@@ -192,7 +192,7 @@ def _get_opentree_activity( userid=None, username=None ):
         'added_collections':[],
         'curated_collections':[]
     }
-    method_dict = get_opentree_services_method_urls(request)
+    method_dict = get_opentree_api_endpoints(request)
 
     # Use GitHub API to gather comments from this user, as shown in
     #   https://github.com/OpenTreeOfLife/feedback/issues/created_by/jimallman

--- a/curator/controllers/study.py
+++ b/curator/controllers/study.py
@@ -12,7 +12,7 @@
 #########################################################################
 
 from applications.opentree.modules.opentreewebapputil import(
-    get_opentree_services_method_urls, 
+    get_opentree_api_endpoints, 
     fetch_current_TNRS_context_names,
     fetch_trees_queued_for_synthesis,
     get_maintenance_info)
@@ -25,7 +25,7 @@ def index():
     Show list searchable/filtered list of all studies
     (default filter = My Studies, if logged in?)
     """
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
 
     if auth.is_logged_in():
         # user is logged in, filter to their own studies by default?
@@ -44,7 +44,7 @@ def view():
     ? OR can this include work-in-progress from a personal branch?
     """
     response.view = 'study/edit.html'
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['maintenance_info'] = get_maintenance_info(request)
     #view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
     view_dict['studyID'] = request.args[0]
@@ -61,7 +61,7 @@ def create():
     if maintenance_info.get('maintenance_in_progress', False):
         redirect(URL('curator', 'default', 'index', vars={"maintenance_notice":"true"}))
         pass
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['message'] = "study/create"
     return view_dict
 
@@ -76,7 +76,7 @@ def edit():
             args=request.args))
     # Fetch a fresh list of search contexts for TNRS? see working example in
     # the header search of the main opentree webapp
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
     view_dict['treesQueuedForSynthesis'] = fetch_trees_queued_for_synthesis(request)
     view_dict['studyID'] = request.args[0]
@@ -93,7 +93,7 @@ def _get_latest_synthesis_details_for_study_id( study_id ):
         import json
         import requests
 
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
 
         # fetch a list of all studies that contribute to synthesis
         fetch_url = method_dict['getSynthesisSourceList_url']

--- a/curator/controllers/tnrs.py
+++ b/curator/controllers/tnrs.py
@@ -6,7 +6,7 @@
 #########################################################################
 
 from applications.opentree.modules.opentreewebapputil import(
-    get_opentree_services_method_urls, 
+    get_opentree_api_endpoints, 
     fetch_current_TNRS_context_names,
     get_maintenance_info)
 
@@ -19,7 +19,7 @@ def index():
     """
 
     response.view = 'tnrs.html'
-    view_dict = get_opentree_services_method_urls(request)
+    view_dict = get_opentree_api_endpoints(request)
     #view_dict['message'] = "This would appear at bottom of page.."
     view_dict['maintenance_info'] = get_maintenance_info(request)
     view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)

--- a/curator/private/config.example
+++ b/curator/private/config.example
@@ -34,6 +34,9 @@ github_redirect_uri = YOUR_REDIRECT_URI_HERE
 # (the installation ID is in the URL of the Configure button here)
 github_app_installation_id = YOUR_APP_INSTALLATION_ID_HERE
 
+#
+# TODO: Revise both API sections below to match our Ansible stuff, or delete this file entirely!
+#
 # List public-facing base URL for supporting data services
 # (NOTE that these are used by both server- and client-side code)
 [domains]

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -911,8 +911,8 @@ body {
         }
     }
 
-    var treemachine_domain = "{{=treemachine_domain}}";
-    var taxomachine_domain = "{{=taxomachine_domain}}";
+    var treemachine_domain = "{{=default_apis}}";
+    var taxomachine_domain = "{{=default_apis}}";
     var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
     var doTNRSForMappingOTUs_url = "{{=doTNRSForMappingOTUs_url}}";
     var getContextForNames_url = "{{=getContextForNames_url}}";

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1918,8 +1918,8 @@ body {
         }
     }
 
-    var treemachine_domain = "{{=treemachine_domain}}";
-    var taxomachine_domain = "{{=taxomachine_domain}}";
+    var treemachine_domain = "{{=default_apis}}";
+    var taxomachine_domain = "{{=default_apis}}";
     var doTNRSForAutocomplete_url = "{{=doTNRSForAutocomplete_url}}";
     var doTNRSForMappingOTUs_url = "{{=doTNRSForMappingOTUs_url}}";
     var getContextForNames_url = "{{=getContextForNames_url}}";

--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 from datetime import datetime
-from opentreewebapputil import (get_opentree_services_method_urls, 
+from opentreewebapputil import (get_opentree_api_endpoints, 
                                 fetch_current_TNRS_context_names,
                                 get_data_deposit_message,)
 import bleach
@@ -34,7 +34,7 @@ def index():
     redirect(URL('about', 'open-tree-of-life'))
 
 # try grabbing shared data just once
-default_view_dict = get_opentree_services_method_urls(request)
+default_view_dict = get_opentree_api_endpoints(request)
 default_view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
 
 # NOTE that web2py should attempt to convert hyphens (dashes) in URLs into underscores
@@ -441,7 +441,7 @@ def fetch_current_synthesis_source_data():
     try:
         import requests
         import json
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
 
         # fetch a list of all studies that contribute to synthesis
         fetch_url = method_dict['getSynthesisSourceList_url']

--- a/webapp/controllers/contact.py
+++ b/webapp/controllers/contact.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from opentreewebapputil import (get_opentree_services_method_urls, 
+from opentreewebapputil import (get_opentree_api_endpoints, 
                                 fetch_current_TNRS_context_names)
 
 ### required - do no delete
@@ -8,7 +8,7 @@ def download(): return response.download(request,db)
 def call(): return service()
 ### end requires
 
-default_view_dict = get_opentree_services_method_urls(request)
+default_view_dict = get_opentree_api_endpoints(request)
 default_view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
 
 def index():

--- a/webapp/controllers/default.py
+++ b/webapp/controllers/default.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import urllib2
 import socket
-from opentreewebapputil import (get_opentree_services_method_urls, 
+from opentreewebapputil import (get_opentree_api_endpoints, 
                                 fetch_current_TNRS_context_names)
 
-default_view_dict = get_opentree_services_method_urls(request)
+default_view_dict = get_opentree_api_endpoints(request)
 default_view_dict['taxonSearchContextNames'] = fetch_current_TNRS_context_names(request)
 
 ### required - do no delete
@@ -118,7 +118,7 @@ def download_subtree():
             'accept' : 'application/json',
         }
 
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
 
         # use the appropriate web service for this ID type
         fetch_url = method_dict['getDraftSubtree_url']
@@ -161,7 +161,7 @@ def fetch_current_synthetic_tree_ids():
         import json
         import requests
 
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
         fetch_url = method_dict['getDraftTreeID_url']
         if fetch_url.startswith('//'):
             # Prepend scheme to a scheme-relative URL

--- a/webapp/controllers/study.py
+++ b/webapp/controllers/study.py
@@ -29,7 +29,8 @@ def _get_nexson_proc_conf(request):
     try:
         d = {}
         d['nexsons_dir'] = conf.get('paths', 'nexsonsdir')
-        d['treemachine_domain'] = conf.get('domains', 'treemachine')
+        # TODO
+        d['treemachine_domain'] = conf.get('api_base_urls', 'default_apis')
         d['study_to_status_script'] = conf.get('paths', 'study_to_status_script')
     except:
         raise HTTP(501, T('Server is not configured to report on NexSON status'))

--- a/webapp/controllers/synthview.py
+++ b/webapp/controllers/synthview.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from opentreewebapputil import get_opentree_services_domains
+from opentreewebapputil import get_opentree_api_base_urls
 
 ### required - do no delete
 def user(): return dict(form=auth())
@@ -7,7 +7,7 @@ def download(): return response.download(request,db)
 def call(): return service()
 ### end requires
 def index():
-    context_dict = get_opentree_services_domains(request)
+    context_dict = get_opentree_api_base_urls(request)
     context_dict['tree_id'] = request.vars.get('tree')
     context_dict['node_id'] = request.vars.get('node')
     return context_dict

--- a/webapp/controllers/treeview.py
+++ b/webapp/controllers/treeview.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from opentreewebapputil import get_opentree_services_domains
+from opentreewebapputil import get_opentree_api_base_urls
 
 ### required - do no delete
 def user(): return dict(form=auth())
@@ -7,7 +7,7 @@ def download(): return response.download(request,db)
 def call(): return service()
 ### end requires
 def index():
-    context_dict = get_opentree_services_domains(request)
+    context_dict = get_opentree_api_base_urls(request)
     context_dict['tree_id'] = request.vars.get('tree')
     context_dict['node_id'] = request.vars.get('node')
     return context_dict

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -119,15 +119,15 @@ def get_opentree_api_endpoints(request):
     base_urls = get_opentree_api_base_urls(request)
 
     conf = get_conf(request)
-    url_pairs = conf.items('method_urls')
-    method_urls = base_urls.copy()
+    url_pairs = conf.items('api_endpoints')
+    api_endpoints = base_urls.copy()
     for mname, murl in url_pairs:
         # replace any base-URL tokens, eg, 'CACHED_production_apis'
         for dname, durl in base_urls.items():
             murl = murl.replace('{%s}' % dname, durl)
-        method_urls[ mname ] = murl
+        api_endpoints[ mname ] = murl
 
-    return method_urls
+    return api_endpoints
 
 def get_user_display_name():
     # Determine the best possible name to show for the current logged-in user.

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -69,25 +69,25 @@ def get_logger(request, name):
         logger.is_configured = True
     return logger
 
-def get_opentree_services_domains(request):
+def get_opentree_api_base_urls(request):
     '''
-    Reads the local configuration to get the domains and returns a dictionary
+    Reads the local configuration to get the base URLs and returns a dictionary
         with keys:
-            treemachine_domain
-            taxomachine_domain
-            oti_domain
-            opentree_api_domain
-        the values of the domain will contain the port (when needed)
+            default_apis
+            production_apis
+            CACHED_default_apis
+            CACHED_production_apis
+        These values will contain the port (when needed) and any base path like `/cached'
 
     This is mainly useful for debugging because it lets developers use local
         instances of the service by tweaking private/conf (see private/conf.example)
     '''
     conf = get_conf(request)
-    domain_pairs = conf.items('domains')
-    domains = dict()
-    for name, url in domain_pairs:
-        domains[ "%s_domain" % name ] = url
-    return domains
+    base_url_pairs = conf.items('api_base_urls')
+    base_urls = dict()
+    for name, url in base_url_pairs:
+        base_urls[ name ] = url
+    return base_urls
 
 def get_maintenance_info(request):
     '''
@@ -106,24 +106,24 @@ def get_maintenance_info(request):
         minfo['maintenance_notice'] = ""
     return minfo
 
-def get_opentree_services_method_urls(request):
+def get_opentree_services_api_endpoints(request):
     '''
-    Reads the local configuration to build on domains and return a dictionary
-        with keys for all domains AND their service methods, whose values are
-        URLs combining domain and partial paths
+    Reads the local configuration to build on base URLs and return a dictionary
+        with keys for all API endpoints (method URLs) combining base URLs
+        and partial paths for each method
 
     This is useful for debugging and for adapting to different ways of 
         configuring services, eg, proxied through a single domain 
         (see private/conf.example)
     '''
-    domains = get_opentree_services_domains(request)
+    base_urls = get_opentree_api_base_urls(request)
 
     conf = get_conf(request)
     url_pairs = conf.items('method_urls')
-    method_urls = domains.copy()
+    method_urls = base_urls.copy()
     for mname, murl in url_pairs:
-        # replace any domain tokens, eg, 'treemachine_domain'
-        for dname, durl in domains.items():
+        # replace any base-URL tokens, eg, 'CACHED_production_apis'
+        for dname, durl in base_urls.items():
             murl = murl.replace('{%s}' % dname, durl)
         method_urls[ mname ] = murl
 

--- a/webapp/modules/opentreewebapputil.py
+++ b/webapp/modules/opentreewebapputil.py
@@ -106,7 +106,7 @@ def get_maintenance_info(request):
         minfo['maintenance_notice'] = ""
     return minfo
 
-def get_opentree_services_api_endpoints(request):
+def get_opentree_api_endpoints(request):
     '''
     Reads the local configuration to build on base URLs and return a dictionary
         with keys for all API endpoints (method URLs) combining base URLs
@@ -268,7 +268,7 @@ def fetch_current_TNRS_context_names(request):
         # fetch the latest contextName values as JSON from remote site
         import requests
 
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
         fetch_url = method_dict['getContextsJSON_url']
         if fetch_url.startswith('//'):
             # Prepend scheme to a scheme-relative URL
@@ -300,7 +300,7 @@ def fetch_trees_queued_for_synthesis(request):
         # <https://github.com/OpenTreeOfLife/peyotl/blob/33b493e84558ffef381d841986281be352f3da53/peyotl/collections_store/__init__.py#L46>
         import requests
 
-        method_dict = get_opentree_services_method_urls(request)
+        method_dict = get_opentree_api_endpoints(request)
         fetch_url = method_dict['getTreesQueuedForSynthesis_url']
         if fetch_url.startswith('//'):
             # Prepend scheme to a scheme-relative URL

--- a/webapp/private/config.example
+++ b/webapp/private/config.example
@@ -26,6 +26,9 @@ github_redirect_uri = YOUR_REDIRECT_URI_HERE
 # (the installation ID is in the URL of the Configure button here)
 github_app_installation_id = YOUR_APP_INSTALLATION_ID_HERE
 
+#
+# TODO: Revise both API sections to match our Ansible stuff, or delete this file entirely!
+#
 # List public-facing base URL for treemachine and taxomachine services
 # (NOTE that these are used by both server- and client-side code)
 [domains]

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -438,7 +438,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         <div class="nav-collapse collapse">
                     <ul class="nav">
               <!--<li class="active"><a href="{{= URL('default','index') }}">Home</a></li>-->
-              <li><a href="{{=curation_app_url}}">Add / browse trees</a></li>
+              <li><a href="{{=curation_webapp_url}}">Add / browse trees</a></li>
               <li><a href="{{= URL('contact','index') }}">Feedback</a></li>
               <li class="dropdown">
                 <a href="{{= URL('about','open-tree-of-life') }}" class="dropdown-toggle" data-toggle="dropdown">

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -91,8 +91,8 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     {{#if globals().get('treemachine_domain',False):}}  <!-- TODO: add a proper test here, to omit while in /opentree/appadmin -->
     <script type="text/javascript">
         // make important API endpoints (and some base URLs) available to client-side code
-        var treemachine_domain = "{{=treemachine_domain}}";
-        var taxomachine_domain = "{{=taxomachine_domain}}";
+        var treemachine_domain = "{{=default_apis}}";
+        var taxomachine_domain = "{{=default_apis}}";
         var getDraftTreeID_url = "{{=getDraftTreeID_url}}";
         var getSyntheticTree_url = "{{=getSyntheticTree_url}}";
         var getTaxonInfo_url = "{{=getTaxonInfo_url}}";

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -90,7 +90,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     <!-- js dependencies for argus -->
     {{if globals().get('treemachine_domain',False):}}  <!-- TODO: add a proper test here, to omit while in /opentree/appadmin -->
     <script type="text/javascript">
-        // make important domains available to client-side code
+        // make important API endpoints (and some base URLs) available to client-side code
         var treemachine_domain = "{{=treemachine_domain}}";
         var taxomachine_domain = "{{=taxomachine_domain}}";
         var getDraftTreeID_url = "{{=getDraftTreeID_url}}";

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -88,7 +88,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
     {{response.files.append(URL('static','plugin_localcomments/css/localcomments.css'))}}
 
     <!-- js dependencies for argus -->
-    {{if globals().get('treemachine_domain',False):}}  <!-- TODO: add a proper test here, to omit while in /opentree/appadmin -->
+    {{#if globals().get('treemachine_domain',False):}}  <!-- TODO: add a proper test here, to omit while in /opentree/appadmin -->
     <script type="text/javascript">
         // make important API endpoints (and some base URLs) available to client-side code
         var treemachine_domain = "{{=treemachine_domain}}";
@@ -112,7 +112,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         var showLegendOnLoad = false;
       {{ pass }}
     </script>
-    {{pass}}
+    {{#pass}}
 
     {{# JSON support for older browsers (esp. IE7)}}
     {{response.files.append(URL('static','js/json2.js'))}}

--- a/webapp/views/layout.html
+++ b/webapp/views/layout.html
@@ -438,7 +438,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_display_na
         <div class="nav-collapse collapse">
                     <ul class="nav">
               <!--<li class="active"><a href="{{= URL('default','index') }}">Home</a></li>-->
-              <li><a href="/curator">Add / browse trees</a></li>
+              <li><a href="{{=curation_app_url}}">Add / browse trees</a></li>
               <li><a href="{{= URL('contact','index') }}">Feedback</a></li>
               <li class="dropdown">
                 <a href="{{= URL('about','open-tree-of-life') }}" class="dropdown-toggle" data-toggle="dropdown">

--- a/webapp/views/synthview/index.html
+++ b/webapp/views/synthview/index.html
@@ -77,7 +77,7 @@ $(document).ready(function (){
     "domSource": "ottol",
     "container": document.getElementById("argusCanvasContainer"),
     "treemachineDomain": "{{=default_apis}}",
-    "taxomachineDomain": "{{=taxomachine_domain}}",
+    "taxomachineDomain": "{{=default_apis}}",
     "useTreemachine": true,
     "useSyntheticTree": true,
     "maxDepth": 3

--- a/webapp/views/synthview/index.html
+++ b/webapp/views/synthview/index.html
@@ -1,8 +1,4 @@
 {{extend 'layout.html'}}
-<p>Pre vars dump</p>
-<p>{{=treemachine_domain}}</p>
-<p>{{=taxomachine_domain}}</p>
-<p>Post vars dump</p>
 
 <p>Pre DB p element</p>
 <div id="argusDBContainer" />
@@ -80,7 +76,7 @@ $(document).ready(function (){
   var argus = createArgus({
     "domSource": "ottol",
     "container": document.getElementById("argusCanvasContainer"),
-    "treemachineDomain": "{{=treemachine_domain}}",
+    "treemachineDomain": "{{=default_apis}}",
     "taxomachineDomain": "{{=taxomachine_domain}}",
     "useTreemachine": true,
     "useSyntheticTree": true,

--- a/webapp/views/treeview/index.html
+++ b/webapp/views/treeview/index.html
@@ -1,7 +1,6 @@
 {{extend 'layout.html'}}
 <p>Pre vars dump</p>
-<p>{{=treemachine_domain}}</p>
-<p>{{=taxomachine_domain}}</p>
+<p>{{=default_apis}}</p>
 <p>Post vars dump</p>
 
 <p>Pre DB p element</p>

--- a/webapp/views/treeview/index.html
+++ b/webapp/views/treeview/index.html
@@ -80,8 +80,8 @@ $(document).ready(function (){
     "domSource": "ottol",
     "nodeID": "805080", 
     "container": document.getElementById("argusCanvasContainer"),
-    "treemachineDomain": "{{=treemachine_domain}}",
-    "taxomachineDomain": "{{=taxomachine_domain}}",
+    "treemachineDomain": "{{=public_apis}}",
+    "taxomachineDomain": "{{=public_apis}}",
     "useTreemachine": true
   });
   argus.displayNode({"nodeID" : nodeID, 


### PR DESCRIPTION
This restores the unusual (production) curation app URL used in our "curatorless" synth-tree viewer. Other changes here will reflect any renaming of API "domains" and method URLs (endpoints) happening in ot-ansible.