### PR TITLE
Smarter DOI lookup (improved)

### DIFF
--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -758,7 +758,7 @@ def to_nexson():
 def search_crossref_proxy():
     encoded_ref_string = request.env.web2py_original_uri.split('search_crossref_proxy?')[1]
     # prepend the CrossRef search base URL and return the response
-    search_crossref_url = 'https://api.crossref.org/works?rows=10&query=%s' % encoded_ref_string
+    search_crossref_url = 'https://api.crossref.org/works/%s' % encoded_ref_string
     # NB - the query-string is already properly encoded! Do NOT double-encode
     # this, or we'll get wildly wrong results.
     try:

--- a/curator/controllers/default.py
+++ b/curator/controllers/default.py
@@ -754,13 +754,19 @@ def to_nexson():
     assert (False)
 
 # provide support for CrossRef.org URLs via HTTPS
-# NB - We are submitting (partial?) reference text, hoping to retrieve the matching DOI!
 def search_crossref_proxy():
     encoded_ref_string = request.env.web2py_original_uri.split('search_crossref_proxy?')[1]
+
     # prepend the CrossRef search base URL and return the response
-    search_crossref_url = 'https://api.crossref.org/works/%s' % encoded_ref_string
     # NB - the query-string is already properly encoded! Do NOT double-encode
     # this, or we'll get wildly wrong results.
+    if (encoded_ref_string.startswith("10.")):
+        # therr's a bare DOI at start of search text; query against just that DOI
+        search_crossref_url = 'https://api.crossref.org/works/%s' % encoded_ref_string
+    else:
+        # submit (partial?) reference text and hope we can retrieve the matching DOI.
+        search_crossref_url = 'https://api.crossref.org/works?rows=10&query=%s' % encoded_ref_string
+
     try:
         resp = requests.get(url=search_crossref_url).content
     except:

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9019,7 +9019,7 @@ function lookUpDOI() {
             //data: {'q': combinedSearchText},
             complete: function( jqXHR, textStatus ) {
                 hideModalScreen();
-                if (textStatus !== 'parsererror') {
+                if (textStatus === 'parsererror') {
                     // NB - CrossRef API is quirky. Returns 'Resource not found' with status 200 (vs. 404) and funky textStatus!
                     var errMsg = "Sorry, we couldn't find a publication with this publication DOI. Please double-check your DOIs and try again."
                     showErrorMessage(errMsg);

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -9019,6 +9019,12 @@ function lookUpDOI() {
             //data: {'q': combinedSearchText},
             complete: function( jqXHR, textStatus ) {
                 hideModalScreen();
+                if (textStatus !== 'parsererror') {
+                    // NB - CrossRef API is quirky. Returns 'Resource not found' with status 200 (vs. 404) and funky textStatus!
+                    var errMsg = "Sorry, we couldn't find a publication with this publication DOI. Please double-check your DOIs and try again."
+                    showErrorMessage(errMsg);
+                    return;
+                }
                 if (textStatus !== 'success') {
                     var errMsg = 'Sorry, there was an error looking up this study\'s DOI. <a href="#" onclick="toggleFlashErrorDetails(this); return false;">Show details</a><pre class="error-details" style="display: none;">'+ jqXHR.responseText +'</pre>';
                     showErrorMessage(errMsg);
@@ -9033,7 +9039,11 @@ function lookUpDOI() {
                     return;
                 }
                 var foundItems = resultsJSON.message.items;
-                console.log("FOUND "+ foundItems.length +" matching items");
+                if (!foundItems) {
+                    // it's a singleton (probably matched on a DOI)
+                    console.log("wrapping a single result in a new list");
+                    foundItems = [ resultsJSON.message ];
+                }
                 if (foundItems.length === 0) {
                     asyncAlert('No matches found, please check your publication reference text.')
                 } else {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8852,14 +8852,17 @@ function autoApplyExactMatch() {
 function lookUpDOI() {
     // try to find a match, based on existing metadata
     var referenceText = $.trim( $('#ot_studyPublicationReference').val() );
+    // toss in the current URL as well, in case this is the latest input
+    var urlText = $.trim( $('#ot_studyPublication').val() );
+    var combinedSearchText = referenceText +" "+ urlText;
     var lookupURL;
-    if (referenceText === '') {
+    if ($.trim(combinedSearchText) === '') {
         // try a generic search in a new window
         lookupURL = 'http://search.crossref.org/';
         window.open(lookupURL,'lookup');
     } else {
         // see if we get lucky..
-        lookupURL = '/curator/search_crossref_proxy?' + encodeURIComponent(referenceText).replace(/\(/g,'%28').replace(/\)/g,'%29');
+        lookupURL = '/curator/search_crossref_proxy?' + encodeURIComponent(combinedSearchText).replace(/\(/g,'%28').replace(/\)/g,'%29');
 
         // show potential matches in popup? or new frame?
         showModalScreen("Looking up DOI...", {SHOW_BUSY_BAR:true});
@@ -8870,7 +8873,7 @@ function lookUpDOI() {
             // crossdomain: true,
             // contentType: "application/json; charset=utf-8",
             url: lookupURL,
-            //data: {'q': referenceText},
+            //data: {'q': combinedSearchText},
             complete: function( jqXHR, textStatus ) {
                 hideModalScreen();
                 if (textStatus !== 'success') {

--- a/curator/static/js/study-editor.js
+++ b/curator/static/js/study-editor.js
@@ -8988,7 +8988,16 @@ function lookUpDOI() {
     var referenceText = $.trim( $('#ot_studyPublicationReference').val() );
     // toss in the current URL as well, in case this is the latest input
     var urlText = $.trim( $('#ot_studyPublication').val() );
-    var combinedSearchText = referenceText +" "+ urlText;
+    var combinedSearchText = urlText +" "+ referenceText;
+    // find any bare DOIs among mixed text (and DOIs-in-URL-form) and prepend them to the text
+    var possibleDOIs = combinedSearchText.match(minimalDOIPattern);  // pattern defined elsewhere
+    if( possibleDOIs ) {
+        // we found one or more DOIs; add them to the text!
+        combinedSearchText = (possibleDOIs.join(' ') +" "+ combinedSearchText);
+    }
+    console.log( "Searching for DOI/ref using this combined search text:" );
+    console.log( combinedSearchText );
+
     var lookupURL;
     if ($.trim(combinedSearchText) === '') {
         // try a generic search in a new window

--- a/curator/views/collection/edit.html
+++ b/curator/views/collection/edit.html
@@ -946,7 +946,7 @@ body {
                 <a id="current-ref-URL" style="display: block;" href="#" target="_blank" onclick="return false;">&nbsp;</a>
             </div>
             <p>
-                Based on the reference text for this study,
+                Based on the reference text (or current DOI) for this study,
                 <a href="http://crossref.org/" target="_blank">CrossRef.org</a>
                 returned these <span class="found-matches-count"></span> matching records (best matches first).
             </p>

--- a/curator/views/study/edit.html
+++ b/curator/views/study/edit.html
@@ -1941,7 +1941,7 @@ body {
                 <a id="current-ref-URL" style="display: block;" href="#" target="_blank" onclick="return false;">&nbsp;</a>
             </div>
             <p>
-                Based on the reference text for this study,
+                Based on the reference text (or current DOI) for this study,
                 <a href="http://crossref.org/" target="_blank">CrossRef.org</a>
                 returned these <span class="found-matches-count"></span> matching records (best matches first).
             </p>


### PR DESCRIPTION
OK, I've adapted the logic here to the latest CrossRef API, which has different methods for searching based on a DOI (single result only) versus other metadata. So now we check our payload text for any possible DOIs, strip them to bare DOIs (vs URL form), and choose the best available method.

If a curator has the right DOI, this will help them update its metadata (or complain if CrossRef doesn't have that DOI). If no DOI is present, the rest of the metadata is submitted and several likely matches will be provided.

This is working now on **devtree**.