### PR TITLE
Fix collection Save Copy

### DIFF
--- a/curator/models/menu.py
+++ b/curator/models/menu.py
@@ -13,7 +13,7 @@ response.subtitle = ""
 
 ## read more at http://dev.w3.org/html5/markup/meta.name.html
 response.meta.author = 'Your Name <you@example.com>'
-response.meta.description = 'a cool new app'
+response.meta.description = 'Open Tree - study and tree curation tool'
 response.meta.keywords = 'web2py, python, framework'
 response.meta.generator = 'Web2py Web Framework'
 

--- a/curator/models/menu.py
+++ b/curator/models/menu.py
@@ -13,7 +13,7 @@ response.subtitle = ""
 
 ## read more at http://dev.w3.org/html5/markup/meta.name.html
 response.meta.author = 'Your Name <you@example.com>'
-response.meta.description = 'Open Tree - study and tree curation tool'
+response.meta.description = 'a cool new app'
 response.meta.keywords = 'web2py, python, framework'
 response.meta.generator = 'Web2py Web Framework'
 

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2450,7 +2450,7 @@ function saveTreeCollection( collection ) {
             */
             if (collectionUI === 'FULL_PAGE') {
                 // Let's try a full reload and see what happens
-                loadSelectedCollection();
+                loadSelectedCollection( currentlyEditingCollectionID );
                 hideModalScreen();
                 cancelChangesToCollection(collection);
             } else {

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2396,7 +2396,7 @@ function saveTreeCollection( collection ) {
         contentType: "application/json; charset=utf-8",
         url: saveURL,
         processData: false,
-        data: JSON.stringify(collection.data),
+        data: ko.toJSON(collection.data), // converts KO observables to simple values!
         //data: collection,  // OR collection.data?
         complete: function( jqXHR, textStatus ) {
             // report errors or malformed data, if any

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -625,11 +625,13 @@ async function showCollectionViewer( collection, options ) {
         // NOTE that we must call cleanNode first, to allow "re-binding" with KO.
         var $boundElements = $('#tree-collection-viewer').find('.modal-body, .modal-header');
         // Step carefully to avoid un-binding important modal behavior (close widgets, etc)!
-        $.each($boundElements, function(i, el) {
-            ko.cleanNode(el);
-            ko.applyBindings(collection, el);
-        });
+    } else {  // it's 'FULL_PAGE'
+        var $boundElements = $('#tree-collection-viewer');
     }
+    $.each($boundElements, function(i, el) {
+        ko.cleanNode(el);
+        ko.applyBindings(collection, el);
+    });
 
     var updateCollectionDisplay = function(options) {
         options = options || {};

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2447,13 +2447,11 @@ function saveTreeCollection( collection ) {
                 ;
             }
             */
-            if ((collectionUI === 'FULL_PAGE') &&
-                (createOrUpdate === 'UPDATE')) {
-                    // update this page (re-bind observables, etc.) to restore proper editing behavior
-                    loadSelectedCollection( currentlyEditingCollectionID );
-                    hideModalScreen();
-                    cancelChangesToCollection(collection);
-                }
+            if ((collectionUI === 'FULL_PAGE') && (createOrUpdate === 'UPDATE')) {
+                // update this page (re-bind observables, etc.) to restore proper editing behavior
+                loadSelectedCollection( currentlyEditingCollectionID );
+                hideModalScreen();
+                cancelChangesToCollection(collection);
             } else {
                 // jump to the edit page of our new collection (or newly-minted copy)
                 jumpToCollectionEditor( currentlyEditingCollectionID );

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -626,7 +626,7 @@ async function showCollectionViewer( collection, options ) {
         var $boundElements = $('#tree-collection-viewer').find('.modal-body, .modal-header');
         // Step carefully to avoid un-binding important modal behavior (close widgets, etc)!
     } else {  // it's 'FULL_PAGE'
-        var $boundElements = $('#tree-collection-viewer');
+        var $boundElements = $('#tree-collection-viewer, #History');
     }
     $.each($boundElements, function(i, el) {
         ko.cleanNode(el);

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -2446,24 +2446,24 @@ function saveTreeCollection( collection ) {
                 // TODO: Update local collection history
                 ;
             }
-            // re-bind observables, etc. to restore proper editing behavior
             */
-            if (collectionUI === 'FULL_PAGE') {
-                // Let's try a full reload and see what happens
-                loadSelectedCollection( currentlyEditingCollectionID );
-                hideModalScreen();
-                cancelChangesToCollection(collection);
+            if ((collectionUI === 'FULL_PAGE') &&
+                (createOrUpdate === 'UPDATE')) {
+                    // update this page (re-bind observables, etc.) to restore proper editing behavior
+                    loadSelectedCollection( currentlyEditingCollectionID );
+                    hideModalScreen();
+                    cancelChangesToCollection(collection);
+                }
             } else {
-                // jump from popup to the full-page editor for this collection
-                jumpToCollectionEditor(collection);
+                // jump to the edit page of our new collection (or newly-minted copy)
+                jumpToCollectionEditor( currentlyEditingCollectionID );
             }
         }
     });
 }
-function jumpToCollectionEditor( collection ) {
-    // move this page to the chosen version
-    var viewURL = getCollectionDirectURL( collection );
-    var editURL = viewURL.split('/view/').join('/edit/');
+function jumpToCollectionEditor( collectionID ) {
+    // move this page to the chosen collection ID
+    var editURL = '/curator/collection/edit/'+ collectionID;
     window.location.href = editURL;
 }
 async function deleteTreeCollection( collection ) {

--- a/curator/static/js/curation-helpers.js
+++ b/curator/static/js/curation-helpers.js
@@ -594,6 +594,7 @@ async function showCollectionViewer( collection, options ) {
             .find('#tree-collection-contributors > li').eq(0).clone();
         $stashedCollectionDecisionElement = $('#tree-collection-viewer')
             .find('#tree-collection-decisions > tr.single-tree-row').eq(0).clone();
+            // OR .find('#tree-collection-decisions > tr.single-tree-row, #tree-list-holder > tr.single-tree-row').eq(0).clone();
     } else {
         // Replace with pristine markup to avoid weird results in later popups
         if (options.MAINTAIN_SCROLL) {

--- a/curator/static/js/tree-collection-editor.js
+++ b/curator/static/js/tree-collection-editor.js
@@ -897,9 +897,6 @@ function loadSelectedCollection() {
                 normalizeDecision( dec );
             });
 
-            var mainPageArea = $('#main .tab-content')[0];
-            ko.cleanNode(mainPageArea);
-            ko.applyBindings(viewModel, mainPageArea);
             var metadataPopup = $('#collection-metadata-popup')[0];
             ko.cleanNode(metadataPopup);
             ko.applyBindings(viewModel, metadataPopup);

--- a/curator/static/js/tree-collection-editor.js
+++ b/curator/static/js/tree-collection-editor.js
@@ -370,7 +370,7 @@ $(document).ready(function() {
 
     collectionHasUnsavedChanges = false;
     disableSaveButton();
-    loadSelectedCollection();
+    loadSelectedCollection( collectionID );
 
     // Initialize the jQuery File Upload widgets
     $('#fileupload').fileupload({
@@ -536,7 +536,7 @@ var knockoutMappingOptions = {
 };
  */
 
-function loadSelectedCollection() {
+function loadSelectedCollection( selectedCollectionID ) {
     /* Use REST API to pull collection data from datastore
      * :EXAMPLE: GET http://api.opentreeoflife.org/v3/collection/{jimallman/test}
      *
@@ -549,7 +549,7 @@ function loadSelectedCollection() {
      *  - any local storage (in Lawnchair) that trumps the one in remote storage
      */
 
-    var fetchURL = API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID);
+    var fetchURL = API_load_collection_GET_url.replace('{COLLECTION_ID}', selectedCollectionID);
 
     // TEST URL with local JSON file
     ///fetchURL = '/curator/static/1003.json';

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -80,7 +80,7 @@ body {
             onclick="confirmHyperlink(this, 'Are you sure you want to edit this collection?'); return false;"
            {{ pass }}
           >Edit Collection</a>
-          <a onclick="copyCollection(); return false;"
+          <a onclick="copyCollection(viewModel); return false;"
              title="Copy this collection (you will own the copy)"
              class="pull-right btn" style="margin-right: 8px;">
                 Save a copy <i class="icon-repeat"></i>
@@ -93,7 +93,7 @@ body {
             onclick="confirmHyperlink(this, 'Are you sure you want to edit this collection?'); return false;"
            {{ pass }}
           >Login to Edit Collection</a>
-          <a onclick="copyCollection(); return false;"
+          <a onclick="copyCollection(viewModel); return false;"
              title="Copy this collection (requires login)"
              class="pull-right btn" style="margin-right: 8px;">
                 Save a copy <i class="icon-repeat"></i>
@@ -220,17 +220,6 @@ body {
                             class="pull-right btn btn-mini row-controls-ghosted"
                             style="margin-left: 4px; opacity: 0.5;">
                             <i class="icon-list-alt"></i>
-                        </button>
-                        -->
-
-                        <!-- DUPLICATE button
-                        <button data-bind="click: copyCollection,
-                                            visible: true,
-                                            attr: {'title': userIsLoggedIn() ? 'Copy this collection (you will own the copy)' : 'Copy this collection (requires login)'}"
-                            title=""
-                            class="pull-right btn btn-mini row-controls-ghosted"
-                            style="margin-left: 4px;">
-                            Save a copy <i class="icon-repeat"></i>
                         </button>
                         -->
                        <!-- /ko -->

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -157,7 +157,7 @@ body {
         {{ if viewOrEdit == 'VIEW': }}
             <div class="control-group">
                 <a class="btn btn-info"
-                   href="{{= API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID) + '.json' }}"
+                   href="{{= API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID) }}"
                    target="_blank">Download collection as JSON <i class="icon-arrow-down icon-white"></i></a>
                 <span> or you can use the
                     <strong><a href="https://github.com/OpenTreeOfLife/germinator/wiki/Open-Tree-of-Life-Web-APIs"

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -502,12 +502,13 @@ body {
                     </tr>
                   </thead>
 
-                  <tbody data-bind="foreach: { data: viewModel.filteredTrees().pagedItems(), as: 'tree' }">
-                    <tr data-bind="attr: { class: (userIsEditingCollection($parent) && $data['status'] == 'REMOVED') ?
+                  <tbody id="tree-collection-decisions" data-bind="foreach: { data: viewModel.filteredTrees().pagedItems(), as: 'tree' }">
+                    <tr class="single-tree-row"
+                        data-bind="attr: { class: (userIsEditingCollection($parent) && $data['status'] == 'REMOVED') ?
                                                     'single-tree-row error' :
                                                     (userIsEditingCollection($parent) && $data['status'] == 'MODIFIED' ?
                                                       'single-tree-row warning' :
-                                                      'single-tree-row-'+ $data['status'] )
+                                                      'single-tree-row '+ $data['status'] )
                                           },
                                    css: viewModel.ticklers.TREES">
                         <td style="white-space: nowrap;" data-bind="visible: getTreeColumnVisibility('RANK')">

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -309,7 +309,6 @@ body {
                         </form>
                       </div>
                 </div><!-- end of .modal-body -->
-              </div><!-- end of #tree-collection-viewer.modal- -->
 
             <div style="margin-bottom: 100px; clear: right; padding-top: 1em;">
               <div class="navbar">
@@ -694,6 +693,8 @@ body {
               </div><!-- #tree-list-holder -->
 
             </div>
+
+              </div><!-- end of #tree-collection-viewer.modal- -->
 
            </div><!-- end of main column... -->
 

--- a/curator/views/layout.html
+++ b/curator/views/layout.html
@@ -781,7 +781,7 @@ from applications.opentree.modules.opentreewebapputil import get_user_login, get
                                                       'single-tree-row error' :
                                                       (userIsEditingCollection($parent) && $data['status'] == 'MODIFIED' ?
                                                         'single-tree-row warning' :
-                                                        'single-tree-row-'+ $data['status'] )
+                                                        'single-tree-row '+ $data['status'] )
                                             }">
                           <td>
                           <!-- ko if: userIsEditingCollection($parent) -->


### PR DESCRIPTION
When saving a copy of a tree collection, it seems sensible that we should jump to the editor of the *new* (saved) collection, instead of staying put. This should now be working (with some other bug fixes) in the full-page *and* popup editor. Working now on **devtree**.