### PR TITLE
Fix outbound links

### DIFF
--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -731,7 +731,7 @@ body {
                     data-bind="visible: viewModel.filteredFiles().pagedItems().length &gt; 0">
                   <thead>
                     <tr>
-                        <th width="35%">File name (click to download)</th>
+                        <th width="35%">File name</th>
                         <th width="*">Description</th>
                         <th width="15%">Size</th><!-- also includes possible delete button -->
                     </tr>
@@ -740,16 +740,9 @@ body {
                     <tr>
                     {{ if viewOrEdit == 'EDIT': }}
                         <td>
-                          <!-- ko if: file['@url']  -->
-                            <a href="#" target="_blank" data-bind="text: file['@filename'] || '?', attr: { href: file['@url'] }">
-                                Alignment data (urchins).xls
-                            </a>
-                          <!-- /ko -->
-                          <!-- ko if: !file['@url'] -->
-                            <span style="color: #999;" data-bind="text: file['@filename'] || '?'" onclick="showErrorMessage('No URL stored for this file!')">
+                            <span style="color: #999;" data-bind="text: file['@filename'] || '?'">
                                 Alignment data (urchins).xls
                             </span>
-                          <!-- /ko -->
                         </td>
                         <td>
                             <div><textarea data-bind="value: file.description.$,
@@ -788,16 +781,9 @@ body {
                         </td>
                     {{ else: }}
                         <td>
-                          <!-- ko if: file['@url']  -->
-                            <a href="#" target="_blank" data-bind="text: file['@filename'] || '?', attr: { href: file['@url'] }">
-                                Alignment data (urchins).xls
-                            </a>
-                          <!-- /ko -->
-                          <!-- ko if: !file['@url'] -->
-                            <span style="color: #999;" data-bind="text: file['@filename'] || '?'" onclick="showErrorMessage('No URL stored for this file!')">
+                            <span style="color: #999;" data-bind="text: file['@filename'] || '?'">
                                 Alignment data (urchins).xls
                             </span>
-                          <!-- /ko -->
                         </td>
                         <td>
                             <div data-bind="text: file.description.$">Microsoft Excel spreadsheet</div>

--- a/webapp/views/contact/index.html
+++ b/webapp/views/contact/index.html
@@ -35,7 +35,7 @@
                 </tr>
                 <tr>
                     <td align="right">
-                        <a href="https://gitter.im/OpenTreeOfLife/public" target="_blank">
+                        <a href="https://app.gitter.im/#/room/#OpenTreeOfLife_public:gitter.im" target="_blank">
                             <img src="{{= URL('static', 'images/gitter.png') }}" alt="Visit our Gitter room" />
                         </a>
                     </td>

--- a/webapp/views/contact/index.html
+++ b/webapp/views/contact/index.html
@@ -15,9 +15,9 @@
                     </td>
                     <td width="*" style="padding: 2em;">
                         We have three public google groups: </br>
-                        1. <a href="https://groups.google.com/forum/#!forum/opentreeoflife">opentreeoflife</a>: general mailing list </br>
-                        2. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-software">opentreeoflife-software</a>: software discussion (largely deprecated in favour of Gitter; see below) </br>
-                        3. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-announce">opentreeoflife-announce</a>: announcements of new releases and features; only admins can post</br>
+                        1. <a href="https://groups.google.com/forum/#!forum/opentreeoflife" target="_blank">opentreeoflife</a>: general mailing list </br>
+                        2. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-software" target="_blank">opentreeoflife-software</a>: software discussion (largely deprecated in favour of Gitter; see below) </br>
+                        3. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-announce" target="_blank">opentreeoflife-announce</a>: announcements of new releases and features; only admins can post</br>
                     </td>
                 </tr>
                 <tr>
@@ -28,9 +28,9 @@
                     </td>
                     <td style="padding: 2em;">
                         All of our software is on
-                        <a href="http://github.com/opentreeoflife">GitHub</a>,
+                        <a href="http://github.com/opentreeoflife" target="_blank">GitHub</a>,
                         and you can leave bug reports and feature request as an
-                        <a href="https://github.com/OpenTreeOfLife/feedback/issues">issue in our feedback repo</a>.
+                        <a href="https://github.com/OpenTreeOfLife/feedback/issues" target="_blank">issue in our feedback repo</a>.
                     </td>
                 </tr>
                 <tr>
@@ -41,9 +41,9 @@
                     </td>
                     <td style="padding: 2em;">
                         Most of our project conversation happens in a public chat room on
-                        <a href="https://app.gitter.im/#/room/#OpenTreeOfLife_public:gitter.im">Gitter</a>. Clicking the logo at left will
+                        <a href="https://app.gitter.im/#/room/#OpenTreeOfLife_public:gitter.im" target="_blank">Gitter</a>. Clicking the logo at left will
                         take you to the room. You can browse without logging in, or use your
-                        <a href="http://github.com/opentreeoflife">GitHub</a> account to join the conversation.
+                        <a href="http://github.com/opentreeoflife" target="_blank">GitHub</a> account to join the conversation.
                     </td>
                 </tr>
             </table>

--- a/webapp/views/contact/index.html
+++ b/webapp/views/contact/index.html
@@ -9,19 +9,6 @@
             <table style="width: 100%;">
                 <tr>
                     <td width="200" align="right">
-                        <a href="https://groups.google.com/forum/#!forum/opentreeoflife" target="_blank">
-                            <img src="{{= URL('static', 'images/Logo_Google_groups.png') }}" alt="Google Groups logo" />
-                        </a>
-                    </td>
-                    <td width="*" style="padding: 2em;">
-                        We have three public google groups: </br>
-                        1. <a href="https://groups.google.com/forum/#!forum/opentreeoflife" target="_blank">opentreeoflife</a>: general mailing list </br>
-                        2. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-software" target="_blank">opentreeoflife-software</a>: software discussion (largely deprecated in favour of Gitter; see below) </br>
-                        3. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-announce" target="_blank">opentreeoflife-announce</a>: announcements of new releases and features; only admins can post</br>
-                    </td>
-                </tr>
-                <tr>
-                    <td width="200" align="right">
                         <a href="http://github.com/opentreeoflife" target="_blank">
                             <img src="{{= URL('static', 'images/Github.png') }}" alt="GitHub logo" />
                         </a>
@@ -44,6 +31,19 @@
                         <a href="https://app.gitter.im/#/room/#OpenTreeOfLife_public:gitter.im" target="_blank">Gitter</a>. Clicking the logo at left will
                         take you to the room. You can browse without logging in, or use your
                         <a href="http://github.com/opentreeoflife" target="_blank">GitHub</a> account to join the conversation.
+                    </td>
+                </tr>
+                <tr>
+                    <td width="200" align="right">
+                        <a href="https://groups.google.com/forum/#!forum/opentreeoflife" target="_blank">
+                            <img src="{{= URL('static', 'images/Logo_Google_groups.png') }}" alt="Google Groups logo" />
+                        </a>
+                    </td>
+                    <td width="*" style="padding: 2em;">
+                        We have three public google groups: </br>
+                        1. <a href="https://groups.google.com/forum/#!forum/opentreeoflife" target="_blank">opentreeoflife</a>: general mailing list </br>
+                        2. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-software" target="_blank">opentreeoflife-software</a>: software discussion (largely deprecated in favour of Gitter; see above) </br>
+                        3. <a href="https://groups.google.com/forum/#!forum/opentreeoflife-announce" target="_blank">opentreeoflife-announce</a>: announcements of new releases and features; only admins can post</br>
                     </td>
                 </tr>
             </table>

--- a/webapp/views/contact/index.html
+++ b/webapp/views/contact/index.html
@@ -41,7 +41,7 @@
                     </td>
                     <td style="padding: 2em;">
                         Most of our project conversation happens in a public chat room on
-                        <a href="https://gitter.im">Gitter</a>. Clicking the logo at left will
+                        <a href="https://app.gitter.im/#/room/#OpenTreeOfLife_public:gitter.im">Gitter</a>. Clicking the logo at left will
                         take you to the room. You can browse without logging in, or use your
                         <a href="http://github.com/opentreeoflife">GitHub</a> account to join the conversation.
                     </td>
@@ -53,7 +53,7 @@
 
         </div>
     </div>
-
+https://gitter.im
 </div><!-- end of .container -->
 
 <script type="text/javascript">


### PR DESCRIPTION
Make minor update to outbound links in the Contact/Support page. Disable download links to study supporting files, as these are sometimes archived and no longer available without manual intervention. These changes are working now on **devtree**. 