### PR TITLE
Restore the '.json' extension to trigger download

### DIFF
--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -157,7 +157,7 @@ body {
         {{ if viewOrEdit == 'VIEW': }}
             <div class="control-group">
                 <a class="btn btn-info"
-                   href="{{= API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID) }}"
+                   href="{{= API_load_collection_GET_url.replace('{COLLECTION_ID}', collectionID) + '.json' }}"
                    target="_blank">Download collection as JSON <i class="icon-arrow-down icon-white"></i></a>
                 <span> or you can use the
                     <strong><a href="https://github.com/OpenTreeOfLife/germinator/wiki/Open-Tree-of-Life-Web-APIs"


### PR DESCRIPTION
This matches the expected behavior in the same-named pull request in phylesystem-api.