### PR TITLE
Fix collection download

### DIFF
--- a/curator/models/menu.py
+++ b/curator/models/menu.py
@@ -13,7 +13,7 @@ response.subtitle = ""
 
 ## read more at http://dev.w3.org/html5/markup/meta.name.html
 response.meta.author = 'Your Name <you@example.com>'
-response.meta.description = 'a cool new app'
+response.meta.description = 'Open Tree - study and tree curation tool'
 response.meta.keywords = 'web2py, python, framework'
 response.meta.generator = 'Web2py Web Framework'
 

--- a/curator/models/menu.py
+++ b/curator/models/menu.py
@@ -13,7 +13,7 @@ response.subtitle = ""
 
 ## read more at http://dev.w3.org/html5/markup/meta.name.html
 response.meta.author = 'Your Name <you@example.com>'
-response.meta.description = 'Open Tree - study and tree curation tool'
+response.meta.description = 'a cool new app'
 response.meta.keywords = 'web2py, python, framework'
 response.meta.generator = 'Web2py Web Framework'
 

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -157,7 +157,7 @@ body {
         {{ if viewOrEdit == 'VIEW': }}
             <div class="control-group">
                 <a class="btn btn-info"
-                   href="{{= API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID) + '.json' }}"
+                   href="{{= API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID) }}"
                    target="_blank">Download collection as JSON <i class="icon-arrow-down icon-white"></i></a>
                 <span> or you can use the
                     <strong><a href="https://github.com/OpenTreeOfLife/germinator/wiki/Open-Tree-of-Life-Web-APIs"


### PR DESCRIPTION
This fixes the download button in the full-page collection editor. Working now on **devtree**.

(The collection API doesn't expect a file extension, nor does it know how to provide anything but JSON.)