### PR TITLE
Fix production-curation URLs

### DIFF
--- a/webapp/static/js/treeview.js
+++ b/webapp/static/js/treeview.js
@@ -1167,7 +1167,7 @@ function showObjectProperties( objInfo, options ) {
                                 pCompactRef = fullToCompactReference( pRef );
                                 // show compact reference for each study, with a toggle for more below
                                 displayVal = '<div class="related-study"><div class="compact-ref"><a href="'+ curationProductionWebappURL
-                                           + '/curator/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'
+                                           + '/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'
                                            + pCompactRef +'</a></div>';
                                 displayVal += '<div class="full-study-details" style="display: none;">';
                                 displayVal += '<div class="full-ref">'+ pRef +'</div>';
@@ -1183,13 +1183,13 @@ function showObjectProperties( objInfo, options ) {
                                 */
                                 displayVal += (
                                     'Open Tree curation of this study: <a href="'+ curationProductionWebappURL
-                                  + '/curator/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'+ pID +'</a><br/>'
+                                  + '/study/view/'+ pID +'" target="_blank" title="Link to this study in curation app">'+ pID +'</a><br/>'
                                   + 'Supporting '+ (studyInfo.supportingTrees.length > 1 ? 'trees:' : 'tree:')
                                 );
                                 for (var treeID in studyInfo.supportingTrees) {
                                     displayVal += (
                                         '&nbsp; <a href="'+ curationProductionWebappURL
-                                      + '/curator/study/view/'+ pID +'?tab=trees&tree='+ treeID +'" '
+                                      + '/study/view/'+ pID +'?tab=trees&tree='+ treeID +'" '
                                       + 'target="_blank" title="Link to this supporting tree in curation app">'+ treeID +'</a>'
                                     );
                                 }


### PR DESCRIPTION
This complements [another commit (accidentally) merged to `staging`.](https://github.com/OpenTreeOfLife/opentree/commit/67e796317effd33481acc06c59d7e4792c0f215e) This tweaks the production-curation URLs created in that step, reading the production URL from our private app-config file (and thus a matching change to ot-ansible).