### PR TITLE
Add <pre> to allowed tags for version notes.

### DIFF
--- a/webapp/controllers/about.py
+++ b/webapp/controllers/about.py
@@ -12,7 +12,7 @@ from bleach.sanitizer import Cleaner
 # whitelist.
 # N.B. HTML comments are stripped by default. Non-allowed tags will appear
 # "naked" in output, so we can identify any bad actors.
-common_version_notes_tags = [u'p', u'br',
+common_version_notes_tags = [u'p', u'br', u'pre',
                              u'h1', u'h2', u'h3', u'h4', u'h5', u'h6',
                              u'table', u'tbody', u'tr', u'td', u'th',
                              ]


### PR DESCRIPTION
This fixes https://github.com/OpenTreeOfLife/feedback/issues/570 by adding ```<pre>``` to the white-list for acceptable HTML tags in our version notes (OTT and synthesis). This is working now on **devtree**.